### PR TITLE
Use async/await in AudioWeb class

### DIFF
--- a/web/src/lib/components/pages/record/audio-ios.ts
+++ b/web/src/lib/components/pages/record/audio-ios.ts
@@ -98,8 +98,8 @@ export default class AudioIOS {
     this.postMessage('lockportrait');
   }
 
-  init() {
-    return Promise.resolve();
+  async init(): Promise<void> {
+    return;
   }
 
   setVolumeCallback(cb: Function) {

--- a/web/src/lib/components/pages/record/audio-web.ts
+++ b/web/src/lib/components/pages/record/audio-web.ts
@@ -111,68 +111,71 @@ export default class AudioWeb {
     this.volumeCallback = cb;
   }
 
-  init() {
-    if (this.initPromise) {
-      return this.initPromise;
+  init(): Promise<void> {
+    if (!this.initPromise) {
+      this.initPromise = this.doInit();
     }
 
-    return (this.initPromise = this.getMicrophone()
-      .then((microphone: MediaStream) => {
-        this.microphone = microphone;
-        var audioContext = new AudioContext();
-        var sourceNode = audioContext.createMediaStreamSource(microphone);
-        var volumeNode = audioContext.createGain();
-        var analyzerNode = audioContext.createAnalyser();
-        var outputNode = audioContext.createMediaStreamDestination();
+    return this.initPromise;
+  }
 
-        // Make sure we're doing mono everywhere.
-        sourceNode.channelCount = 1;
-        volumeNode.channelCount = 1;
-        analyzerNode.channelCount = 1;
-        outputNode.channelCount = 1;
+  private async doInit(): Promise<void> {
+    try {
+      const microphone = await this.getMicrophone();
 
-        // Connect the nodes together
-        sourceNode.connect(volumeNode);
-        volumeNode.connect(analyzerNode);
-        analyzerNode.connect(outputNode);
+      this.microphone = microphone;
+      var audioContext = new AudioContext();
+      var sourceNode = audioContext.createMediaStreamSource(microphone);
+      var volumeNode = audioContext.createGain();
+      var analyzerNode = audioContext.createAnalyser();
+      var outputNode = audioContext.createMediaStreamDestination();
 
-        // and set up the recorder.
-        this.recorder = new MediaRecorder(outputNode.stream);
+      // Make sure we're doing mono everywhere.
+      sourceNode.channelCount = 1;
+      volumeNode.channelCount = 1;
+      analyzerNode.channelCount = 1;
+      outputNode.channelCount = 1;
 
-        // Set up the analyzer node, and allocate an array for its data
-        // FFT size 64 gives us 32 bins. But those bins hold frequencies up to
-        // 22kHz or more, and we only care about visualizing lower frequencies
-        // which is where most human voice lies, so we use fewer bins
-        analyzerNode.fftSize = 128;
-        analyzerNode.smoothingTimeConstant = 0.96;
-        this.frequencyBins = new Uint8Array(analyzerNode.frequencyBinCount);
+      // Connect the nodes together
+      sourceNode.connect(volumeNode);
+      volumeNode.connect(analyzerNode);
+      analyzerNode.connect(outputNode);
 
-        // Setup audio visualizer.
-        this.jsNode = audioContext.createScriptProcessor(256, 1, 1);
-        this.jsNode.connect(audioContext.destination);
+      // and set up the recorder.
+      this.recorder = new MediaRecorder(outputNode.stream);
 
-        // Another audio node used by the beep() function
-        var beeperVolume = audioContext.createGain();
-        beeperVolume.connect(audioContext.destination);
+      // Set up the analyzer node, and allocate an array for its data
+      // FFT size 64 gives us 32 bins. But those bins hold frequencies up to
+      // 22kHz or more, and we only care about visualizing lower frequencies
+      // which is where most human voice lies, so we use fewer bins
+      analyzerNode.fftSize = 128;
+      analyzerNode.smoothingTimeConstant = 0.96;
+      this.frequencyBins = new Uint8Array(analyzerNode.frequencyBinCount);
 
-        this.analyzerNode = analyzerNode;
-        this.audioContext = audioContext;
+      // Setup audio visualizer.
+      this.jsNode = audioContext.createScriptProcessor(256, 1, 1);
+      this.jsNode.connect(audioContext.destination);
 
-        this.ready = true;
-      })
-      .catch(err => {
-        if (err === ERROR_MSG.ERR_NO_MIC) {
-          return confirm(
-            'You must allow microphone access.',
-            'Retry',
-            'Cancel'
-          ).then(() => {
-            window.location.reload();
-          });
-        } else {
-          throw err;
-        }
-      }));
+      // Another audio node used by the beep() function
+      var beeperVolume = audioContext.createGain();
+      beeperVolume.connect(audioContext.destination);
+
+      this.analyzerNode = analyzerNode;
+      this.audioContext = audioContext;
+
+      this.ready = true;
+    } catch (err) {
+      if (err === ERROR_MSG.ERR_NO_MIC) {
+        const shouldRetry = await confirm(
+          'You must allow microphone access.',
+          'Retry',
+          'Cancel'
+        );
+        window.location.reload();
+      } else {
+        throw err;
+      }
+    }
   }
 
   start(): Promise<void> {

--- a/web/src/lib/components/pages/record/audio-web.ts
+++ b/web/src/lib/components/pages/record/audio-web.ts
@@ -23,7 +23,7 @@ export default class AudioWeb {
   last: AudioInfo;
   lastRecordingData: Blob;
   lastRecordingUrl: string;
-  initPromise: Promise<void>;
+  isInitialized: boolean = false;
   frequencyBins: Uint8Array;
   volumeCallback: Function;
   jsNode: any;
@@ -111,15 +111,11 @@ export default class AudioWeb {
     this.volumeCallback = cb;
   }
 
-  init(): Promise<void> {
-    if (!this.initPromise) {
-      this.initPromise = this.doInit();
+  async init(): Promise<void> {
+    if (this.isInitialized) {
+      return;
     }
 
-    return this.initPromise;
-  }
-
-  private async doInit(): Promise<void> {
     try {
       const microphone = await this.getMicrophone();
 

--- a/web/src/lib/components/pages/record/audio-web.ts
+++ b/web/src/lib/components/pages/record/audio-web.ts
@@ -23,7 +23,6 @@ export default class AudioWeb {
   last: AudioInfo;
   lastRecordingData: Blob;
   lastRecordingUrl: string;
-  isInitialized: boolean = false;
   frequencyBins: Uint8Array;
   volumeCallback: Function;
   jsNode: any;
@@ -112,7 +111,7 @@ export default class AudioWeb {
   }
 
   async init(): Promise<void> {
-    if (this.isInitialized) {
+    if (this.ready) {
       return;
     }
 

--- a/web/src/lib/confirm/confirm.ts
+++ b/web/src/lib/confirm/confirm.ts
@@ -1,20 +1,24 @@
 /**
  * Present a modal dialog (asynchronously). Usage:
  *
- *   confirm('are you sure?').then(...)
+ *   const isConfirmed = await confirm('are you sure?', 'yes', 'no')
+ *   if (!isConfirmed) { ... show error ... }
  *
- * @param label A string label.
- * @return {Promise}
+ * @param label The main text/label for the dialog.
+ * @param okLabel Label for the "OK" button.
+ * @param cancelLabel Label for the "Cancel" button.
+ * @returns A Promise that is resolved with `true` if user clicks the "OK" button, 
+ *    or resolved with `false` if user clicks the "Cancel" button.
  */
 export default function confirm(
   label: string,
   okLabel: string,
   cancelLabel: string
 ) {
-  let element = document.createElement('div');
+  const element = document.createElement('div');
   element.classList.add('confirm-modal');
 
-  let mainSection = document.createElement('div');
+  const mainSection = document.createElement('div');
   mainSection.classList.add('main-section');
   element.appendChild(mainSection);
 


### PR DESCRIPTION
This replaces `Promise.then()` usage with async/await in the `AudioWeb` class, as part of #402.

@mikehenrty, please take a look at the remaining usages of `then()` in the web part of the code. I would actually leave them as they are, because they intentionally spawn off asynchronous actions and don't directly wait for them.
Introducing async/await in their place would pull up the Promise another call, and require changes in more places. In contrast to our goal with #402, this would actually degrade readability IMO.
