### PR TITLE
Fix whitespace issue on record page

### DIFF
--- a/web/src/lib/components/listen-box/listen-box.tsx
+++ b/web/src/lib/components/listen-box/listen-box.tsx
@@ -40,7 +40,7 @@ export default class ListenBox extends Component<Props, State> {
   }
 
   state: State = {
-    loaded: false,
+    loaded: true,
     playing: false,
     played: false,
     audio: null,
@@ -173,6 +173,7 @@ export default class ListenBox extends Component<Props, State> {
           {...this.props.src && { src: this.props.src }}
           preload="auto"
           onLoadStart={this.onLoadStart}
+          onLoadedData={this.onCanPlayThrough}
           onCanPlayThrough={this.onCanPlayThrough}
           onDurationChange={this.onCanPlayThrough}
           onEnded={this.onPlayEnded}

--- a/web/src/lib/components/pages/record/profile-actions.css
+++ b/web/src/lib/components/pages/record/profile-actions.css
@@ -1,7 +1,5 @@
 #profile-actions {
     margin: 2rem auto;
-    /* Disable editing profile from the recording flow for now */
-    visibility: hidden;
 }
 
 #create-profile-button {

--- a/web/src/lib/components/pages/record/record.css
+++ b/web/src/lib/components/pages/record/record.css
@@ -150,12 +150,6 @@
     cursor: pointer;
 }
 
-.full #undo-clip,
-#undo-clip.hide {
-    transform: translateX(-10rem);
-    opacity: 0;
-}
-
 #record-help {
     font-size: 1rem;
     padding: 0 2rem;
@@ -169,20 +163,5 @@
 @media (min-width: 600px) {
     #voice-record {
         padding: 0 0.25rem;
-    }
-}
-
-.full #voice-record {
-    visibility: hidden;
-}
-
-.full #voice-submit {
-    opacity: 1;
-    transform: translateY(-27.5rem);
-}
-
-@media (max-width: 600px) {
-    .full #voice-submit {
-        transform: translateY(-22.5rem);
     }
 }

--- a/web/src/lib/components/pages/record/record.tsx
+++ b/web/src/lib/components/pages/record/record.tsx
@@ -392,7 +392,6 @@ export default class RecordPage extends Component<RecordProps, RecordState> {
     }
 
     // During uploading, we display the submit page for progress.
-    let isFull = this.isFull() || this.state.uploading;
     let texts = []; // sentence elements
     let listens = []; // listen boxes
 
@@ -424,7 +423,6 @@ export default class RecordPage extends Component<RecordProps, RecordState> {
     }
 
     let showBack = this.state.recordings.length !== 0 && !this.state.isReRecord;
-    let className = this.props.active + (isFull ? ' full' : '');
     let progress = this.state.uploadProgress;
     if (this.state.uploading) {
       // Look ahead in the progress bar when uploading.
@@ -444,36 +442,43 @@ export default class RecordPage extends Component<RecordProps, RecordState> {
         ]
       : ERR_SENTENCES_NOT_LOADED;
 
+    const recordingsCount = this.state.recordings.length;
     return (
-      <div id="record-container" className={className}>
-        <div id="voice-record">
-          <div className="record-sentence">
-            {texts}
-            <Icon
-              id="undo-clip"
-              type="undo"
-              onClick={this.goBack}
-              className={!showBack ? 'hide' : ''}
+      <div id="record-container" className={this.props.active}>
+        {!this.isFull() && !this.state.uploading ? (
+          <div id="voice-record">
+            <div className="record-sentence">
+              {texts}
+              {recordingsCount > 0 &&
+                !this.state.isReRecord && (
+                  <Icon
+                    id="undo-clip"
+                    type="undo"
+                    onClick={this.goBack}
+                    className={!showBack ? 'hide' : ''}
+                  />
+                )}
+            </div>
+            <div class="record-controls">{controlElements}</div>
+            <p id="recordings-count">
+              <span style={this.state.isReRecord ? 'display: none;' : ''}>
+                {recordingsCount + 1} of 3
+              </span>
+            </p>
+            <ProfileActions
+              user={this.props.user}
+              navigate={this.props.navigate}
             />
           </div>
-          <div class="record-controls">{controlElements}</div>
-          <p id="recordings-count">
-            <span style={this.state.isReRecord ? 'display: none;' : ''}>
-              {this.state.recordings.length + 1} of 3
-            </span>
-          </p>
-          <ProfileActions
+        ) : (
+          <Review
+            progress={progress}
             user={this.props.user}
             navigate={this.props.navigate}
-          />
-        </div>
-        <Review
-          progress={progress}
-          user={this.props.user}
-          navigate={this.props.navigate}
-          onSubmit={this.onSubmit}>
-          {listens}
-        </Review>
+            onSubmit={this.onSubmit}>
+            {listens}
+          </Review>
+        )}
       </div>
     );
   }

--- a/web/src/lib/components/pages/record/review.css
+++ b/web/src/lib/components/pages/record/review.css
@@ -1,6 +1,15 @@
+@keyframes slidein {
+    from {
+        transform: translateY(50rem);
+    }
+    to {
+        transform: translateY(0);
+    }
+}
+
 #voice-submit {
-    opacity: 0;
     transition: all 0.2s var(--bounce-curve);
+    animation: slidein .2s;
 }
 
 #voice-submit-review {


### PR DESCRIPTION
Switched to conditionally rendering either recordings view or the review submissions view. This should fix the whitespace issues. Also we need less arbitrary offsetting of the submissions view like before.

But a problem that came up is the audio element inside of `ListenBox` not triggering `onCanPlayThrough` after re-recording. I "fixed" this, by setting `loaded` to `true` by default (it gets set to `false` when loading starts, so we should be good?!). Maybe you have an idea about that @mikehenrty?