### PR TITLE
Show names of external link targets for help links

### DIFF
--- a/web/css/index.css
+++ b/web/css/index.css
@@ -492,6 +492,8 @@ header.active {
   box-sizing: border-box;
   text-align: center;
   width: 10rem;
+  height: 4.8rem;
+  padding: .2rem 0;
 }
 
 #help-links a:first-child {
@@ -500,6 +502,14 @@ header.active {
 
 #help-links a:nth-child(2) {
   border-right: 1px solid black;
+}
+
+#help-links a .help-link-label {
+  margin-top: .2rem;
+}
+
+#help-links a .help-link-name {
+  font-size: .7rem;
 }
 
 #moz-links {

--- a/web/src/lib/components/pages.tsx
+++ b/web/src/lib/components/pages.tsx
@@ -383,17 +383,19 @@ export default class Pages extends Component<PagesProps, PagesState> {
               <a id="help" onClick={this.linkNavigate}
                  href="/faq">
                 <Icon type="help" />
-                <p class="strong">Help</p>
+                <p class="strong help-link-label">Help</p>
               </a>
               <a id="contribute"
                  target="_blank" href="https://github.com/mozilla/voice-web">
                 <Icon type="github" />
-                <p class="strong">Contribute</p>
+                <p class="strong help-link-label">Contribute</p>
+                <p class="help-link-name">on GitHub</p>
               </a>
               <a id="discourse"
                  target="blank" href="https://discourse.mozilla-community.org/c/voice">
                 <Icon type="discourse" />
-                <p class="strong">Community</p>
+                <p class="strong help-link-label">Community</p>
+                <p class="help-link-name">on Discourse</p>
               </a>
             </div>
           </div>


### PR DESCRIPTION
Since the Discourse link was recently moved from the footer links to the "help links" (cyan section above the very bottom footer) in #421, it was also re-labeled to "Community".

I think it's generally nice to tell the user where a link is going to lead them, especially external ones. And while some people may recognize the GitHub logo for the "Contribute" link, the label and icon for "Community" are so generic that I dont think most people can guess it leads to Discourse.

When I checked the [GUI specs](https://mozilla.github.io/voice-web/docs/GUI/#artboard2), I found that there's a suggestion to include names of external targets in the help links section as small text below the main label.

This change implements this naming for the GitHub and Discourse links, with some adjusted spacing.

Some notes:
* the GUI specs use a 20px font-size for the link labels (Help/Contribute/Community), while the page currently uses the page-wide default 15px font-size, and a smaller font-size (14px) for the names (GitHub/Discourse)
  * instead of making the label text bigger, I decided to scale down the name text proportionally (14px/20px = 70% -> I used `0.7rem`)
* since "Help" is an internal link, I don't think it needs a name below the label (and I couldn't think of a good one either)
  * this has the side effect that two of the three help links have a name, while one doesn't, so they have different visual heights
  * in order to properly align all three of them, I had to adjust the size and alignment of these help links
  * if we want to add a name below the "Help" link (and if someone has a good suggestion), I can easily adjust this PR to include that; that would also allow re-simplification of the style rules, since all three links would then be the same height

---

Screenshots:

| Platform | Before | After |
| --- | --- | --- |
| Desktop | <img width="772" alt="screen shot 2017-08-19 at 12 40 19" src="https://user-images.githubusercontent.com/1099818/29485939-988d9d48-84db-11e7-9e6e-c95d615b712a.png"> | <img width="780" alt="screen shot 2017-08-19 at 12 40 54" src="https://user-images.githubusercontent.com/1099818/29485944-ac547360-84db-11e7-99d8-5fca3ed001aa.png"> |
| Mobile | <img width="319" alt="screen shot 2017-08-19 at 12 43 14" src="https://user-images.githubusercontent.com/1099818/29485961-08ba7a78-84dc-11e7-8319-1f73fe6aaa8f.png"> | <img width="319" alt="screen shot 2017-08-19 at 12 43 02" src="https://user-images.githubusercontent.com/1099818/29485962-0e5db030-84dc-11e7-8933-776ba4591181.png"> |