### PR TITLE
[Mobile] Pad menu items from the top.

### DIFF
--- a/web/src/components/nav.css
+++ b/web/src/components/nav.css
@@ -318,6 +318,6 @@ footer a:hover, footer button:hover {
 }
 
 #navigation-modal a {
-    line-height: 3.2;
+    padding-top: 2.5rem;
     font-size: 1.3rem;
 }

--- a/web/src/components/nav.css
+++ b/web/src/components/nav.css
@@ -318,6 +318,6 @@ footer a:hover, footer button:hover {
 }
 
 #navigation-modal a {
-    padding-top: 2.5rem;
+    line-height: 3.2;
     font-size: 1.3rem;
 }

--- a/web/src/components/nav.css
+++ b/web/src/components/nav.css
@@ -315,6 +315,7 @@ footer a:hover, footer button:hover {
 #navigation-modal .nav-list {
     flex-flow: column;
     font-size: 1.3rem;
+    padding-top: 1rem;
 }
 
 #navigation-modal a {


### PR DESCRIPTION
Menu items had padding at the top and bottom. Therefore the first item was closer to the top, than it was from the second item.

Before:
![capture1](https://user-images.githubusercontent.com/335152/33575418-7aa4a21a-d934-11e7-9817-57de91aa4d29.PNG)

After:
![capture](https://user-images.githubusercontent.com/335152/33575422-7ef8236e-d934-11e7-9558-0b3b9f8d5707.PNG)

Fixes: https://github.com/mozilla/voice-web/issues/718