### PR TITLE
Feature/fix hover style for ios

### DIFF
--- a/web/css/index.css
+++ b/web/css/index.css
@@ -139,10 +139,8 @@ button {
   }
 }
 
-@media (min-width: 600px) {
-  button:hover:not(.ios) {
-    background-color: var(--color-speak);
-  }
+body:not(.mobile-safari) button:hover {
+  background-color: var(--color-speak);
 }
 
 button.highlight {
@@ -319,8 +317,10 @@ input:invalid {
   transition: 100ms;
 }
 
-.delete-box:hover,
-.play-box:hover {
+body:not(.mobile-safari) .delete-box:hover,
+body.mobile-safari .delete-box:active,
+body:not(.mobile-safari) .play-box:hover,
+body.mobile-safari .play-box:active {
   background-color: var(--color-listen-dark);
 }
 
@@ -346,10 +346,8 @@ input:invalid {
   align-items: flex-end;
 }
 
-@media (min-width: 600px) {
-  .vote-box > a:hover {
-    background-color: var(--color-listen);
-  }
+body:not(.mobile-safari) .vote-box > a:hover {
+  background-color: var(--color-listen);
 }
 
 .vote-box.disabled > a {
@@ -1088,7 +1086,7 @@ body.mobile-safari:not(.ios) #install-app.hide {
   }
 }
 
-.robot .bubble:hover {
+body:not(.mobile-safari) .robot .bubble:hover {
   transform: scale(1.05);
 }
 

--- a/web/css/index.css
+++ b/web/css/index.css
@@ -742,11 +742,11 @@ body:not(.ios) .recording #background-container {
   transition: transform 0.2s linear;
 }
 
-body.mobile-safari #install-app {
+body.mobile-safari:not(.ios) #install-app {
   transform: translateY(0);
 }
 
-body.mobile-safari #install-app.hide {
+body.mobile-safari:not(.ios) #install-app.hide {
   transform: translateY(3rem);
 }
 

--- a/web/css/index.css
+++ b/web/css/index.css
@@ -742,13 +742,12 @@ body:not(.ios) .recording #background-container {
   transition: transform 0.2s linear;
 }
 
-@media (max-width: 600px) {
-  .safari #install-app {
-    transform: translateY(0);
-  }
-  .safari #install-app.hide {
-    transform: translateY(3rem);
-  }
+body.mobile-safari #install-app {
+  transform: translateY(0);
+}
+
+body.mobile-safari #install-app.hide {
+  transform: translateY(3rem);
 }
 
 #install-app a {

--- a/web/src/lib/app.tsx
+++ b/web/src/lib/app.tsx
@@ -2,7 +2,7 @@ import { h, render } from 'preact';
 import User from './user';
 import API from './api';
 import Pages from './components/pages';
-import { isSafari, isFocus, isNativeIOS } from './utility';
+import { isMobileSafari, isFocus, isNativeIOS } from './utility';
 import DebugBox from './components/debug-box';
 
 const LOAD_DELAY = 500; // before pulling the curtain
@@ -54,8 +54,8 @@ export default class App {
       document.body.classList.add('focus');
     }
 
-    if (isSafari()) {
-      document.body.classList.add('safari');
+    if (isMobileSafari()) {
+      document.body.classList.add('mobile-safari');
     }
 
     this.user = new User();

--- a/web/src/lib/utility.ts
+++ b/web/src/lib/utility.ts
@@ -46,8 +46,18 @@ export function isFocus(): boolean {
   return navigator.userAgent.indexOf('Focus') !== -1;
 }
 
-export function isSafari(): boolean {
-  return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+/**
+ * Check whether the browser is mobile Safari (i.e. on iOS).
+ * 
+ * The logic is collected from answers to this SO question: https://stackoverflow.com/q/3007480
+ */
+export function isMobileSafari(): boolean {
+  const userAgent = window.navigator.userAgent;
+  const isIOS = /(iPod|iPhone|iPad)/i.test(userAgent);
+  const isWebkit = /AppleWebKit/i.test(userAgent);
+  const isIOSSafari =
+    isIOS && isWebkit && !/(Chrome|CriOS|OPiOS)/.test(userAgent);
+  return isIOSSafari;
 }
 
 export function isProduction(): boolean {


### PR DESCRIPTION
Fixes #424.

Based on #466 (and contains the changes from there, for now, due to the way PRs work).

This PR disables hover styles on iOS, since they "get stuck" as described in detail in #424.

For the generic `button`, the `vote-box` buttons and the robot's bubble, I simple disabled the hover style without a new replacement, since there are already other `:active` styles in place (button, vote-box) or tapping the element immediately navigates away (robot's bubble), respectively.

For the `listen-box` elements (play/pause button and delete button), I adjusted the CSS to apply the style that was used for `:hover` until now to the `:active` state for iOS. This preserves visual feedback while the user is tapping the element, but does not get stuck like `:hover` does.

These changes apply to both Safari on iOS and the native iOS app. However, I could only test this in the iOS simulator on a Mac, since I don't currently have any iOS test devices around.  
Therefore it would be great if someone could double-test this.