### PR TITLE
Improvements to the 'Open In App' bar on iOS

### DIFF
--- a/ios/voicebank-ios-wrapper/Info.plist
+++ b/ios/voicebank-ios-wrapper/Info.plist
@@ -23,7 +23,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Data captured from microphone is used to improve Mozilla's speech recognition models</string>
+	<string>Data captured from microphone is used to improve Mozilla&apos;s speech recognition models</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -31,6 +31,17 @@
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>
+	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>commonvoice</string>
+			</array>
+		</dict>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>

--- a/web/css/index.css
+++ b/web/css/index.css
@@ -736,8 +736,12 @@ body:not(.ios) .recording #background-container {
   color: white;
   font-weight: bold;
   z-index: var(--top-z-index);
-  transform: translateY(3rem);
+  transform: translateY(0);
   transition: transform 0.2s linear;
+}
+
+#install-app.hide {
+  transform: translateY(3rem);
 }
 
 #install-app a {

--- a/web/css/index.css
+++ b/web/css/index.css
@@ -723,39 +723,6 @@ body:not(.ios) .recording #background-container {
   }
 }
 
-#install-app {
-  position: fixed;
-  bottom: 0;
-  left: 0; right: 0;
-  background-color: rgba(61, 254, 253, 0.9);
-  height: 3rem;
-  line-height: 3rem;
-  vertical-align: middle;
-  cursor: pointer;
-  text-align: center;
-  color: white;
-  font-weight: bold;
-  z-index: var(--top-z-index);
-  transform: translateY(3rem);
-  transition: transform 0.2s linear;
-}
-
-body.mobile-safari:not(.ios) #install-app {
-  transform: translateY(0);
-}
-
-body.mobile-safari:not(.ios) #install-app.hide {
-  transform: translateY(3rem);
-}
-
-#install-app a {
-  position: absolute;
-  right: 0;
-  height: 100%;
-  width: 3rem;
-  color: white;
-}
-
 /**
  * We have two different page transition types:
  * one for desktop and one for mobile.

--- a/web/css/index.css
+++ b/web/css/index.css
@@ -740,14 +740,6 @@ body:not(.ios) .recording #background-container {
   transition: transform 0.2s linear;
 }
 
-body.mobile-safari:not(.ios) #install-app {
-  transform: translateY(0);
-}
-
-body.mobile-safari:not(.ios) #install-app.hide {
-  transform: translateY(3rem);
-}
-
 #install-app a {
   position: absolute;
   right: 0;

--- a/web/css/index.css
+++ b/web/css/index.css
@@ -723,6 +723,39 @@ body:not(.ios) .recording #background-container {
   }
 }
 
+#install-app {
+  position: fixed;
+  bottom: 0;
+  left: 0; right: 0;
+  background-color: rgba(61, 254, 253, 0.9);
+  height: 3rem;
+  line-height: 3rem;
+  vertical-align: middle;
+  cursor: pointer;
+  text-align: center;
+  color: white;
+  font-weight: bold;
+  z-index: var(--top-z-index);
+  transform: translateY(3rem);
+  transition: transform 0.2s linear;
+}
+
+body.mobile-safari:not(.ios) #install-app {
+  transform: translateY(0);
+}
+
+body.mobile-safari:not(.ios) #install-app.hide {
+  transform: translateY(3rem);
+}
+
+#install-app a {
+  position: absolute;
+  right: 0;
+  height: 100%;
+  width: 3rem;
+  color: white;
+}
+
 /**
  * We have two different page transition types:
  * one for desktop and one for mobile.

--- a/web/index.html
+++ b/web/index.html
@@ -12,6 +12,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@mozilla" />
     <meta name="twitter:creator" content="@mikehenrty" />
+    <meta name="apple-itunes-app" content="app-id=1240588326">
     <link rel="stylesheet" href="/dist/index.css">
   </head>
   <body>

--- a/web/src/lib/app.tsx
+++ b/web/src/lib/app.tsx
@@ -2,7 +2,7 @@ import { h, render } from 'preact';
 import User from './user';
 import API from './api';
 import Pages from './components/pages';
-import { isMobileSafari, isFocus, isNativeIOS } from './utility';
+import { isMobileWebkit, isFocus, isNativeIOS } from './utility';
 import DebugBox from './components/debug-box';
 
 const LOAD_DELAY = 500; // before pulling the curtain
@@ -54,7 +54,7 @@ export default class App {
       document.body.classList.add('focus');
     }
 
-    if (isMobileSafari()) {
+    if (isMobileWebkit()) {
       document.body.classList.add('mobile-safari');
     }
 

--- a/web/src/lib/components/pages.tsx
+++ b/web/src/lib/components/pages.tsx
@@ -114,8 +114,6 @@ export default class Pages extends Component<PagesProps, PagesState> {
     this.renderUser = this.renderUser.bind(this);
     this.linkNavigate = this.linkNavigate.bind(this);
     this.clearRobot = this.clearRobot.bind(this);
-    this.openInApp = this.openInApp.bind(this);
-    this.closeOpenInApp = this.closeOpenInApp.bind(this);
     this.onVolume = this.onVolume.bind(this);
   }
 
@@ -123,16 +121,6 @@ export default class Pages extends Component<PagesProps, PagesState> {
     if (!this.state.transitioning && this.state.recording) {
       this.setState({ recorderVolume: volume });
     }
-  }
-
-  private openInApp() {
-    window.location.href = getItunesURL();
-  }
-
-  private closeOpenInApp(evt: Event) {
-    evt.stopPropagation();
-    evt.preventDefault();
-    document.getElementById('install-app').classList.add('hide');
   }
 
   private getCurrentPageName() {
@@ -344,10 +332,6 @@ export default class Pages extends Component<PagesProps, PagesState> {
 
     return (
       <div id="main" className={className}>
-        <div onClick={this.openInApp} id="install-app">
-          Open in App
-          <a onClick={this.closeOpenInApp}>X</a>
-        </div>
         <header
           className={
             this.state.isMenuVisible || this.state.scrolled ? 'active' : ''

--- a/web/src/lib/components/pages.tsx
+++ b/web/src/lib/components/pages.tsx
@@ -125,8 +125,15 @@ export default class Pages extends Component<PagesProps, PagesState> {
     }
   }
 
+  /**
+   * If the iOS app is installed, open it. Otherwise, open the App Store.
+   */
   private openInApp() {
-    window.location.href = getItunesURL();
+    window.location.href = 'commonvoice://';
+
+    setTimeout(function() {
+      window.location.href = getItunesURL();
+    }, 500);
   }
 
   private closeOpenInApp(evt: Event) {

--- a/web/src/lib/components/pages.tsx
+++ b/web/src/lib/components/pages.tsx
@@ -114,6 +114,8 @@ export default class Pages extends Component<PagesProps, PagesState> {
     this.renderUser = this.renderUser.bind(this);
     this.linkNavigate = this.linkNavigate.bind(this);
     this.clearRobot = this.clearRobot.bind(this);
+    this.openInApp = this.openInApp.bind(this);
+    this.closeOpenInApp = this.closeOpenInApp.bind(this);
     this.onVolume = this.onVolume.bind(this);
   }
 
@@ -121,6 +123,16 @@ export default class Pages extends Component<PagesProps, PagesState> {
     if (!this.state.transitioning && this.state.recording) {
       this.setState({ recorderVolume: volume });
     }
+  }
+
+  private openInApp() {
+    window.location.href = getItunesURL();
+  }
+
+  private closeOpenInApp(evt: Event) {
+    evt.stopPropagation();
+    evt.preventDefault();
+    document.getElementById('install-app').classList.add('hide');
   }
 
   private getCurrentPageName() {
@@ -332,6 +344,10 @@ export default class Pages extends Component<PagesProps, PagesState> {
 
     return (
       <div id="main" className={className}>
+        <div onClick={this.openInApp} id="install-app">
+          Open in App
+          <a onClick={this.closeOpenInApp}>X</a>
+        </div>
         <header
           className={
             this.state.isMenuVisible || this.state.scrolled ? 'active' : ''

--- a/web/src/lib/components/pages.tsx
+++ b/web/src/lib/components/pages.tsx
@@ -353,7 +353,8 @@ export default class Pages extends Component<PagesProps, PagesState> {
       <div id="main" className={className}>
         {isIOS() &&
           !isSafari() && (
-            // In iOS Safari, we display a Smart App Banner instead.
+            // This is a banner for non-Safari browsers on iOS.
+            // In iOS Safari, we display a 'Smart App Banner' instead.
             <div onClick={this.openInApp} id="install-app">
               Open in App
               <a onClick={this.closeOpenInApp}>X</a>

--- a/web/src/lib/components/pages.tsx
+++ b/web/src/lib/components/pages.tsx
@@ -344,13 +344,14 @@ export default class Pages extends Component<PagesProps, PagesState> {
 
     return (
       <div id="main" className={className}>
-        {isIOS() && !isSafari() &&
-          // In iOS Safari, we display a Smart App Banner instead.
-          <div onClick={this.openInApp} id="install-app">
-            Open in App
-            <a onClick={this.closeOpenInApp}>X</a>
-          </div>
-        }
+        {isIOS() &&
+          !isSafari() && (
+            // In iOS Safari, we display a Smart App Banner instead.
+            <div onClick={this.openInApp} id="install-app">
+              Open in App
+              <a onClick={this.closeOpenInApp}>X</a>
+            </div>
+          )}
         <header
           className={
             this.state.isMenuVisible || this.state.scrolled ? 'active' : ''

--- a/web/src/lib/components/pages.tsx
+++ b/web/src/lib/components/pages.tsx
@@ -1,5 +1,5 @@
 import { h, Component } from 'preact';
-import { getItunesURL, isNativeIOS } from '../utility';
+import { getItunesURL, isNativeIOS, isIOS, isSafari } from '../utility';
 import Logo from './logo';
 import Icon from './icon';
 import PrivacyContent from './privacy-content';
@@ -344,10 +344,13 @@ export default class Pages extends Component<PagesProps, PagesState> {
 
     return (
       <div id="main" className={className}>
-        <div onClick={this.openInApp} id="install-app">
-          Open in App
-          <a onClick={this.closeOpenInApp}>X</a>
-        </div>
+        {isIOS() && !isSafari() &&
+          // In iOS Safari, we display a Smart App Banner instead.
+          <div onClick={this.openInApp} id="install-app">
+            Open in App
+            <a onClick={this.closeOpenInApp}>X</a>
+          </div>
+        }
         <header
           className={
             this.state.isMenuVisible || this.state.scrolled ? 'active' : ''

--- a/web/src/lib/utility.ts
+++ b/web/src/lib/utility.ts
@@ -47,17 +47,35 @@ export function isFocus(): boolean {
 }
 
 /**
+ * Test whether this is a browser on iOS.
+ */
+export function isIOS(): boolean {
+  return /(iPod|iPhone|iPad)/i.test(window.navigator.userAgent);
+}
+
+/**
+ * Check whether the browser is Safari (either desktop or mobile).
+ */
+export function isSafari(): boolean {
+  const userAgent = window.navigator.userAgent;
+  /* Just checking isSafari isn't enough, because multiple browsers on iOS
+   * identify as Safari. The difference is that they have a different version
+   * string in the user agent. E.g. Safari has Version/<version>, Chrome has
+   * CriOS/<version>, Firefox has FxiOS/<version>.
+   */
+  const isWebkit = /AppleWebKit/i.test(userAgent);
+  const pretendsSafari = /Safari/i.test(userAgent);
+  const isSafari = /Version/i.test(userAgent);
+  return isWebkit && pretendsSafari && isSafari;
+}
+
+/**
  * Check whether the browser is mobile Safari (i.e. on iOS).
- * 
+ *
  * The logic is collected from answers to this SO question: https://stackoverflow.com/q/3007480
  */
 export function isMobileSafari(): boolean {
-  const userAgent = window.navigator.userAgent;
-  const isIOS = /(iPod|iPhone|iPad)/i.test(userAgent);
-  const isWebkit = /AppleWebKit/i.test(userAgent);
-  const isIOSSafari =
-    isIOS && isWebkit && !/(Chrome|CriOS|OPiOS)/.test(userAgent);
-  return isIOSSafari;
+  return isSafari() && isIOS();
 }
 
 export function isProduction(): boolean {

--- a/web/src/lib/utility.ts
+++ b/web/src/lib/utility.ts
@@ -79,12 +79,11 @@ export function isSafari(): boolean {
  * The logic is collected from answers to this SO question: https://stackoverflow.com/q/3007480
  */
 export function isMobileWebkit(): boolean {
-  const userAgent = window.navigator.userAgent;
-  const isIOS = /(iPod|iPhone|iPad)/i.test(userAgent);
-  const isWebkit = this.isWebkit();
-  const isIOSSafari =
-    isIOS && isWebkit && !/(Chrome|CriOS|OPiOS)/.test(userAgent);
-  return isIOSSafari;
+  return (
+    this.isIOS() &&
+    this.isWebkit() &&
+    !/(Chrome|CriOS|OPiOS)/.test(window.navigator.userAgent)
+  );
 }
 
 export function isProduction(): boolean {

--- a/web/src/lib/utility.ts
+++ b/web/src/lib/utility.ts
@@ -53,6 +53,10 @@ export function isIOS(): boolean {
   return /(iPod|iPhone|iPad)/i.test(window.navigator.userAgent);
 }
 
+export function isWebkit(): boolean {
+  return /AppleWebKit/i.test(window.navigator.userAgent);
+}
+
 /**
  * Check whether the browser is Safari (either desktop or mobile).
  */
@@ -63,7 +67,7 @@ export function isSafari(): boolean {
    * string in the user agent. E.g. Safari has Version/<version>, Chrome has
    * CriOS/<version>, Firefox has FxiOS/<version>.
    */
-  const isWebkit = /AppleWebKit/i.test(userAgent);
+  const isWebkit = this.isWebkit();
   const pretendsSafari = /Safari/i.test(userAgent);
   const isSafari = /Version/i.test(userAgent);
   return isWebkit && pretendsSafari && isSafari;
@@ -74,8 +78,13 @@ export function isSafari(): boolean {
  *
  * The logic is collected from answers to this SO question: https://stackoverflow.com/q/3007480
  */
-export function isMobileSafari(): boolean {
-  return isSafari() && isIOS();
+export function isMobileWebkit(): boolean {
+  const userAgent = window.navigator.userAgent;
+  const isIOS = /(iPod|iPhone|iPad)/i.test(userAgent);
+  const isWebkit = this.isWebkit();
+  const isIOSSafari =
+    isIOS && isWebkit && !/(Chrome|CriOS|OPiOS)/.test(userAgent);
+  return isIOSSafari;
 }
 
 export function isProduction(): boolean {


### PR DESCRIPTION
Fixes #467.

iOS Safari users were redirected to the Common Voice app in the App Store with a green banner at the bottom of the screen. I replaced this with a so-called [Smart App Banner](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/PromotingAppswithAppBanners/PromotingAppswithAppBanners.html). This is a bar at the top of the screen which redirects users to the app's page in the App Store if the app is not installed yet, and it opens the app if it is.

Browsers on iOS other than Safari do not support Smart App Banners. The old bar is still in place for them. Clicking this banner previously always opened the App Store, regardless of whether the app was installed. Now, the app's page in the App Store will be opened if the app isn't installed, and the app will be opened if it is installed.

To open the app if it's installed, I added a custom link to the iOS app: `commonvoice://`. iOS will open any links starting with that prefix in the Common Voice app. Side-effect: people who have already installed the app but haven't updated it yet will be redirected to the app's page in the App Store if they click this link in their browser (where I suppose they can update it).