### PR TITLE
More spacing below robot on homepage (issue #720)

### DIFF
--- a/web/src/components/index.css
+++ b/web/src/components/index.css
@@ -203,7 +203,7 @@ button {
   }
 
   .home .hero-space {
-    height: 25rem;
+    height: 26rem;
   }
 }
 


### PR DESCRIPTION
Fixes issue #720. Tested in Firefox and Chrome on Android. Screenshot:
![Screenshot of the change](https://user-images.githubusercontent.com/24497353/33571559-fb4019e8-d8f5-11e7-9046-8afb82d909da.png)
