### PR TITLE
Recording sense checks

### DIFF
--- a/web/src/lib/components/pages/record.tsx
+++ b/web/src/lib/components/pages/record.tsx
@@ -124,14 +124,6 @@ export default class RecordPage extends Component<RecordProps, RecordState> {
 
     this.props.onRecordStop && this.props.onRecordStop();
 
-    if (!this.props.onRecordingSet) {
-      return;
-    }
-
-    if (this.isFull()) {
-      this.props.onRecordingSet();
-    }
-
     let error = this.checkRecording();
     if (error) {
       // Remove the invalid recording to go back.
@@ -143,6 +135,14 @@ export default class RecordPage extends Component<RecordProps, RecordState> {
 
       console.log(error);
       // TODO display error to user
+    }
+
+    if (!this.props.onRecordingSet) {
+      return;
+    }
+
+    if (this.isFull()) {
+      this.props.onRecordingSet();
     }
   }
 

--- a/web/src/lib/components/pages/record.tsx
+++ b/web/src/lib/components/pages/record.tsx
@@ -124,7 +124,7 @@ export default class RecordPage extends Component<RecordProps, RecordState> {
 
     this.props.onRecordStop && this.props.onRecordStop();
 
-    let error = this.checkRecording();
+    const error = this.checkRecording();
     if (error) {
       // Remove the invalid recording to go back.
       let recordings = this.state.recordings;
@@ -147,7 +147,7 @@ export default class RecordPage extends Component<RecordProps, RecordState> {
   }
 
   private checkRecording(): string {
-    let length = this.state.recordingStopTime - this.state.recordingStartTime;
+    const length = this.state.recordingStopTime - this.state.recordingStartTime;
     if (length < MIN_RECORDING_LENGTH) {
       return 'The recording is too short.';
     }

--- a/web/src/lib/components/pages/record.tsx
+++ b/web/src/lib/components/pages/record.tsx
@@ -133,14 +133,21 @@ export default class RecordPage extends Component<RecordProps, RecordState> {
 
     const error = this.getRecordingError();
     if (error) {
-      // Remove the invalid recording to go back.
-      let recordings = this.state.recordings;
-      recordings.pop();
-      this.setState({
-        recordings: recordings
-      });
-
-      console.log(error);
+      let message;
+      switch (error) {
+        case RecordingError.TOO_SHORT:
+          message = 'The recording was too short.';
+          break;
+        case RecordingError.TOO_LONG:
+          message = 'The recording was too long.';
+          break;
+        case RecordingError.TOO_QUIET:
+          message = 'The recording was too quiet.';
+          break;
+        default:
+          message = 'There was something wrong with the recording.';
+      }
+      console.log(message);
       // TODO display error to user
     }
 

--- a/web/src/lib/components/pages/record.tsx
+++ b/web/src/lib/components/pages/record.tsx
@@ -15,7 +15,7 @@ import confirm from '../confirm';
 const CACHE_SET_COUNT = 9;
 const SET_COUNT = 3;
 const PAGE_NAME = 'record';
-const MIN_RECORDING_LENGTH = 400;   // ms
+const MIN_RECORDING_LENGTH = 300;   // ms
 const MAX_RECORDING_LENGTH = 10000; // ms
 const MIN_VOLUME = 1;
 

--- a/web/src/lib/components/pages/record.tsx
+++ b/web/src/lib/components/pages/record.tsx
@@ -19,6 +19,13 @@ const MIN_RECORDING_LENGTH = 400;   // ms
 const MAX_RECORDING_LENGTH = 10000; // ms
 const MIN_VOLUME = 1;
 
+enum RecordingValidity {
+  VALID,
+  TOO_SHORT,
+  TOO_LONG,
+  TOO_QUIET
+};
+
 interface RecordProps {
   active: string;
   user: User;
@@ -146,17 +153,18 @@ export default class RecordPage extends Component<RecordProps, RecordState> {
     }
   }
 
-  private checkRecording(): string {
+  private checkRecording(): RecordingValidity {
     const length = this.state.recordingStopTime - this.state.recordingStartTime;
     if (length < MIN_RECORDING_LENGTH) {
-      return 'The recording is too short.';
+      return RecordingValidity.TOO_SHORT;
     }
     if (length > MAX_RECORDING_LENGTH) {
-      return 'The recording is too long.';
+      return RecordingValidity.TOO_LONG;
     }
     if (this.state.maxVolume < MIN_VOLUME) {
-      return 'The recording is silent.';
+      return RecordingValidity.TOO_QUIET;
     }
+    return RecordingValidity.VALID;
   }
 
   private deleteRecording(index: number): void {


### PR DESCRIPTION
Fixes #384.

I added client-side volume and length checks on recordings. If a recording is invalid, the user has to re-record it.

At the moment, the user doesn't get notified about what's wrong with the recording. I'm not great at UI. Can someone help me to [make some kind of alert appear](https://github.com/Omniscimus/voice-web/blob/75117895b4d8983aa1af8b0d099f2b20103431e2/web/src/lib/components/pages/record.tsx#L137) to notify the user?

Also, thoughts about the length bounds (>0.4s and <10s)?