### PR TITLE
Improve page loading UX by letting content fade in over spinner

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -17,6 +17,8 @@
     <link rel="stylesheet" href="/dist/index.css">
   </head>
   <body>
+    <div id="spinner"></div>
+    <div id="main"></div>
     <script src="/dist/bundle.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This improve page load UX by keeping the spinner in the DOM until them `#main` content is considered ready (images are pre-loaded or timeout occurred) and the fade-in transition is done.

It also replaces two `setTimeout` calls used for this with usage of our own Promise-based `sleep(ms)` utility function, improving code readability.

Short preview video: <a href="https://www.dropbox.com/s/bdq5h9zkfkr6arh/load-spinner.mov" target="_blank">on Dropbox</a>
