### PR TITLE
Fix for issue #448 - include AWS signature version to enable S3 buckets in new regions

### DIFF
--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -29,7 +29,7 @@ export default class Clip {
   private files: Files;
 
   constructor() {
-    this.s3 = new AWS.S3();
+    this.s3 = new AWS.S3({signatureVersion: 'v4'});
     this.files = new Files();
   }
 


### PR DESCRIPTION
S3 buckets in newer AWS regions require the v4 signature version, although the older ones support v2.  The default region used in voice-web is older and thus does handle v2 but for anyone who switches to use buckets in a newer region will run into errors with the signature, as explained in issue #448.

This fix simply explicitly adds the v4 signature version so it works on all regions.