### PR TITLE
Fixed a typo in HOWTO_S3.md: 'catagory' -> 'category'

### DIFF
--- a/docs/HOWTO_S3.md
+++ b/docs/HOWTO_S3.md
@@ -11,7 +11,7 @@ in which to store voice clips.
 #### Create a new S3 bucket:
 
 1. Log into your new Amazon Services account:
-2. Choose "S3" under the "Storage" catagory in the "Services" drop down.
+2. Choose "S3" under the "Storage" category in the "Services" drop down.
 3. Click "Create bucket"
 4. Choose a bucket name. For this example guide we'll choose "voice-web".
 5. Choose a region.

--- a/docs/HOWTO_S3.md
+++ b/docs/HOWTO_S3.md
@@ -47,4 +47,4 @@ in which to store voice clips.
 
 1. Create a file in your repository folder called `config.json`
 2. Add a key `BUCKET_NAME`, and enter a value of the bucket we chose earlier "voice-web"
-3. Add a key `BUCKET_LOATION` with Region corresponding to your region name listed here: http://docs.aws.amazon.com/general/latest/gr/rande.html
+3. Add a key `BUCKET_LOCATION` with Region corresponding to your region name listed here: http://docs.aws.amazon.com/general/latest/gr/rande.html


### PR DESCRIPTION
quick fix for a type on HOWTO_S3.md. 

====
Create a new S3 bucket:

    Log into your new Amazon Services account:
    Choose "S3" under the "Storage" catagory in the "Services" drop down.

====

The word "catagory" was changed to "category".

Also fixed the key BUCKET_LOATION (last step in the document) to BUCKET_LOCATION.

Fix #560 