### PR TITLE
Move "Delete Profile" link to its own line

### DIFF
--- a/web/src/components/profile-form/profile-form.css
+++ b/web/src/components/profile-form/profile-form.css
@@ -15,6 +15,11 @@
     #profile-card .half-width {
         width: 100%;
     }
+
+    #profile-card .title-and-action {
+        flex-direction: column;
+        text-align: center;
+    }
 }
 
 @media (min-width: 450px) {


### PR DESCRIPTION
Fixes issue #716 by changing the wrapping div to flex-direction: column
and centering the "Create a Profile" header when on mobile. Screenshot:
![screen shot 2017-12-05 at 12 02 26](https://user-images.githubusercontent.com/24497353/33623008-36e08324-d9b5-11e7-962a-31ef624f4b74.png)
