### PR TITLE
Restrict Safari detection to iOS-only

### DIFF
--- a/web/css/index.css
+++ b/web/css/index.css
@@ -742,11 +742,11 @@ body:not(.ios) .recording #background-container {
   transition: transform 0.2s linear;
 }
 
-body.mobile-safari #install-app {
+body.mobile-safari:not(.ios) #install-app {
   transform: translateY(0);
 }
 
-body.mobile-safari #install-app.hide {
+body.mobile-safari:not(.ios) #install-app.hide {
   transform: translateY(3rem);
 }
 

--- a/web/css/index.css
+++ b/web/css/index.css
@@ -742,13 +742,12 @@ body:not(.ios) .recording #background-container {
   transition: transform 0.2s linear;
 }
 
-@media (max-width: 600px) {
-  .safari #install-app {
-    transform: translateY(0);
-  }
-  .safari #install-app.hide {
-    transform: translateY(3rem);
-  }
+body.mobile-safari #install-app {
+  transform: translateY(0);
+}
+
+body.mobile-safari #install-app.hide {
+  transform: translateY(3rem);
 }
 
 #install-app a {

--- a/web/src/lib/app.tsx
+++ b/web/src/lib/app.tsx
@@ -2,7 +2,7 @@ import { h, render } from 'preact';
 import User from './user';
 import API from './api';
 import Pages from './components/pages';
-import { isSafari, isFocus, isNativeIOS } from './utility';
+import { isMobileSafari, isFocus, isNativeIOS } from './utility';
 import DebugBox from './components/debug-box';
 
 const LOAD_DELAY = 500; // before pulling the curtain
@@ -54,8 +54,8 @@ export default class App {
       document.body.classList.add('focus');
     }
 
-    if (isSafari()) {
-      document.body.classList.add('safari');
+    if (isMobileSafari()) {
+      document.body.classList.add('mobile-safari');
     }
 
     this.user = new User();

--- a/web/src/lib/utility.ts
+++ b/web/src/lib/utility.ts
@@ -46,8 +46,18 @@ export function isFocus(): boolean {
   return navigator.userAgent.indexOf('Focus') !== -1;
 }
 
-export function isSafari(): boolean {
-  return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+/**
+ * Check whether the browser is mobile Safari (i.e. on iOS).
+ * 
+ * The logic is collected from answers to this SO question: https://stackoverflow.com/q/3007480
+ */
+export function isMobileSafari(): boolean {
+  const userAgent = window.navigator.userAgent;
+  const isIOS = /(iPod|iPhone|iPad)/i.test(userAgent);
+  const isWebkit = /AppleWebKit/i.test(userAgent);
+  const isIOSSafari =
+    isIOS && isWebkit && !/(Chrome|CriOS|OPiOS)/.test(userAgent);
+  return isIOSSafari;
 }
 
 export function isProduction(): boolean {


### PR DESCRIPTION
As I started working on implementing #424, I noticed that the Safari detection was too broad (it caught macOS Safari as well).

Changes in this PR:
* restrict Safari browser detection to iOS Safari (using logic collected from [this SO question](https://stackoverflow.com/q/3007480)
* rename the detection function and CSS class to `mobile-safari` to reflect its updated meaning
* adjust CSS to show the "Open in app" banner at the bottom of the screen on all iOS devices, not just narrow-viewport ones
  * previously, it was not shown on iPads (their viewports are too wide to hit the media query that was in use)