### PR TITLE
Tweak footer styling

### DIFF
--- a/web/src/components/nav.css
+++ b/web/src/components/nav.css
@@ -94,6 +94,12 @@ footer a:hover, footer button:hover {
     flex-direction: column;
 }
 
+@media (--mobile) {
+    #moz-links {
+        padding: var(--page-margin);
+    }
+}
+
 @media (--desktop) {
     #moz-links {
         margin: 0 auto;
@@ -115,7 +121,7 @@ footer a:hover, footer button:hover {
 
 @media (--mobile) {
     #moz-links .content {
-        padding: var(--page-margin);
+        padding-bottom: var(--page-margin);
     }
 }
 
@@ -142,7 +148,10 @@ footer a:hover, footer button:hover {
     #moz-links .links > p:last-child,
     #moz-links .links > :first-child a {
         display: block;
-        padding: 0.5rem 0;
+    }
+
+    #moz-links .links {
+        padding-top: 1.5rem;
     }
 }
 


### PR DESCRIPTION
This PR intends to fix #715.

1. Removes the padding around the lines of links and adds some padding
above them.
2. Removes the padding around the content div, except on the bottom.
This is replaced by padding on the entire moz-links section of the
footer, which creates the padding around the bottom box and keeps
everything nice and neat.

Screenshot: 
![screen shot 2017-12-05 at 12 49 22](https://user-images.githubusercontent.com/24497353/33625641-d5764b88-d9bd-11e7-8dd6-e1495ff12b00.png)
