### PR TITLE
Fix Invalid URI errors in Firefox console

### DIFF
--- a/web/src/lib/components/listen-box.tsx
+++ b/web/src/lib/components/listen-box.tsx
@@ -138,7 +138,9 @@ export default class ListenBox extends Component<Props, State> {
           <Icon type="x"/>Nope.</a>
       </div>
       <audio className="audio-box"
-        src={this.props.src}
+        // Only include the src attribute if the source is defined
+        // (empty src attributes are invalid)
+        {...this.props.src && {src: this.props.src}}
         preload="auto"
         onLoadStart={this.onLoadStart}
         onCanPlayThrough={this.onCanPlayThrough}


### PR DESCRIPTION
This is a fix for the `Invalid URI. Load of media resource failed.` error in the Firefox console when loading the app (#397).

If the listen boxes were disabled, the `src` attribute of its `audio` element had the value of an empty string. This is invalid, because the src attribute on media elements must always contain a valid, non-empty URL if it is present ([source](https://html.spec.whatwg.org/#attr-media-src)).