### PR TITLE
Added a Content Security Policy header

### DIFF
--- a/nubis/puppet/web.pp
+++ b/nubis/puppet/web.pp
@@ -42,6 +42,8 @@ apache::vhost { $project_name:
       'set X-XSS-Protection "1; mode=block"',
       'set X-Frame-Options "DENY"',
       'set Strict-Transport-Security "max-age=31536000"',
+      # The media-src directive is required for recording audio.
+      'set Content-Security-Policy "default-src \'self\'; object-src \'none\'; media-src blob: \'self\'"',
     ],
     rewrites           => [
       {

--- a/nubis/puppet/web.pp
+++ b/nubis/puppet/web.pp
@@ -42,8 +42,8 @@ apache::vhost { $project_name:
       'set X-XSS-Protection "1; mode=block"',
       'set X-Frame-Options "DENY"',
       'set Strict-Transport-Security "max-age=31536000"',
-      # The media-src directive is required for recording audio.
-      'set Content-Security-Policy "default-src \'self\'; object-src \'none\'; media-src blob: \'self\'"',
+      # media-src blob: is required for recording audio.
+      'set Content-Security-Policy "default-src \'self\'; img-src \'self\' https://www.google-analytics.com; media-src blob: https://*.amazonaws.com; script-src \'self\' \'unsafe-eval\' https://www.google-analytics.com/analytics.js"'
     ],
     rewrites           => [
       {


### PR DESCRIPTION
Fixes #103. The CSP header may be important for security (XSS prevention), especially when more user-generated content will be displayed to other users in the future, such as accent information. The browser will ignore content loaded from external websites, as well as inline scripts and CSS.

Couldn't test this properly due to #315. I did test the header by adding it in a meta tag to web/index.html. If the `media-src` directive is omitted, the browser refuses to load recorded audio, which appears to have a URI similar to `blob:https://voice.mozilla.org/ad3c9602-f211-4a28-88f2-f98f61bbe72f`.

Before being merged, this should be tested on a website where the Nubis stuff works. If the header contains mistakes, legitimate content may not load. I'm curious about downloading validation audio and recording audio, which I could not test properly either because I don't have an Amazon Cloud thing. Chrome logs CSP violations in its debug console, which may be useful.

**NOTE**: any inline CSS will be ignored by the browser with this CSP header. This appeared to be no problem, because it's all loaded from external stylesheets.