### PR TITLE
Display error/waiting message while sentences are not/being loaded

### DIFF
--- a/web/css/index.css
+++ b/web/css/index.css
@@ -1310,8 +1310,13 @@ body:not(.mobile-safari) .robot .bubble:hover {
   height: 2.5rem;
   width: 2.5rem;
   margin: 1rem auto;
-  margin-top: calc(1rem + 4px);
   cursor: pointer;
+}
+
+.record-controls {
+  height:  5rem;
+  margin: 1rem auto;
+  margin-top: calc(1rem + 4px);
 }
 
 .recording #record-button {

--- a/web/src/lib/components/pages/record.tsx
+++ b/web/src/lib/components/pages/record.tsx
@@ -351,7 +351,7 @@ export default class RecordPage extends Component<RecordProps, RecordState> {
 
   private async newSentenceSet() {
     // If we don't have enough sentences in our cache, fill it before continuing.
-    while (!this.areSentencesLoaded()) {
+    while (!this.areSentencesLoaded) {
       console.error('slow path for getting new sentences');
       await sleep(RETRY_TIMEOUT);
       await this.refillSentenceCache();
@@ -366,7 +366,7 @@ export default class RecordPage extends Component<RecordProps, RecordState> {
     }
   }
 
-  areSentencesLoaded() {
+  private get areSentencesLoaded(): boolean {
     return this.sentenceCache.length >= SET_COUNT;
   }
 
@@ -432,7 +432,7 @@ export default class RecordPage extends Component<RecordProps, RecordState> {
       progress += 100 / SET_COUNT * 1;
     }
 
-    const controlElements = this.areSentencesLoaded()
+    const controlElements = this.areSentencesLoaded
       ? [
           <div
             id="record-button"

--- a/web/src/lib/components/pages/record.tsx
+++ b/web/src/lib/components/pages/record.tsx
@@ -25,6 +25,8 @@ const MIN_RECORDING_LENGTH = 300; // ms
 const MAX_RECORDING_LENGTH = 10000; // ms
 const MIN_VOLUME = 1;
 const RETRY_TIMEOUT = 1000;
+const ERR_SENTENCES_NOT_LOADED =
+  'Sorry! Sentinces are being loaded, please wait or try again shortly.';
 
 enum RecordingError {
   TOO_SHORT = 1,
@@ -349,7 +351,7 @@ export default class RecordPage extends Component<RecordProps, RecordState> {
 
   private async newSentenceSet() {
     // If we don't have enough sentences in our cache, fill it before continuing.
-    while (this.sentenceCache.length < SET_COUNT) {
+    while (!this.areSentencesLoaded()) {
       console.error('slow path for getting new sentences');
       await sleep(RETRY_TIMEOUT);
       await this.refillSentenceCache();
@@ -362,6 +364,10 @@ export default class RecordPage extends Component<RecordProps, RecordState> {
     if (this.sentenceCache.length < SET_COUNT * 2) {
       this.refillSentenceCache();
     }
+  }
+
+  areSentencesLoaded() {
+    return this.sentenceCache.length >= SET_COUNT;
   }
 
   render() {
@@ -426,6 +432,19 @@ export default class RecordPage extends Component<RecordProps, RecordState> {
       progress += 100 / SET_COUNT * 1;
     }
 
+    const controlElements = this.areSentencesLoaded()
+      ? [
+          <div
+            id="record-button"
+            onTouchStart={this.onRecordClick}
+            onClick={this.onRecordClick}
+          />,
+          <p id="record-help">
+            Please tap to record, then read the above sentence aloud.
+          </p>,
+        ]
+      : ERR_SENTENCES_NOT_LOADED;
+
     return (
       <div id="record-container" className={className}>
         <div id="voice-record">
@@ -443,14 +462,7 @@ export default class RecordPage extends Component<RecordProps, RecordState> {
               className={!showBack ? 'hide' : ''}
             />
           </div>
-          <div
-            id="record-button"
-            onTouchStart={this.onRecordClick}
-            onClick={this.onRecordClick}
-          />
-          <p id="record-help">
-            Please tap to record, then read the above sentence aloud.
-          </p>
+          <div class="record-controls">{controlElements}</div>
         </div>
         <div id="voice-submit">
           <p id="thank-you">


### PR DESCRIPTION
Closes #435 
Paired on it with @irmela 

We thought that it makes more sense to replace the record button while/if sentences are being/not loaded.

We faked the error by throwing an exception inside `getRandomSentences` in `src/lib/api.ts`.