### PR TITLE
Fix issue with record button not centered

### DIFF
--- a/web/css/index.css
+++ b/web/css/index.css
@@ -1316,13 +1316,12 @@ body:not(.ios) .recording #background-container {
 }
 
 #record-button {
-  display: inline-block;
   border-radius: 50%;
   border: 0.6rem solid black;
   background-color: white;
   height: 2.5rem;
   width: 2.5rem;
-  margin: 1rem 0;
+  margin: 1rem auto;
   cursor: pointer;
 }
 

--- a/web/css/index.css
+++ b/web/css/index.css
@@ -1322,6 +1322,7 @@ body:not(.ios) .recording #background-container {
   height: 2.5rem;
   width: 2.5rem;
   margin: 1rem auto;
+  margin-top: calc(1rem + 4px);
   cursor: pointer;
 }
 
@@ -1356,6 +1357,8 @@ body:not(.ios) .recording #background-container {
 #record-help {
   font-size: 1rem;
   padding: 0 2rem;
+  line-height: 1em;
+  margin-bottom: 2px;
 }
 
 #voice-submit {

--- a/web/css/index.css
+++ b/web/css/index.css
@@ -1357,8 +1357,6 @@ body:not(.ios) .recording #background-container {
 #record-help {
   font-size: 1rem;
   padding: 0 2rem;
-  line-height: 1em;
-  margin-bottom: 2px;
 }
 
 #voice-submit {


### PR DESCRIPTION
Elements with `display: inline-block` could introduces a space between elements: https://stackoverflow.com/q/5078239

Looks better now? Fixes #164

![capture-centered](https://user-images.githubusercontent.com/3090380/29077154-fb85b7b4-7c89-11e7-91f5-7f20ba9ad10c.PNG)
