### PR TITLE
Remove bluebird dependency (use native ES6 Promise instead)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -397,11 +397,6 @@
         "inherits": "2.0.3"
       }
     },
-    "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
-    },
     "boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "aws-sdk": "^2.67.0",
     "bcrypt": "^1.0.2",
-    "bluebird": "^3.5.0",
     "eslint": "^4.7.2",
     "eslint-plugin-prettier": "^2.3.1",
     "ff": "0.2.1",

--- a/server/src/lib/api.ts
+++ b/server/src/lib/api.ts
@@ -5,13 +5,12 @@ import * as path from 'path';
 import WebHook from './webhook';
 import respond from './responder';
 
-const Promise = require('bluebird');
 const Random = require('random-js');
 
 const SENTENCE_FOLDER = '../../data/';
 
 export default class API {
-  sentencesCache: String[];
+  sentencesCache: string[];
   webhook: WebHook;
   randomEngine: any;
 
@@ -95,7 +94,7 @@ export default class API {
     }
   }
 
-  getSentences() {
+  getSentences(): Promise<string[]> {
     if (this.sentencesCache) {
       return Promise.resolve(this.sentencesCache);
     }
@@ -133,9 +132,11 @@ export default class API {
           sentences = sentences.concat.apply(sentences, sentenceArrays);
           console.log('sentences found', sentences.length);
           this.sentencesCache = sentences;
+          return this.sentencesCache;
         })
         .catch((err: any) => {
           console.error('could not retrieve sentences', err);
+          return [];
         })
     );
   }

--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -10,7 +10,6 @@ import respond, { CONTENT_TYPES } from './responder';
 
 const ms = require('mediaserver');
 const ff = require('ff');
-const Promise = require('bluebird');
 const mkdirp = require('mkdirp');
 const AWS = require('./aws');
 const Transcoder = require('stream-transcoder');
@@ -383,7 +382,7 @@ export default class Clip {
 
     this.files
       .getRandomClip(uid)
-      .then((clip: string[2]) => {
+      .then((clip: string[]) => {
         if (!clip) {
         }
 

--- a/server/src/lib/db.ts
+++ b/server/src/lib/db.ts
@@ -2,7 +2,6 @@ import Mysql from './db/mysql';
 import UserDB from './db/user-db';
 import BadgesDB from './db/badges-db';
 import ProgressDB from './db/progress-db';
-const Promise = require('bluebird');
 
 export default class DB {
   mysql: Mysql;

--- a/server/src/lib/db/base-db.ts
+++ b/server/src/lib/db/base-db.ts
@@ -1,5 +1,4 @@
 import Mysql from './mysql';
-const Promise = require('bluebird');
 
 /**
  * Base object for dealing with data in Postgres table

--- a/server/src/lib/files.ts
+++ b/server/src/lib/files.ts
@@ -4,7 +4,6 @@ import { map } from '../promisify';
 import { getFileExt } from './utility';
 
 const MemoryStream = require('memorystream');
-const Promise = require('bluebird');
 const Random = require('random-js');
 const AWS = require('./aws');
 
@@ -279,7 +278,7 @@ export default class Files {
   /**
    * Grab a random sentence and associated sound file path.
    */
-  getRandomClip(uid: string): Promise<string[2]> {
+  getRandomClip(uid: string): Promise<string[]> {
     // Make sure we have at least 1 file to choose from.
     if (this.paths.length === 0) {
       return Promise.reject('No files.');

--- a/server/src/promisify.ts
+++ b/server/src/promisify.ts
@@ -1,5 +1,3 @@
-let Promise = require('bluebird');
-
 /**
  * Turn a callback function into a promise function.
  */
@@ -8,7 +6,7 @@ export default function make(context: any, method: Function, args?: any[]) {
     args = [args];
   }
 
-  return new Promise((resolve: any, reject: any) => {
+  return new Promise((resolve, reject) => {
     method.apply(
       context,
       args.concat([


### PR DESCRIPTION
As shortly discussed with @mikehenrty in #402, this removes the dependency on `bluebird`.

The server part now uses native ES6 Promises just like the web part does.

@mikehenrty, since I have relatively little time (in particular to make changes you request), I'm creating this as a separate small PR and didn't attack introducing async/await yet. I'll follow up with that in a new PR when I can, but if someone else gets around to starting it first, I don't want to block that :)

Also, feel free to make minor adjustments yourself as you see fit :)