### PR TITLE
Adjust 'speak' page to avoid empty space

### DIFF
--- a/web/css/index.css
+++ b/web/css/index.css
@@ -1369,11 +1369,13 @@ body:not(.ios) .recording #background-container {
 }
 
 #voice-submit {
+  display: none;
   opacity: 0;
   transition: all 0.2s var(--bounce-curve);
 }
 
 #voice-record {
+  display: initial;
   overflow-x: hidden;
   padding: 0 0.5rem;
 }
@@ -1385,10 +1387,11 @@ body:not(.ios) .recording #background-container {
 }
 
 .full #voice-record {
-  visibility: hidden;
+  display: none;
 }
 
 .full #voice-submit {
+  display: initial;
   opacity: 1;
   transform: translateY(-27.5rem);
 }


### PR DESCRIPTION
On the "speak" page, the review box was taking up space in the DOM even in the recording stage. This pushed the footer bar further down that it should be (basically there was a big block of unused space).

This PR hides the review box and the record box whenever they're not in use, using `display: none`.

Edit: This seems to be the same issue that was reported in #185.