### PR TITLE
Add TS typings for (most) server dependencies

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ const DIR_CLIENT = CWD + 'web/';
 const DIR_CLIENT_SRC = DIR_CLIENT + 'src/';
 const DIR_SERVER = CWD + 'server/';
 const DIR_SERVER_SRC = DIR_SERVER + 'src/';
+const DIR_SERVER_DEFS = DIR_SERVER + '@types/';
 const DIR_UPLOAD = DIR_SERVER + 'upload/';
 const DIR_SERVER_JS = DIR_SERVER + 'js/';
 const DIR_DIST = DIR_CLIENT + 'dist/';
@@ -18,6 +19,7 @@ const PATH_CSS = DIR_CLIENT + 'css/*.css';
 const PATH_TS = DIR_CLIENT_SRC + TS_GLOB;
 const PATH_TS_CONFIG = DIR_CLIENT + TS_CONFIG;
 const PATH_TS_SERVER = DIR_SERVER_SRC + TS_GLOB;
+const PATH_TS_DEFS_SERVER = DIR_SERVER_DEFS + TS_GLOB;
 const PATH_TS_CONFIG_SERVER = DIR_SERVER + TS_CONFIG;
 const PATH_VENDOR = DIR_CLIENT + 'vendor/';
 const SERVER_SCRIPT = './server/js/server.js'
@@ -93,7 +95,7 @@ function compileClient() {
 }
 
 function compileServer() {
-  return compile(PATH_TS_CONFIG_SERVER, PATH_TS_SERVER)
+  return compile(PATH_TS_CONFIG_SERVER, [PATH_TS_SERVER, PATH_TS_DEFS_SERVER])
     .pipe(gulp.dest(DIR_SERVER_JS));
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,15 @@
       "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==",
       "dev": true
     },
+    "@types/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha512-XA4vNO6GCBz8Smq0hqSRo4yRWMqr4FPQrWjhJt6nKskzly4/p87SfuJMFYGRyYb6jo2WNIQU2FDBsY5r1BibUA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "7.0.29"
+      }
+    },
     "@types/mysql": {
       "version": "0.0.34",
       "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-0.0.34.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,25 @@
         "@types/node": "7.0.29"
       }
     },
+    "@types/pg": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-7.1.4.tgz",
+      "integrity": "sha512-Niiko17+q7M7FEpCyI18pkuIolegFTDso+n7v0cG4gFM6qwOB9kfIsNLZXJRdENNwuIT+bPlhqLEmaYIYjBpgA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "7.0.29",
+        "@types/pg-types": "1.11.4"
+      }
+    },
+    "@types/pg-types": {
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@types/pg-types/-/pg-types-1.11.4.tgz",
+      "integrity": "sha512-WdIiQmE347LGc1Vq3Ki8sk3iyCuLgnccqVzgxek6gEHp2H0p3MQ3jniIHt+bRODXKju4kNQ+mp53lmP5+/9moQ==",
+      "dev": true,
+      "requires": {
+        "moment": "2.18.1"
+      }
+    },
     "@types/random-js": {
       "version": "1.0.30",
       "resolved": "https://registry.npmjs.org/@types/random-js/-/random-js-1.0.30.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,27 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/mime": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
+      "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "7.0.29",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.29.tgz",
       "integrity": "sha512-+8JrLZny/uR+d/jLK9eaV63buRM7X/gNzQk57q76NS4KNKLSKOmxJYFIlwuP2zDvA7wqZj05POPhSd9Z1hYQpQ==",
       "dev": true
+    },
+    "@types/node-static": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node-static/-/node-static-0.7.0.tgz",
+      "integrity": "sha512-4SImtzapcVt+rQEAKVtbT0eh2D895DKnyrRkDgcSpw+LNnol9zlJPcU6yDvjWrEV/6nBSPQqzY0AP69v5v2iEQ==",
+      "dev": true,
+      "requires": {
+        "@types/mime": "2.0.0",
+        "@types/node": "7.0.29"
+      }
     },
     "@types/random-js": {
       "version": "1.0.30",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,12 @@
       "integrity": "sha512-+8JrLZny/uR+d/jLK9eaV63buRM7X/gNzQk57q76NS4KNKLSKOmxJYFIlwuP2zDvA7wqZj05POPhSd9Z1hYQpQ==",
       "dev": true
     },
+    "@types/random-js": {
+      "version": "1.0.30",
+      "resolved": "https://registry.npmjs.org/@types/random-js/-/random-js-1.0.30.tgz",
+      "integrity": "sha512-WjnCxSADI8zNFkwwQYzBbYDOMOsX//gzxS7rLvms4E8dEcHPrKzoi4FZXebYLKlTpaWSSqHT3Fp9TkDAiNW5rw==",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3435,11 +3435,6 @@
       "resolved": "https://registry.npmjs.org/mediaserver/-/mediaserver-0.1.0.tgz",
       "integrity": "sha1-qhMCnVyASTgHiT27ZMbMf9xybVI="
     },
-    "memorystream": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI="
-    },
     "merge-stream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,15 @@
       "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==",
       "dev": true
     },
+    "@types/mysql": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-0.0.34.tgz",
+      "integrity": "sha512-IocdMpYtCBSLJqSg0BGgZTbYf3K9iAq81a1sNw6FlgVYh3/2cOXR3LpuQS6o5avWAmNTJqC6u5gS+IRrY56+9Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "7.0.29"
+      }
+    },
     "@types/node": {
       "version": "7.0.29",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.29.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@types/node": "7.0.29",
+    "@types/node-static": "^0.7.0",
     "@types/random-js": "^1.0.30",
     "cssnano": "^3.10.0",
     "gulp-nodemon": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "walk": "^2.3.9"
   },
   "devDependencies": {
+    "@types/mkdirp": "^0.5.1",
     "@types/mysql": "0.0.34",
     "@types/node": "7.0.29",
     "@types/node-static": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "walk": "^2.3.9"
   },
   "devDependencies": {
+    "@types/mysql": "0.0.34",
     "@types/node": "7.0.29",
     "@types/node-static": "^0.7.0",
     "@types/pg": "^7.1.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@types/node": "7.0.29",
+    "@types/random-js": "^1.0.30",
     "cssnano": "^3.10.0",
     "gulp-nodemon": "2.2.1",
     "gulp-postcss": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@types/node": "7.0.29",
     "@types/node-static": "^0.7.0",
+    "@types/pg": "^7.1.4",
     "@types/random-js": "^1.0.30",
     "cssnano": "^3.10.0",
     "gulp-nodemon": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "gulp-shell": "0.6.3",
     "gulp-uglify": "^2.1.2",
     "mediaserver": "0.1.0",
-    "memorystream": "^0.3.1",
     "mkdirp": "^0.5.1",
     "node-static": "^0.7.10",
     "pm2": "^2.4.6",

--- a/server/@types/mediaserver.d.ts
+++ b/server/@types/mediaserver.d.ts
@@ -1,0 +1,6 @@
+
+declare module 'mediaserver' {
+    import { IncomingMessage, ServerResponse } from 'http';
+
+    function pipe(req: IncomingMessage, res: ServerResponse, path: string, type?: string, callback?: (path: string) => void): boolean;
+}

--- a/server/src/lib/aws.ts
+++ b/server/src/lib/aws.ts
@@ -1,7 +1,8 @@
 import { config } from 'aws-sdk';
 
 if (process.env.HTTP_PROXY) {
-  var proxy = require('proxy-agent');
+  // Currently have no TS typings for proxy-agent, so have to use plain require().
+  const proxy = require('proxy-agent');
 
   config.update({
     httpOptions: { agent: proxy(process.env.HTTP_PROXY) },

--- a/server/src/lib/aws.ts
+++ b/server/src/lib/aws.ts
@@ -1,11 +1,9 @@
-var AWS = require('aws-sdk');
+import { config } from 'aws-sdk';
 
 if (process.env.HTTP_PROXY) {
   var proxy = require('proxy-agent');
 
-  AWS.config.update({
+  config.update({
     httpOptions: { agent: proxy(process.env.HTTP_PROXY) },
   });
 }
-
-module.exports = AWS;

--- a/server/src/lib/bucket.ts
+++ b/server/src/lib/bucket.ts
@@ -1,11 +1,12 @@
 import * as path from 'path';
 import * as Random from 'random-js';
+import { S3 } from 'aws-sdk';
 
 import { map } from '../promisify';
 import { getFileExt } from './utility';
+import './aws';
 
 const MemoryStream = require('memorystream');
-const AWS = require('./aws');
 
 const KEYS_PER_REQUEST = 1000; // Max is 1000.
 const LOAD_DELAY = 200;
@@ -30,15 +31,15 @@ interface FileHolder {
 }
 
 export default class Bucket {
-  private s3: any;
+  private s3: S3;
   private files: FileHolder;
   private paths: string[];
   private votes: number;
   private validated: number;
-  private randomEngine: any;
+  private randomEngine: Random.MT19937;
 
   constructor() {
-    this.s3 = new AWS.S3();
+    this.s3 = new S3();
     this.files = {};
     this.votes = 0;
     this.validated = 0;

--- a/server/src/lib/bucket.ts
+++ b/server/src/lib/bucket.ts
@@ -6,8 +6,6 @@ import { map } from '../promisify';
 import { getFileExt } from './utility';
 import './aws';
 
-const MemoryStream = require('memorystream');
-
 const KEYS_PER_REQUEST = 1000; // Max is 1000.
 const LOAD_DELAY = 200;
 const MP3_EXT = '.mp3';

--- a/server/src/lib/bucket.ts
+++ b/server/src/lib/bucket.ts
@@ -1,10 +1,10 @@
 import * as path from 'path';
+import * as Random from 'random-js';
 
 import { map } from '../promisify';
 import { getFileExt } from './utility';
 
 const MemoryStream = require('memorystream');
-const Random = require('random-js');
 const AWS = require('./aws');
 
 const KEYS_PER_REQUEST = 1000; // Max is 1000.

--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -10,7 +10,7 @@ import { getFileExt } from './utility';
 import respond, { CONTENT_TYPES } from './responder';
 import './aws';
 
-const ms = require('mediaserver');
+import * as ms from 'mediaserver';
 const ff = require('ff');
 const mkdirp = require('mkdirp');
 const Transcoder = require('stream-transcoder');

--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -3,15 +3,16 @@ import * as fs from 'fs';
 import * as http from 'http';
 import * as path from 'path';
 import { PassThrough } from 'stream';
+import { S3 } from 'aws-sdk';
 
 import Bucket from './bucket';
 import { getFileExt } from './utility';
 import respond, { CONTENT_TYPES } from './responder';
+import './aws';
 
 const ms = require('mediaserver');
 const ff = require('ff');
 const mkdirp = require('mkdirp');
-const AWS = require('./aws');
 const Transcoder = require('stream-transcoder');
 
 const UPLOAD_PATH = path.resolve(__dirname, '../..', 'upload');
@@ -26,11 +27,11 @@ const BUCKET_NAME = config.BUCKET_NAME || 'common-voice-corpus';
  * Clip - Responsibly for saving and serving clips.
  */
 export default class Clip {
-  private s3: any;
+  private s3: S3;
   private bucket: Bucket;
 
   constructor() {
-    this.s3 = new AWS.S3({ signatureVersion: 'v4' });
+    this.s3 = new S3({ signatureVersion: 'v4' });
     this.bucket = new Bucket();
   }
 

--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -4,15 +4,15 @@ import * as http from 'http';
 import * as path from 'path';
 import { PassThrough } from 'stream';
 import { S3 } from 'aws-sdk';
+import * as ms from 'mediaserver';
+import * as mkdirp from 'mkdirp';
 
 import Bucket from './bucket';
 import { getFileExt } from './utility';
 import respond, { CONTENT_TYPES } from './responder';
 import './aws';
 
-import * as ms from 'mediaserver';
 const ff = require('ff');
-const mkdirp = require('mkdirp');
 const Transcoder = require('stream-transcoder');
 
 const UPLOAD_PATH = path.resolve(__dirname, '../..', 'upload');

--- a/server/src/lib/corpus.ts
+++ b/server/src/lib/corpus.ts
@@ -1,8 +1,7 @@
 import * as path from 'path';
 import { getFilesInFolder, getAllFileContents } from './fs-helper';
 import { getFileExt } from './utility';
-
-const Random = require('random-js');
+import * as Random from 'random-js';
 
 const CWD = process.cwd();
 const SENTENCE_FOLDER = path.resolve(CWD, 'server/data/');

--- a/server/src/lib/db/mysql.ts
+++ b/server/src/lib/db/mysql.ts
@@ -1,6 +1,6 @@
 import { getFirstDefined } from '../utility';
+import { createPool, IPool } from 'mysql';
 
-const mysql = require('mysql');
 const config = require('../../../../config.json');
 
 type MysqlOptions = {
@@ -25,7 +25,7 @@ const DEFAULTS = {
 };
 
 export default class Mysql {
-  pool: any;
+  pool: IPool;
 
   constructor(options?: MysqlOptions) {
     options = options || Object.create(null);
@@ -55,7 +55,7 @@ export default class Mysql {
       ),
     };
 
-    this.pool = mysql.createPool({
+    this.pool = createPool({
       connectionLimit: 100,
       host: myConfig.host,
       user: myConfig.user,
@@ -74,10 +74,6 @@ export default class Mysql {
     this.pool.query(text, (error: any, results: any, fields: any) => {
       error ? callback(error.message, null) : callback(null, results);
     });
-  }
-
-  connect(callback: Function) {
-    return this.pool.connect(callback);
   }
 
   end() {

--- a/server/src/lib/db/postgres.ts
+++ b/server/src/lib/db/postgres.ts
@@ -1,4 +1,4 @@
-const pg = require('pg').native;
+import { native, Client, Pool, QueryResult } from 'pg';
 const config = require('../../../../config.json');
 
 type PostgresOptions = {
@@ -23,7 +23,7 @@ const DEFAULTS = {
 };
 
 export default class Postgres {
-  pool: any;
+  pool: Pool;
 
   constructor(options?: PostgresOptions) {
     options = options || Object.create(null);
@@ -43,7 +43,7 @@ export default class Postgres {
         options.idleTimeoutMillis || DEFAULTS.idleTimeoutMillis,
     };
 
-    this.pool = new pg.Pool(pgConfig);
+    this.pool = new Pool(pgConfig);
     this.pool.on('error', this.handleIdleError.bind(this));
   }
 
@@ -51,11 +51,15 @@ export default class Postgres {
     console.error('idle client error', err.message);
   }
 
-  query(text: string, values: any[], callback: Function) {
+  query(
+    text: string,
+    values: any[],
+    callback: (err: Error, result: QueryResult) => void
+  ) {
     return this.pool.query(text, values, callback);
   }
 
-  connect(callback: Function) {
+  connect(callback: (err: Error, client: Client, done: () => void) => void) {
     return this.pool.connect(callback);
   }
 

--- a/server/src/lib/prometheus.ts
+++ b/server/src/lib/prometheus.ts
@@ -1,33 +1,36 @@
 import * as http from 'http';
+import {
+  collectDefaultMetrics,
+  register,
+  Counter,
+  Registry,
+} from 'prom-client';
 
-var client = require('prom-client');
-
-var collectDefaultMetrics = client.collectDefaultMetrics;
 // Probe every 5th second.
 collectDefaultMetrics({ timeout: 5000 });
 
 export default class Prometheus {
-  register: any;
-  requests: any;
-  clip_cnt: any;
-  api_cnt: any;
-  prometheus_cnt: any;
+  register: Registry;
+  requests: Counter;
+  clip_cnt: Counter;
+  api_cnt: Counter;
+  prometheus_cnt: Counter;
 
   constructor() {
-    this.register = client.register;
-    this.requests = new client.Counter({
+    this.register = register;
+    this.requests = new Counter({
       name: 'voice_requests',
       help: 'Total Requests Served',
     });
-    this.clip_cnt = new client.Counter({
+    this.clip_cnt = new Counter({
       name: 'voice_clips_requests',
       help: 'Total Clip Requests Served',
     });
-    this.api_cnt = new client.Counter({
+    this.api_cnt = new Counter({
       name: 'voice_api_requests',
       help: 'Total API Requests Served',
     });
-    this.prometheus_cnt = new client.Counter({
+    this.prometheus_cnt = new Counter({
       name: 'voice_prometheus_requests',
       help: 'Total Prometheus Requests Served',
     });
@@ -36,7 +39,7 @@ export default class Prometheus {
   /**
    * Is this request directed at the api?
    */
-  isPrometheusRequest(request: http.IncomingMessage) {
+  isPrometheusRequest(request: http.IncomingMessage): boolean {
     return request.url.includes('/metrics');
   }
 

--- a/server/src/lib/utility.ts
+++ b/server/src/lib/utility.ts
@@ -1,8 +1,8 @@
 /**
- * Functions to be shared across mutiple modules.
+ * Functions to be shared across multiple modules.
  */
 
-const child = require('child_process');
+import { exec } from 'child_process';
 
 /**
  * Returns the file extension of some path.
@@ -34,7 +34,7 @@ export function getFirstDefined(...options: any[]) {
  */
 export function isLeaderServer(): Promise<boolean> {
   return new Promise((res: Function, rej: Function) => {
-    child.exec(
+    exec(
       'consul-do common-voice $(hostname) && echo success',
       (err: any, stdout: any, stderr: any) => {
         console.log('checkleader', !err, stdout.length, stderr.length);

--- a/server/src/lib/webhook.ts
+++ b/server/src/lib/webhook.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 import respond from './responder';
 
-const SimpleGit = require('simple-git');
+import * as simpleGit from 'simple-git/promise';
 
 const PROJECT_PATH = path.resolve(__dirname, '../../../');
 
@@ -11,7 +11,7 @@ export default class WebHook {
   git: any;
 
   constructor() {
-    this.git = new SimpleGit(PROJECT_PATH);
+    this.git = simpleGit(PROJECT_PATH);
   }
 
   private concat(request: http.IncomingMessage, callback: Function): void {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import API from './lib/api';
 import Logger from './lib/logger';
 import { isLeaderServer } from './lib/utility';
+import { Server as NodeStaticServer } from 'node-static';
 
 const DEFAULT_PORT = 9000;
 const SLOW_REQUEST_LIMIT = 2000;
@@ -12,7 +13,6 @@ const CLIENT_PATH = '../../web';
 
 const CSP_HEADER = `default-src 'none'; style-src 'self' 'nonce-123456789' 'nonce-987654321'; img-src 'self' www.google-analytics.com; media-src data: blob: https://*.amazonaws.com; script-src 'self' https://www.google-analytics.com/analytics.js; font-src 'self'; connect-src 'self'`;
 
-const nodeStatic = require('node-static');
 const config = require(CONFIG_PATH);
 
 export default class Server {
@@ -22,7 +22,7 @@ export default class Server {
   staticServer: any;
 
   constructor() {
-    this.staticServer = new nodeStatic.Server(
+    this.staticServer = new NodeStaticServer(
       path.join(__dirname, CLIENT_PATH),
       {
         cache: false,


### PR DESCRIPTION
This further improves the server code by installing and using typings for third-party libraries, where available.

Some notes:
* no typings are available (directly or as separate packages) for the following dependencies:
  * `ff`
  * `proxy-agent`
  * `stream-transcoder`
  * `mediaserver`
* I wrote custom typings for the one function used from `mediaserver` (this need a minor adjustment of the gulp script too)
* `memorystream` was unused and therefore removed
* i replaced default/module imports with direct imports of the needed symbols, where possible and appropriate
* the `Postgres` class (in `server/src/lib/db`) seems to be unused. should it be removed?
* `SimpleGit` was previously initialized/instantiated using `new SimpleGit(PROJECT_PATH)`, even though it should be invoked as a function (not a constructor) according to its docs (and typings); i fixed this

As always, I can't fully test the server code, so please do some reasonably thorough testing of existing/needed functionality, @mikehenrty :)