### PR TITLE
Make footer links evenly spaced horizontally

### DIFF
--- a/web/css/index.css
+++ b/web/css/index.css
@@ -545,10 +545,6 @@ header.active {
   color: var(--color-help);
 }
 
-#moz-links .links > :first-child a {
-  margin-right: 1.5rem;
-}
-
 @media (max-width: 600px) {
   #moz-links .links > p:last-child,
   #moz-links .links > :first-child a {
@@ -559,6 +555,8 @@ header.active {
 
 #moz-links .links > :first-child {
   margin-bottom: 0.2rem;
+  display: flex;
+  justify-content: space-between;
 }
 
 .nav-list {


### PR DESCRIPTION
Since the Discource link was moved from the footer link list to the contributions/community bar, the remaining four links in the footer looked like they were "left hanging" there.

So I made a small tweak to align them evenly horizontally, to the width of the line below them.

I implemented this using [CSS flexbox](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Using_CSS_flexible_boxes) for the immediate container of the links. This "new" CSS feature is currently supported by [over 80% of users' browsers according to caniuse.com](https://caniuse.com/#feat=flexbox), so I think it's safe to put in.

**Note:** Semi-unintentionally, this also changes the layout of the footer links on mobile, from a vertical list to a horizontal list (see screenshots below). I think the touch targets are large enough to still be able to hit them, esp. with the increased horizontal spacing between them. If you prefer to keep the vertical list on mobile, let me know and I'll update this :)

---

Screenshots:

_Note: Ignore anything above the footer; I just included that for orientation._

| Platform | Before | After |
| --- | --- | --- |
| Desktop | <img width="782" alt="screen shot 2017-08-19 at 11 30 22" src="https://user-images.githubusercontent.com/1099818/29485423-f6c54870-84d1-11e7-9a68-8dc18ed418ce.png"> | <img width="791" alt="screen shot 2017-08-19 at 11 31 44" src="https://user-images.githubusercontent.com/1099818/29485429-0701ec98-84d2-11e7-9049-ddd6d3c8717b.png"> |
| Mobile | <img width="321" alt="screen shot 2017-08-19 at 11 35 12" src="https://user-images.githubusercontent.com/1099818/29485463-8610619a-84d2-11e7-9c16-b27bc47039f6.png"> | <img width="322" alt="screen shot 2017-08-19 at 11 35 56" src="https://user-images.githubusercontent.com/1099818/29485467-9e457124-84d2-11e7-8182-c599bf785bef.png"> |