### PR TITLE
Fix MySQL error if using empty password

### DIFF
--- a/server/src/lib/db/mysql.ts
+++ b/server/src/lib/db/mysql.ts
@@ -15,7 +15,7 @@ type MysqlOptions = {
 const DEFAULTS = {
   user: 'voiceweb',
   database: 'voiceweb',
-  password: '',
+  password: null,
   host: 'localhost',
   port: 3306,
   max: 10,
@@ -42,7 +42,17 @@ export default class Mysql {
             DEFAULTS.idleTimeoutMillis,
     };
 
-    this.pool  = mysql.createPool({
+    let isEmptyString = function(str: string): boolean {
+      return typeof str !== 'undefined'
+           && !str.length;
+    };
+
+    if (isEmptyString(options.password)
+        || (!options.password && isEmptyString(config.MYSQLPASS))) {
+      myConfig.password = null;
+    }
+
+    this.pool = mysql.createPool({
         connectionLimit : 100,
         host            : myConfig.host,
         user            : myConfig.user,

--- a/server/src/lib/db/mysql.ts
+++ b/server/src/lib/db/mysql.ts
@@ -42,13 +42,12 @@ export default class Mysql {
             DEFAULTS.idleTimeoutMillis,
     };
 
-    let isEmptyString = function(str: string): boolean {
-      return typeof str !== 'undefined'
-           && !str.length;
-    };
-
-    if (isEmptyString(options.password)
-        || (!options.password && isEmptyString(config.MYSQLPASS))) {
+    // Empty strings are evaluated to false, so if the password is an empty
+    // string, the next one in the order of priority would be used. Prevent
+    // this.
+    if (options.password === ''
+        || (!options.password && config.MYSQLPASS === '')) {
+      // An empty password is equivalent to no password.
       myConfig.password = null;
     }
 

--- a/server/src/lib/db/mysql.ts
+++ b/server/src/lib/db/mysql.ts
@@ -1,3 +1,5 @@
+import { getFirstDefined } from '../utility';
+
 const mysql = require('mysql');
 const config = require('../../../../config.json');
 
@@ -15,7 +17,7 @@ type MysqlOptions = {
 const DEFAULTS = {
   user: 'voiceweb',
   database: 'voiceweb',
-  password: null,
+  password: '',
   host: 'localhost',
   port: 3306,
   max: 10,
@@ -27,29 +29,27 @@ export default class Mysql {
 
   constructor(options?: MysqlOptions) {
     options = options || Object.create(null);
+
     // For configuring, use the following order of priority:
     //   1. passed in options
     //   2. options in config.json
     //   3. hard coded DEFAULTS
     var myConfig = {
-        user: options.user || config.MYSQLUSER || DEFAULTS.user,
-        database: options.database || config.MYSQLDB || DEFAULTS.database,
-        password: options.password || config.MYSQLPASS || DEFAULTS.password,
-        host: options.host || config.MYSQLHOST || DEFAULTS.host,
-        port: options.port || config.MYSQLPORT || DEFAULTS.port,
-        max: options.max || DEFAULTS.max,
-        idleTimeoutMillis: options.idleTimeoutMillis ||
-            DEFAULTS.idleTimeoutMillis,
+        user: getFirstDefined(
+          options.user, config.MYSQLUSER, DEFAULTS.user),
+        database: getFirstDefined(
+          options.database, config.MYSQLDB, DEFAULTS.database),
+        password: getFirstDefined(
+          options.password, config.MYSQLPASS, DEFAULTS.password),
+        host: getFirstDefined(
+          options.host, config.MYSQLHOST, DEFAULTS.host),
+        port: getFirstDefined(
+          options.port, config.MYSQLPORT, DEFAULTS.port),
+        max: getFirstDefined(
+          options.max, DEFAULTS.max),
+        idleTimeoutMillis: getFirstDefined(
+          options.idleTimeoutMillis, DEFAULTS.idleTimeoutMillis),
     };
-
-    // Empty strings are evaluated to false, so if the password is an empty
-    // string, the next one in the order of priority would be used. Prevent
-    // this.
-    if (options.password === ''
-        || (!options.password && config.MYSQLPASS === '')) {
-      // An empty password is equivalent to no password.
-      myConfig.password = null;
-    }
 
     this.pool = mysql.createPool({
         connectionLimit : 100,

--- a/server/src/lib/utility.ts
+++ b/server/src/lib/utility.ts
@@ -14,9 +14,9 @@ export function getFileExt(path: string): string {
  * arguments.
  */
 export function getFirstDefined(...options) {
-  for (var i = 0; i < arguments.length; i++) {
-    if (arguments[i] !== undefined) {
-      return arguments[i];
+  for (var i = 0; i < options.length; i++) {
+    if (options[i] !== undefined) {
+      return options[i];
     }
   }
   return null;

--- a/server/src/lib/utility.ts
+++ b/server/src/lib/utility.ts
@@ -8,3 +8,16 @@
 export function getFileExt(path: string): string {
   return path.substr(path.lastIndexOf('.') - path.length);
 }
+
+/**
+ * Returns the first defined argument. Returns null if there are no defined
+ * arguments.
+ */
+export function getFirstDefined(...options) {
+  for (var i = 0; i < arguments.length; i++) {
+    if (arguments[i] !== undefined) {
+      return arguments[i];
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
When an empty string was specified as the password in config.json, then [the createDb.js script](https://github.com/Omniscimus/voice-web/blob/4386d083f4a12a1260e2a29ee6a26030b60492fe/tools/createDb.js) failed with the following error:

`database create error ER_ACCESS_DENIED_ERROR: Access denied for user 'root'@'localhost' (using password: YES)`

The cause of this error was that empty strings are evaluated to `false` by JavaScript and TypeScript. [In the mysql.ts file](https://github.com/Omniscimus/voice-web/blob/4386d083f4a12a1260e2a29ee6a26030b60492fe/server/src/lib/db/mysql.ts#L37), config values were determined using the OR-operand. If one of `options.password` or `config.MYSQLPASS` was an empty string, then it was ignored, and the next one was used.

Fixed this by explicitly checking if those variables are empty strings.