### PR TITLE
Fix #99

### DIFF
--- a/web/src/lib/components/pages/record.tsx
+++ b/web/src/lib/components/pages/record.tsx
@@ -184,8 +184,12 @@ export default class RecordPage extends Component<RecordProps, RecordState> {
   }
 
   newSentenceSet() {
-    this.api.getRandomSentences(SET_COUNT).then(sentences => {
-      this.setState({ sentences: sentences.split('\n') });
+    let recordedSentenceCount = this.state.recordings.length;
+    let numberOfSentenceToGet = SET_COUNT - recordedSentenceCount;
+    this.api.getRandomSentences(numberOfSentenceToGet).then(newSentences => {
+      let targetSentences = this.state.sentences.slice(0,recordedSentenceCount);
+      targetSentences = targetSentences.concat(newSentences.split('\n'));
+      this.setState({ sentences: targetSentences});
     });
   }
 


### PR DESCRIPTION
The method `newSentenceSet()` would unfortunately replace all the sentences, even the ones you already recorded. 

So the solution was to re-write `newSentenceSet()` to only replace those sentences you had not yet recorded.