### PR TITLE
Adding OS dependencies on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Did you notice a bug? Do you have a feature request? Please file an issue [here 
 
 For general discussion (feedback, ideas, random musings), check out our [Discourse Category](https://discourse.mozilla-community.org/c/voice)
 
+### OS Dependencies
+* ffmpeg
+
 ### Development
 ```
 npm install


### PR DESCRIPTION
Adding a section on readme to list the OS dependencies, in some linux distributions the ffmpeg isn't default so the file is sent to s3 without any data

@MycroftAI
https://mycroft.ai/