### PR TITLE
Add link to Travis CI build to the build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Project Common Voice ![Travis Status](https://travis-ci.org/mozilla/voice-web.svg?branch=master "Travis Status")
+## Project Common Voice [![Travis Status](https://travis-ci.org/mozilla/voice-web.svg?branch=master)](https://travis-ci.org/mozilla/voice-web)
 This is a web, android and iOS app for collection speech
 donations for Project Common Voice.
 


### PR DESCRIPTION
The Travis CI status badge currently does not link to the Travis CI builds (when clicking it, you only get the badge image in a new tab).

This uses the recommended markdown snippet from Travis to show the badge, and at the same time make it a link to the build project itself.