### PR TITLE
Fixed the bug for Issue #259.

### DIFF
--- a/web/src/lib/components/pages/record.tsx
+++ b/web/src/lib/components/pages/record.tsx
@@ -220,12 +220,8 @@ export default class RecordPage extends Component<RecordProps, RecordState> {
   }
 
   newSentenceSet() {
-    let recordedSentenceCount = this.state.recordings.length;
-    let numberOfSentenceToGet = SET_COUNT - recordedSentenceCount;
-    this.props.api.getRandomSentences(numberOfSentenceToGet).then(newSentences => {
-      let targetSentences = this.state.sentences.slice(0,recordedSentenceCount);
-      targetSentences = targetSentences.concat(newSentences.split('\n'));
-      this.setState({ sentences: targetSentences});
+    this.props.api.getRandomSentences(SET_COUNT).then(newSentences => {
+      this.setState({ sentences: newSentences.split('\n')});
     });
   }
 

--- a/web/src/lib/components/pages/record.tsx
+++ b/web/src/lib/components/pages/record.tsx
@@ -173,12 +173,12 @@ export default class RecordPage extends Component<RecordProps, RecordState> {
   }
 
   private reset(): void {
-    this.newSentenceSet();
     this.setState({
       recordings: [],
       sentences: [],
       uploadProgress: 0
     });
+    this.newSentenceSet();
   }
 
   onRecordClick() {


### PR DESCRIPTION
In the reset() function, previously we fetched newSentences first and reset the recordings afetr that.
Now I just interchanged the order.