### PR TITLE
Replace getElementById or queryselectors inside preact components by refs during rendering

### DIFF
--- a/web/src/lib/components/pages.tsx
+++ b/web/src/lib/components/pages.tsx
@@ -79,6 +79,7 @@ export default class Pages extends Component<PagesProps, PagesState> {
   private scroller: HTMLElement;
   private content: HTMLElement;
   private bg: HTMLElement;
+  private installApp: HTMLElement;
   private iOSBackground: any[];
 
   state: PagesState = {
@@ -138,7 +139,7 @@ export default class Pages extends Component<PagesProps, PagesState> {
   private closeOpenInApp(evt: Event) {
     evt.stopPropagation();
     evt.preventDefault();
-    document.getElementById('install-app').classList.add('hide');
+    this.installApp.classList.add('hide');
   }
 
   private getCurrentPageName() {
@@ -286,10 +287,6 @@ export default class Pages extends Component<PagesProps, PagesState> {
   }
 
   componentDidMount() {
-    this.scroller = document.getElementById('scroller');
-    this.content = document.getElementById('content');
-    this.header = document.querySelector('header');
-    this.bg = document.getElementById('background-container');
     this.addScrollListener();
     this.setState({
       currentPage: this.props.currentPage,
@@ -355,7 +352,12 @@ export default class Pages extends Component<PagesProps, PagesState> {
           !isSafari() && (
             // This is a banner for non-Safari browsers on iOS.
             // In iOS Safari, we display a 'Smart App Banner' instead.
-            <div onClick={this.openInApp} id="install-app">
+            <div
+              id="install-app"
+              onClick={this.openInApp}
+              ref={div => {
+                this.installApp = div as HTMLElement;
+              }}>
               Open in App
               <a onClick={this.closeOpenInApp}>X</a>
             </div>
@@ -363,7 +365,10 @@ export default class Pages extends Component<PagesProps, PagesState> {
         <header
           className={
             this.state.isMenuVisible || this.state.scrolled ? 'active' : ''
-          }>
+          }
+          ref={header => {
+            this.header = header as HTMLElement;
+          }}>
           <Logo navigate={this.props.navigate} />
           {this.renderUser()}
           <button
@@ -374,9 +379,18 @@ export default class Pages extends Component<PagesProps, PagesState> {
           </button>
           {this.renderNav('main-nav', true)}
         </header>
-        <div id="scroller">
+        <div
+          id="scroller"
+          ref={div => {
+            this.scroller = div as HTMLElement;
+          }}>
           <div id="scrollee">
-            <div id="background-container" style={bgStyle}>
+            <div
+              id="background-container"
+              style={bgStyle}
+              ref={div => {
+                this.bg = div as HTMLElement;
+              }}>
               {this.iOSBackground}
             </div>
             <div class="hero">
@@ -393,7 +407,10 @@ export default class Pages extends Component<PagesProps, PagesState> {
             <div class="hero-space" />
             <div
               id="content"
-              className={this.state.pageTransitioning ? 'transitioning' : ''}>
+              className={this.state.pageTransitioning ? 'transitioning' : ''}
+              ref={div => {
+                this.content = div as HTMLElement;
+              }}>
               <Home
                 active={this.isPageActive([URLS.HOME, URLS.ROOT])}
                 navigate={this.props.navigate}

--- a/web/src/lib/components/pages/profile/profile.tsx
+++ b/web/src/lib/components/pages/profile/profile.tsx
@@ -14,6 +14,11 @@ interface State {
 }
 
 export default class Profile extends Component<Props, State> {
+  private email: HTMLInputElement;
+  private profileAccent: HTMLSelectElement;
+  private profileAge: HTMLSelectElement;
+  private profileGender: HTMLSelectElement;
+
   constructor(props: Props) {
     super(props);
 
@@ -32,8 +37,7 @@ export default class Profile extends Component<Props, State> {
   }
 
   private saveEmail() {
-    let el = document.getElementById('email') as HTMLInputElement;
-    let email = el.value;
+    let email = this.email.value;
     this.props.user.setEmail(email);
 
     this.setState({
@@ -49,16 +53,16 @@ export default class Profile extends Component<Props, State> {
   }
 
   private saveDemographics() {
-    let el = document.getElementById('profile-accent') as HTMLSelectElement;
-    let accent = el.options[el.selectedIndex].value;
+    let selectedIndex = this.profileAccent.selectedIndex;
+    let accent = this.profileAccent.options[selectedIndex].value;
     this.props.user.setAccent(accent);
 
-    el = document.getElementById('profile-age') as HTMLSelectElement;
-    let age = el.options[el.selectedIndex].value;
+    selectedIndex = this.profileAge.selectedIndex;
+    let age = this.profileAge.options[selectedIndex].value;
     this.props.user.setAge(age);
 
-    el = document.getElementById('profile-gender') as HTMLSelectElement;
-    let gender = el.options[el.selectedIndex].value;
+    selectedIndex = this.profileGender.selectedIndex;
+    let gender = this.profileGender.options[selectedIndex].value;
     this.props.user.setGender(gender);
 
     this.setState({
@@ -73,14 +77,15 @@ export default class Profile extends Component<Props, State> {
   private update() {
     let user = this.props.user.getState();
 
-    let el = document.getElementById('email') as HTMLInputElement;
-    let email = el.value;
-    let select = document.getElementById('profile-accent') as HTMLSelectElement;
-    let accent = select.options[select.selectedIndex].value;
-    select = document.getElementById('profile-age') as HTMLSelectElement;
-    let age = select.options[select.selectedIndex].value;
-    select = document.getElementById('profile-gender') as HTMLSelectElement;
-    let gender = select.options[select.selectedIndex].value;
+    let email = this.email.value;
+    let selectedIndex = this.profileAccent.selectedIndex;
+    let accent = this.profileAccent.options[selectedIndex].value;
+
+    selectedIndex = this.profileAge.selectedIndex;
+    let age = this.profileAge.options[selectedIndex].value;
+
+    selectedIndex = this.profileGender.selectedIndex;
+    let gender = this.profileGender.options[selectedIndex].value;
 
     this.setState({
       email: email,
@@ -134,11 +139,13 @@ export default class Profile extends Component<Props, State> {
           <input
             onKeyUp={this.update}
             className={emailModified ? 'unsaved' : ''}
-            id="email"
             type="email"
             name="email"
             tabIndex={1}
             value={this.state.email}
+            ref={input => {
+              this.email = input as HTMLInputElement;
+            }}
           />
           <button
             onClick={this.saveEmail}
@@ -167,7 +174,10 @@ export default class Profile extends Component<Props, State> {
           onChange={this.update}
           id="profile-accent"
           tabIndex={4}
-          className={accentModified ? 'unsaved' : ''}>
+          className={accentModified ? 'unsaved' : ''}
+          ref={select => {
+            this.profileAccent = select as HTMLSelectElement;
+          }}>
           {accentOptions}
         </select>
         <label for="profile-age">Your age</label>
@@ -175,7 +185,10 @@ export default class Profile extends Component<Props, State> {
           onChange={this.update}
           id="profile-age"
           tabIndex={5}
-          className={ageModified ? 'unsaved' : ''}>
+          className={ageModified ? 'unsaved' : ''}
+          ref={select => {
+            this.profileAge = select as HTMLSelectElement;
+          }}>
           {ageOptions}
         </select>
         <label for="profile-gender">Your gender</label>
@@ -183,7 +196,10 @@ export default class Profile extends Component<Props, State> {
           onChange={this.update}
           id="profile-gender"
           tabIndex={6}
-          className={genderModified ? 'unsaved' : ''}>
+          className={genderModified ? 'unsaved' : ''}
+          ref={select => {
+            this.profileGender = select as HTMLSelectElement;
+          }}>
           {genderOptions}
         </select>
         <button


### PR DESCRIPTION
References to document.getElementById and document.queryselector inside components were replaced by attributes that are set when rendering the components by using refs.

Only preact components were reviewed. The HTML files containing pure HTML elements not rendered by a preact component were not modified (i.e. voice-web/ios/voicebank-ios-wrapper/index-cv.html)

resolves #541 