### PR TITLE
Use TS 'import' instead of 'require' where currently possible

### DIFF
--- a/server/src/lib/api.ts
+++ b/server/src/lib/api.ts
@@ -1,9 +1,10 @@
+import * as fs from 'fs';
 import * as http from 'http';
+import * as path from 'path';
+
 import WebHook from './webhook';
 import respond from './responder';
 
-const path = require('path');
-const fs = require('fs');
 const Promise = require('bluebird');
 const Random = require('random-js');
 
@@ -55,20 +56,14 @@ export default class API {
   private getFileContents(filepath: string) {
     return new Promise(
       (res: (contents: string) => void, rej: (error: any) => void) => {
-        fs.readFile(
-          filepath,
-          {
-            contents: 'utf8',
-          },
-          (err: any, data: Buffer) => {
-            if (err) {
-              rej(err);
-              return;
-            }
-
-            res(data.toString());
+        fs.readFile(filepath, (err: any, data: Buffer) => {
+          if (err) {
+            rej(err);
+            return;
           }
-        );
+
+          res(data.toString());
+        });
       }
     );
   }

--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -1,17 +1,18 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
 import * as http from 'http';
+import * as path from 'path';
+import { PassThrough } from 'stream';
+
 import Files from './files';
 import { getFileExt } from './utility';
 import respond, { CONTENT_TYPES } from './responder';
 
 const ms = require('mediaserver');
-const path = require('path');
 const ff = require('ff');
-const fs = require('fs');
-const crypto = require('crypto');
 const Promise = require('bluebird');
 const mkdirp = require('mkdirp');
 const AWS = require('./aws');
-const PassThrough = require('stream').PassThrough;
 const Transcoder = require('stream-transcoder');
 
 const UPLOAD_PATH = path.resolve(__dirname, '../..', 'upload');

--- a/server/src/lib/files.ts
+++ b/server/src/lib/files.ts
@@ -1,8 +1,9 @@
+import * as path from 'path';
+
 import { map } from '../promisify';
 import { getFileExt } from './utility';
 
 const MemoryStream = require('memorystream');
-const path = require('path');
 const Promise = require('bluebird');
 const Random = require('random-js');
 const AWS = require('./aws');

--- a/server/src/lib/logger.ts
+++ b/server/src/lib/logger.ts
@@ -1,4 +1,4 @@
-const os = require('os');
+import * as os from 'os';
 
 const NAME = 'voice';
 const LEVEL_LOG = 'log';

--- a/server/src/lib/webhook.ts
+++ b/server/src/lib/webhook.ts
@@ -1,7 +1,8 @@
 import * as http from 'http';
+import * as path from 'path';
+
 import respond from './responder';
 
-const path = require('path');
 const SimpleGit = require('simple-git');
 
 const PROJECT_PATH = path.resolve(__dirname, '../../../');

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,4 +1,6 @@
 import * as http from 'http';
+import * as path from 'path';
+
 import API from './lib/api';
 import Clip from './lib/clip';
 import Logger from './lib/logger';
@@ -10,7 +12,6 @@ const CLIENT_PATH = '../../web';
 
 const nodeStatic = require('node-static');
 const config = require(CONFIG_PATH);
-const path = require('path');
 
 export default class Server {
   api: API;


### PR DESCRIPTION
Since the Node typings are already part of package.json (though currently in version 7, we need to remember to change this if we decide to make Node 8 the minimum supported version), parts of the Node standard library can imported with `import` already, adding type support.

I'm planning to add more typings for other libraries used, but that will go in a separate PR :)