### PR TITLE
Grow green containers vertically to fix overflow

### DIFF
--- a/web/css/index.css
+++ b/web/css/index.css
@@ -261,7 +261,13 @@ input:invalid {
   pointer-events: all;
 }
 
-.listen-box > div {
+.sentence-box {
+  min-height: var(--listen-box-height);
+}
+
+.play-box,
+.delete-box,
+.vote-box {
   height: var(--listen-box-height);
 }
 
@@ -305,7 +311,6 @@ input:invalid {
   .sentence-box {
     font-size: 0.8rem;
     line-height: 1.2rem;
-    height: var(--listen-box-height);
     flex: 1;
   }
 }


### PR DESCRIPTION
Fixes #225.

Allow sentence-box to grow by just setting min-height instead
of height.