### PR TITLE
Fix #562: Modify apache config to compress js, css, and svg files.

### DIFF
--- a/nubis/puppet/web.pp
+++ b/nubis/puppet/web.pp
@@ -33,7 +33,13 @@ apache::vhost { $project_name:
     AddOutputFilterByType DEFLATE application/x-font-ttf
 
     # Deflate JavaScript
-    AddOutputFilterByType DEFLATE text/javascript
+    AddOutputFilterByType DEFLATE text/javascript application/javascript
+
+    # Deflate CSS
+    AddOutputFilterByType DEFLATE text/css
+
+    # Deflate SVG images
+    AddOutputFilterByType DEFLATE image/svg+xml
 
     # Sane expires defaults
     ExpiresActive On


### PR DESCRIPTION
Add settings to Apache's configuration file to compress js, css, and svg files. This fixes #562.

It looks like your site serves javascript with the "application/javascript" content type, but I left the "text/javascript" content type in there just to be on the safe side.