### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "voice-web",
   "version": "1.0.0",
   "description": "",
+  "license": "MPL-2.0",
   "main": "server/server.js",
   "dependencies": {
     "aws-sdk": "^2.67.0",


### PR DESCRIPTION
One less warning during the build process :smile:

`npm WARN voice-web@1.0.0 No license field.`