### PR TITLE
Output all static files to one folder, and serve them from there

### DIFF
--- a/nubis/puppet/web.pp
+++ b/nubis/puppet/web.pp
@@ -12,7 +12,7 @@ class { 'apache::mod::proxy_http': }
 apache::vhost { $project_name:
     port               => 80,
     default_vhost      => true,
-    docroot            => "/var/www/${project_name}/web",
+    docroot            => "/var/www/${project_name}/web/dist",
     docroot_owner      => 'root',
     docroot_group      => 'root',
     block              => ['scm'],
@@ -26,7 +26,7 @@ apache::vhost { $project_name:
 
     directories        => [
       {
-        path            => "/var/www/${project_name}/web",
+        path            => "/var/www/${project_name}/web/dist",
         custom_fragment => "
     # Handle and compress font files
     AddType application/x-font-ttf        .ttf

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -9,7 +9,7 @@ import { Server as NodeStaticServer } from 'node-static';
 import { CommonVoiceConfig, getConfig } from './config-helper';
 
 const SLOW_REQUEST_LIMIT = 2000;
-const CLIENT_PATH = '../../web';
+const CLIENT_PATH = '../../web/dist';
 
 const CSP_HEADER = `default-src 'none'; style-src 'self' 'nonce-123456789' 'nonce-987654321' https://fonts.googleapis.com; img-src 'self' www.google-analytics.com; media-src data: blob: https://*.amazonaws.com https://*.amazon.com; script-src 'self' https://www.google-analytics.com/analytics.js; font-src 'self' https://fonts.gstatic.com; connect-src 'self'`;
 

--- a/web/index.html
+++ b/web/index.html
@@ -14,11 +14,11 @@
     <meta name="twitter:creator" content="@mikehenrty" />
     <meta name="apple-itunes-app" content="app-id=1240588326">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
-    <link rel="stylesheet" href="/dist/index.css">
+    <link rel="stylesheet" href="/index.css">
   </head>
   <body>
     <div id="spinner"></div>
     <div id="main"></div>
-    <script src="/dist/bundle.js"></script>
+    <script src="/bundle.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This should fix #371.

With this, the build outputs all static assets needed for the frontend into the `/web/dist` folder.
The backend is also adjusted to serve the static files from this folder instead.

I also adjusted the puppet file that seemed to be the appropriate place.

The local server backend / dev environment seems to work fine with this change, but I can't test whether the puppet file correctly sets up the apache. So I hope you can check (and, if necessary, fix) that for me, @mikehenrty and @Gregoor.

Edit: I think this shouldn't interfere with #580.

Maybe @gozer can also take a look at this.