### PR TITLE
Server Side Rendering (SSR)

### DIFF
--- a/server/src/render-web/index.html
+++ b/server/src/render-web/index.html
@@ -30,7 +30,7 @@
       }</script>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root"><!-- APP_HERE --></div>
     <script src="/dist/bundle.js"></script>
   </body>
 </html>

--- a/server/src/render-web/render-web.tsx
+++ b/server/src/render-web/render-web.tsx
@@ -1,0 +1,42 @@
+import * as fs from 'fs';
+import * as http from 'http';
+import * as path from 'path';
+import * as React from 'react';
+import { renderToNodeStream } from 'react-dom/server';
+import { StaticRouter } from 'react-router';
+
+import App from '../../../web/src/components/app';
+
+const [startHTML, endHTML] = fs
+  .readFileSync(
+    path.join(
+      __dirname,
+      '..',
+      '..',
+      'server',
+      'src',
+      'render-web',
+      'index.html'
+    ),
+    'utf-8'
+  )
+  .split('<!-- APP_HERE -->');
+
+export default function renderWeb(
+  request: http.IncomingMessage,
+  response: http.ServerResponse
+) {
+  response.write(startHTML, 'utf-8');
+
+  const reactNodeStream = renderToNodeStream(
+    <StaticRouter context={{}} location={request.url}>
+      <App />
+    </StaticRouter>
+  );
+
+  reactNodeStream.pipe(response, { end: false });
+
+  reactNodeStream.on('end', () => {
+    response.end(endHTML, 'utf-8');
+  });
+}

--- a/server/src/render-web/render-web.tsx
+++ b/server/src/render-web/render-web.tsx
@@ -28,6 +28,9 @@ export default function renderWeb(
 ) {
   response.write(startHTML, 'utf-8');
 
+  const { NODE_ENV } = process.env;
+
+  process.env.NODE_ENV = 'production';
   const reactNodeStream = renderToNodeStream(
     <StaticRouter context={{}} location={request.url}>
       <App />
@@ -38,5 +41,6 @@ export default function renderWeb(
 
   reactNodeStream.on('end', () => {
     response.end(endHTML, 'utf-8');
+    process.env.NODE_ENV = NODE_ENV;
   });
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7,6 +7,7 @@ import Logger from './lib/logger';
 import { isLeaderServer, getElapsedSeconds } from './lib/utility';
 import { Server as NodeStaticServer } from 'node-static';
 import { CommonVoiceConfig, getConfig } from './config-helper';
+import renderWeb from './render-web/render-web';
 
 const SLOW_REQUEST_LIMIT = 2000;
 const CLIENT_PATH = '../web';
@@ -79,17 +80,9 @@ export default class Server {
       .addListener('end', () => {
         this.staticServer.serve(request, response, (err: any) => {
           if (err && err.status === 404) {
-            this.print('non-static resource request', request.url);
-
             // If file was not front, use main page and
             // let the front end handle url routing.
-            this.staticServer.serveFile(
-              'index.html',
-              200,
-              {},
-              request,
-              response
-            );
+            renderWeb(request, response);
             return;
           }
 

--- a/web/src/components/app.tsx
+++ b/web/src/components/app.tsx
@@ -1,47 +1,11 @@
 import * as React from 'react';
 import { Provider } from 'react-redux';
 import Pages from './pages';
-import { isMobileWebkit, isFocus, isNativeIOS, sleep } from '../utility';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { isMobileWebkit, isFocus, isNativeIOS } from '../utility';
 import store from '../stores/root';
 
-const LOAD_TIMEOUT = 5000; // we can only wait so long.
-
-/**
- * Preload these images before revealing contents.
- * TODO: right now we load all images, which is unnecessary.
- */
-const PRELOAD = [
-  '/img/cv-logo-bw.svg',
-  '/img/cv-logo-one-color-white.svg',
-  '/img/robot-greetings.png',
-  '/img/robot-listening.png',
-  '/img/robot-thanks.png',
-  '/img/robot-thinking.png',
-  '/img/robot-thumbs-up.png',
-  '/img/speech-bubble.png',
-  '/img/wave-blue-large.png',
-  '/img/wave-blue-mobile.png',
-  '/img/wave-red-large.png',
-  '/img/wave-red-mobile.png',
-];
-
-interface State {
-  loaded: boolean;
-}
-
-export default class App extends React.Component<{}, State> {
-  main: HTMLElement;
-  progressMeter: HTMLSpanElement;
-
-  state = { loaded: false };
-
-  /**
-   * App will handle routing to page controllers.
-   */
-  constructor() {
-    super();
-
+export default class App extends React.Component<{}, {}> {
+  componentDidMount() {
     if (isNativeIOS()) {
       this.bootstrapIOS();
     }
@@ -56,74 +20,17 @@ export default class App extends React.Component<{}, State> {
   }
 
   /**
-   * Pre-Load all images before first content render.
-   */
-  private preloadImages(
-    progressCallback?: (percentLoaded: number) => void
-  ): Promise<void> {
-    return new Promise<void>(resolve => {
-      let loadedSoFar = 0;
-      const onLoad = () => {
-        ++loadedSoFar;
-        if (loadedSoFar === PRELOAD.length) {
-          resolve();
-          return;
-        }
-
-        if (progressCallback) {
-          progressCallback(loadedSoFar / PRELOAD.length);
-        }
-      };
-      PRELOAD.forEach(imageUrl => {
-        const image = new Image();
-        image.addEventListener('load', onLoad);
-        image.src = imageUrl;
-      });
-    });
-  }
-
-  /**
    * Perform any native iOS specific operations.
    */
   private bootstrapIOS() {
     document.body.classList.add('ios');
   }
 
-  async componentDidMount() {
-    await Promise.race([
-      sleep(LOAD_TIMEOUT),
-      this.preloadImages((progress: number) => {
-        if (this.progressMeter) {
-          // TODO: find something performant here. (ie not this)
-          // let whatsLeft = 1 - progress;
-          // this.progressMeter.style.cssText =
-          //   `transform: scale(${whatsLeft});`;
-        }
-      }),
-    ]);
-
-    this.setState({ loaded: true });
-  }
-
   render() {
-    return this.state.loaded ? (
-      <Router>
-        <Provider store={store}>
-          <Pages match={null} location={null} history={null} />
-        </Provider>
-      </Router>
-    ) : (
-      <div id="spinner">
-        <span
-          ref={el => {
-            if (this.progressMeter) {
-              return;
-            }
-
-            this.progressMeter = el as HTMLSpanElement;
-          }}
-        />
-      </div>
+    return (
+      <Provider store={store}>
+        <Pages match={null} location={null} history={null} />
+      </Provider>
     );
   }
 }

--- a/web/src/components/index.css
+++ b/web/src/components/index.css
@@ -155,20 +155,10 @@ button.dark:active {
   transition: transform 1s var(--easing);
 }
 
-@keyframes fadein {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
 #main {
   position: relative;
   box-sizing: border-box;
   background-color: var(--base-background-color);
-  animation: fadein 0.5s linear;
 }
 
 @import url('nav.css');
@@ -618,39 +608,6 @@ body:not(.ios) .recording #background-container {
 #faq-container a,
 #terms-container a {
   color: blue;
-}
-
-#spinner {
-  position: fixed;
-  left: 0;
-  right: 0;
-  top: 0;
-  bottom: 0;
-  margin: auto;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-sizing: border-box;
-}
-
-#spinner span {
-  border-radius: 50%;
-  display: inline-block;
-  position: absolute;
-  height: var(--spinner-height);
-  width: var(--spinner-height);
-  top: 0; bottom: 0;
-  left: 0; right: 0;
-  margin: auto;
-  animation: spin 4s linear infinite;
-  background-color: black;
-  opacity: 1;
-  transition: opacity 0.1s linear;
-}
-
-@keyframes spin {
-  50%{ border-radius: 0; }
-  100%{ transform: rotate(-360deg); }
 }
 
 .focus #donate {

--- a/web/src/components/pages.tsx
+++ b/web/src/components/pages.tsx
@@ -29,8 +29,6 @@ import Privacy from './pages/privacy';
 import Terms from './pages/terms';
 import NotFound from './pages/not-found';
 
-const showDatasetsPage = localStorage.getItem('showDatasetsPage');
-
 const shareURL = 'https://voice.mozilla.org/';
 const encodedShareText = encodeURIComponent(
   'Help robots talk, donate your voice at ' + shareURL
@@ -413,11 +411,9 @@ class Pages extends React.Component<PagesProps, PagesState> {
         <NavLink to={URLS.RECORD} exact>
           Speak
         </NavLink>
-        {showDatasetsPage && (
-          <NavLink to={URLS.DATA} exact>
-            Datasets
-          </NavLink>
-        )}
+        <NavLink to={URLS.DATA} exact>
+          Datasets
+        </NavLink>
         <NavLink to={URLS.PROFILE} exact>
           Profile
         </NavLink>

--- a/web/src/components/pages/home/home.css
+++ b/web/src/components/pages/home/home.css
@@ -38,7 +38,6 @@
 #home-title {
     position: absolute;
     top: 0;
-    animation: fade-in .5s;
 }
 
 #contribute-button {

--- a/web/src/components/pages/record/audio-web.ts
+++ b/web/src/components/pages/record/audio-web.ts
@@ -1,5 +1,5 @@
 import ERROR_MSG from '../../../error-msg';
-import { isNativeIOS } from '../../../utility';
+import { isBrowser, isNativeIOS } from '../../../utility';
 
 const AUDIO_TYPE = 'audio/ogg; codecs=opus';
 
@@ -68,10 +68,11 @@ export default class AudioWeb {
   // Check all the browser prefixes for microhpone support.
   isMicrophoneSupported() {
     return (
-      (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) ||
-      navigator.getUserMedia ||
-      navigator.webkitGetUserMedia ||
-      navigator.mozGetUserMedia
+      isBrowser &&
+      ((navigator.mediaDevices && navigator.mediaDevices.getUserMedia) ||
+        navigator.getUserMedia ||
+        navigator.webkitGetUserMedia ||
+        navigator.mozGetUserMedia)
     );
   }
 

--- a/web/src/components/pages/record/record.tsx
+++ b/web/src/components/pages/record/record.tsx
@@ -69,6 +69,7 @@ interface RecordProps extends PropsFromState, PropsFromDispatch {
 }
 
 interface RecordState {
+  isUnsupportedPlatform?: boolean;
   recordingStartTime: number;
   recordingStopTime: number;
   isReRecord: boolean;
@@ -105,16 +106,16 @@ class RecordPage extends React.Component<RecordProps, RecordState> {
     this.audio = isNativeIOS() ? new AudioIOS() : new AudioWeb();
     this.audio.setVolumeCallback(this.updateVolume.bind(this));
 
-    if (
-      !this.audio.isMicrophoneSupported() ||
-      !this.audio.isAudioRecordingSupported() ||
-      isFocus()
-    ) {
-      this.isUnsupportedPlatform = true;
-      return;
-    }
-
     this.maxVolume = 0;
+  }
+
+  componentDidMount() {
+    this.setState({
+      isUnsupportedPlatform:
+        !this.audio.isMicrophoneSupported() ||
+        !this.audio.isAudioRecordingSupported() ||
+        isFocus(),
+    });
   }
 
   private processRecording = (info: AudioInfo) => {
@@ -273,11 +274,27 @@ class RecordPage extends React.Component<RecordProps, RecordState> {
   };
 
   render() {
-    if (this.isUnsupportedPlatform) {
+    const {
+      areSentencesLoaded,
+      isSetFull,
+      recordingsCount,
+      sentenceRecordings,
+    } = this.props;
+    const {
+      isUnsupportedPlatform,
+      isReRecord,
+      recordingError,
+      reRecordSentence,
+      showRetryModal,
+      showSubmitSuccess,
+    } = this.state;
+
+    if (isUnsupportedPlatform === undefined) return <div />;
+    if (isUnsupportedPlatform) {
       return <UnsupportedInfo />;
     }
 
-    if (this.props.isSetFull) {
+    if (isSetFull) {
       return (
         <div id="record-container">
           <Review
@@ -290,18 +307,6 @@ class RecordPage extends React.Component<RecordProps, RecordState> {
       );
     }
 
-    const {
-      areSentencesLoaded,
-      recordingsCount,
-      sentenceRecordings,
-    } = this.props;
-    const {
-      isReRecord,
-      recordingError,
-      reRecordSentence,
-      showRetryModal,
-      showSubmitSuccess,
-    } = this.state;
     const recordIndex = isReRecord
       ? Object.keys(sentenceRecordings).indexOf(reRecordSentence)
       : recordingsCount;

--- a/web/src/components/profile-form/profile-form.tsx
+++ b/web/src/components/profile-form/profile-form.tsx
@@ -7,12 +7,12 @@ import Modal from '../modal/modal';
 import { LabeledInput, LabeledSelect } from '../ui/ui';
 
 interface EditableUser {
-  email: string;
-  username: string;
-  accent: string;
-  age: string;
-  gender: string;
-  sendEmails: boolean;
+  email?: string;
+  username?: string;
+  accent?: string;
+  age?: string;
+  gender?: string;
+  sendEmails?: boolean;
 }
 
 const userFormFields = [
@@ -47,6 +47,14 @@ interface State extends EditableUser {
 
 class ProfileForm extends React.Component<Props, State> {
   state = { ...filterUserFields(this.props.user), showClearModal: false };
+
+  private isFormInitialized = false;
+  componentWillReceiveProps(nextProps: Props) {
+    if (!this.isFormInitialized) {
+      this.isFormInitialized = true;
+      this.setState({ ...filterUserFields(nextProps.user) });
+    }
+  }
 
   private toggleClearModal = () => {
     this.setState(state => ({ showClearModal: !state.showClearModal }));

--- a/web/src/components/vars.css
+++ b/web/src/components/vars.css
@@ -20,7 +20,6 @@
     --hero-height-mobile: 12.5rem;
     --robot-height: 22rem;
     --robot-height-mobile: 16rem;
-    --spinner-height: 10rem;
     --easing: cubic-bezier(0.4, 0.0, 0.2, 1);
     --shadow-overhang: 0 1px 0 rgba(12,13,14,0.1),
     0 1px 3px rgba(12,13,14,0.1),

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { render } from 'react-dom';
+import { hydrate } from 'react-dom';
+import { BrowserRouter } from 'react-router-dom';
+import App from './components/app';
 import './components/index.css';
-
-declare var require: any;
 
 if (typeof Promise === 'undefined') {
   require('es6-promise').polyfill();
@@ -22,8 +22,9 @@ if (!Object.entries) {
 // Safari hack to allow :active styles.
 document.addEventListener('touchstart', function() {}, true);
 
-// Start the app when DOM is ready.
-document.addEventListener('DOMContentLoaded', () => {
-  const App = require('./components/app').default;
-  render(React.createElement(App), document.getElementById('root'));
-});
+hydrate(
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>,
+  document.getElementById('root')
+);

--- a/web/src/stores/root.ts
+++ b/web/src/stores/root.ts
@@ -14,7 +14,7 @@ let preloadedState: StateTree = {
   api: undefined,
   recordings: undefined,
   user: undefined,
-  validations: undefined
+  validations: undefined,
 };
 
 const composeEnhancers =
@@ -28,7 +28,7 @@ interface MergeAction {
 const store = createStore(
   function root(
     { recordings, user, validations }: StateTree,
-    action: MergeAction | Recordings.Action | User.Action| Validations.Action
+    action: MergeAction | Recordings.Action | User.Action | Validations.Action
   ): StateTree {
     const newState = {
       recordings: Recordings.reducer(recordings, action as Recordings.Action),
@@ -48,20 +48,20 @@ const store = createStore(
   composeEnhancers(applyMiddleware(thunk))
 );
 
-if (isBrowser)
-  setTimeout(() => {
-    try {
+if (isBrowser) {
+  try {
+    const user = JSON.parse(localStorage.getItem(USER_KEY)) || undefined;
+    if (user) {
       store.dispatch({
         type: 'MERGE',
-        state: {
-          user: JSON.parse(localStorage.getItem(USER_KEY)) || undefined,
-        },
+        state: { user },
       });
-    } catch (e) {
-      console.error('failed parsing storage', e);
-      localStorage.removeItem(USER_KEY);
     }
-  });
+  } catch (e) {
+    console.error('failed parsing storage', e);
+    localStorage.removeItem(USER_KEY);
+  }
+}
 
 const tracker = new Tracker();
 const fieldTrackers: any = {

--- a/web/src/utility.ts
+++ b/web/src/utility.ts
@@ -2,6 +2,8 @@
  * Functions to be shared across mutiple modules.
  */
 
+export const isBrowser = typeof window !== 'undefined';
+
 /**
  * Generate RFC4122 compliant globally unique identifier.
  */
@@ -36,6 +38,7 @@ export function countSyllables(text: string): number {
  */
 export function isNativeIOS(): boolean {
   return (
+    isBrowser &&
     window['webkit'] &&
     webkit.messageHandlers &&
     webkit.messageHandlers.scriptHandler
@@ -43,24 +46,28 @@ export function isNativeIOS(): boolean {
 }
 
 export function isFocus(): boolean {
-  return navigator.userAgent.indexOf('Focus') !== -1;
+  return (
+    typeof navigator !== 'undefined' &&
+    navigator.userAgent.indexOf('Focus') !== -1
+  );
 }
 
 /**
  * Test whether this is a browser on iOS.
  */
 export function isIOS(): boolean {
-  return /(iPod|iPhone|iPad)/i.test(window.navigator.userAgent);
+  return isBrowser && /(iPod|iPhone|iPad)/i.test(window.navigator.userAgent);
 }
 
 export function isWebkit(): boolean {
-  return /AppleWebKit/i.test(window.navigator.userAgent);
+  return isBrowser && /AppleWebKit/i.test(window.navigator.userAgent);
 }
 
 /**
  * Check whether the browser is Safari (either desktop or mobile).
  */
 export function isSafari(): boolean {
+  if (!isBrowser) return false;
   const userAgent = window.navigator.userAgent;
   /* Just checking isSafari isn't enough, because multiple browsers on iOS
    * identify as Safari. The difference is that they have a different version
@@ -80,6 +87,7 @@ export function isSafari(): boolean {
  */
 export function isMobileWebkit(): boolean {
   return (
+    isBrowser &&
     this.isIOS() &&
     this.isWebkit() &&
     !/(Chrome|CriOS|OPiOS)/.test(window.navigator.userAgent)
@@ -87,7 +95,7 @@ export function isMobileWebkit(): boolean {
 }
 
 export function isProduction(): boolean {
-  return window.location.origin === 'https://voice.mozilla.org';
+  return isBrowser && window.location.origin === 'https://voice.mozilla.org';
 }
 
 export function getItunesURL(): string {

--- a/web/webpack.common.config.js
+++ b/web/webpack.common.config.js
@@ -4,7 +4,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const OUTPUT_PATH = path.resolve(__dirname, 'dist');
 
 module.exports = {
-  entry: './src/main.ts',
+  entry: './src/main.tsx',
   output: {
     path: OUTPUT_PATH,
     filename: 'bundle.js',

--- a/web/webpack.dev.config.js
+++ b/web/webpack.dev.config.js
@@ -4,21 +4,4 @@ const commonConfig = require('./webpack.common.config.js');
 
 module.exports = merge(commonConfig, {
   devtool: 'cheap-module-eval-source-map',
-  module: {
-    rules: [
-      {
-        test: /\.(ts|tsx)$/,
-        enforce: 'pre',
-        use: [
-          {
-            options: {
-              formatter: eslintFormatter,
-              eslintPath: require.resolve('eslint'),
-            },
-            loader: require.resolve('eslint-loader'),
-          },
-        ],
-      },
-    ],
-  },
 });


### PR DESCRIPTION
# Comparison

## Site rendering
Local requests with network throttled to fast 3G speed:

### Before (Without SSR)
5.5s to fully load the landing page

### After
Text & CSS loaded after 1s.
Landing page with all images after 2.5s **-46%**


## Server Load
There's bound to be a heavier load on the server / less requests can be handled per second. I used [wrk](https://github.com/wg/wrk) to get some numbers on that.

Both before & after were running 30s test @ http://localhost:9000
12 threads and 400 connections

### Before

Thread Stats | Avg | Stdev | Max | +/- Stdev
--- | --- | ---  | --- | ---
**Latency** | 112.64ms | 24.56ms | 416.80ms | 91.38%
**Req/Sec** | 295.56 | 59.61 | 494.00 | 84.04%

105521 requests in 30.09s, 226.03MB read

**Requests/sec:** 3506.83
**Transfer/sec:** 7.51MB 

### After

Thread Stats | Avg | Stdev | Max | +/- Stdev
--- | --- | ---  | --- | ---
**Latency** | 1.08s **+860%**  | 120.60ms **+391%** | 1.63s **+290%** | 91.72%
**Req/Sec** | 48.62 | 44.17 | 220.00 | 72.61%

10796 requests in 30.09s, 108.54MB read

**Requests/sec:** 358.83 **-90%**
**Transfer/sec:** 3.61MB **-52%**

# Future

What is suboptimal is that we don't know about the user at request time, so we can't preload sentences to speak/verify. Also the profile-form doesn't get populated on the initial render (otherwise there'd be a mismatch between what the server vs. the client renders). We'll look at cookie-based user identification in the future, when we have more user data stored in the backend.