### PR TITLE
Remove unused `Clip` type and improve naming related to ClipJson

### DIFF
--- a/server/src/lib/bucket.ts
+++ b/server/src/lib/bucket.ts
@@ -185,21 +185,17 @@ export default class Bucket {
   async getRandomClipJson(uid: string): Promise<string> {
     const clip = this.model.getEllibleClip(uid);
     if (!clip) {
-      return Promise.reject('No globs from me');
+      throw new Error('Could not find any eligible clips for this user');
     }
 
     // On the client, the clipid is called 'glob'
-    let glob = clip.clipid;
+    const glob = clip.clipid;
 
-    let clipJson = {
+    const clipJson = {
       glob: glob,
       text: clip.sentenceText,
       sound: this.getPublicUrl(clip.clipPath),
     };
-
-    if (clipJson.text) {
-      return Promise.resolve(JSON.stringify(clipJson));
-    }
 
     if (!clipJson.text) {
       clipJson.text = await this.fetchSentenceFromS3(glob);

--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -149,7 +149,7 @@ export default class Clip {
         this.saveClip(request, response);
       }
     } else if (this.isRandomClipJsonRequest(request)) {
-      this.serveRandomClipJson(request, response);
+      this.serveRandomClip(request, response);
     } else {
       this.serve(request, response);
     }
@@ -354,7 +354,7 @@ export default class Clip {
     });
   }
 
-  async serveRandomClipJson(
+  async serveRandomClip(
     request: http.IncomingMessage,
     response: http.ServerResponse
   ): Promise<void> {
@@ -368,7 +368,7 @@ export default class Clip {
       const clipJson = await this.bucket.getRandomClipJson(uid);
       respond(response, clipJson, 200, CONTENT_TYPES.JSON);
     } catch (err) {
-      console.error('could not get random clip', err);
+      console.error('could not get random clip:', (err as Error).message);
       respond(response, 'Still loading', 500);
     }
   }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,7 +1,7 @@
 import User from './user';
 import AudioIOS from './components/pages/record/audio-ios';
 
-export interface ClipJson {
+export interface Clip {
   glob: string;
   text: string;
   sound: string;
@@ -82,16 +82,15 @@ export default class API {
   }
 
   /**
-   * Ask the server for a clip
+   * Ask the server for a random clip.
    */
-  async getRandomClipJson(): Promise<ClipJson> {
+  async getRandomClip(): Promise<Clip> {
     const req = await this.fetch('upload/random.json', {
       responseType: 'json',
       headers: { uid: this.user.getId() },
     });
 
-    let response = req.response as ClipJson;
-    return response;
+    return req.response;
   }
 
   castVote(glob: string, vote: boolean): Promise<Event> {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,12 +1,6 @@
 import User from './user';
 import AudioIOS from './components/pages/record/audio-ios';
 
-export interface Clip {
-  glob: string;
-  audio: string;
-  sentence: string;
-}
-
 export interface ClipJson {
   glob: string;
   text: string;

--- a/web/src/lib/components/pages/listen.tsx
+++ b/web/src/lib/components/pages/listen.tsx
@@ -1,5 +1,5 @@
 import { h, Component } from 'preact';
-import { Clip, default as API } from '../../api';
+import API from '../../api';
 import Validator from '../validator';
 import User from '../../user';
 

--- a/web/src/lib/components/validator.tsx
+++ b/web/src/lib/components/validator.tsx
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 import ListenBox from './listen-box/listen-box';
-import { ClipJson, default as API } from '../api';
+import API from '../api';
 
 const LOADING_MESSAGE = 'Loading...';
 const LOAD_ERROR_MESSAGE =
@@ -42,12 +42,12 @@ export default class Validator extends Component<Props, State> {
   private async loadClip() {
     this.setState({ loading: true });
     try {
-      const clipJson = await this.props.api.getRandomClipJson();
+      const clip = await this.props.api.getRandomClip();
       this.setState({
         loading: false,
-        glob: clipJson.glob,
-        sentence: decodeURIComponent(clipJson.text),
-        audioSrc: clipJson.sound,
+        glob: clip.glob,
+        sentence: decodeURIComponent(clip.text),
+        audioSrc: clip.sound,
       });
     } catch (err) {
       console.error('could not fetch random clip for validator', err);


### PR DESCRIPTION
Minor cleanup:
* remove unused `Clip` type from web code
* rename some things called "ClipJson" to just "Clip" to reflect they're not actually passing around JSON anymore
* other minor cleanup of the modified code passages