### PR TITLE
Tweaks to help links subfooter

### DIFF
--- a/web/src/components/nav.css
+++ b/web/src/components/nav.css
@@ -72,6 +72,20 @@ footer a:hover, footer button:hover {
     height: 2.5rem;
 }
 
+@media (--mobile) {
+    #help-links .divider {
+        display: none;
+    }
+
+    #help-links img {
+        width: 21px;
+    }
+
+    #help-links a {
+        font-size: .8em;
+    }
+}
+
 #help-links {
     margin-top: calc(2 * var(--standard-margin));
 }

--- a/web/src/components/nav.css
+++ b/web/src/components/nav.css
@@ -86,7 +86,7 @@ footer a:hover, footer button:hover {
     }
 
     #help-links a {
-        font-size: .8em;
+        font-size: var(--small-font-size);
     }
 }
 

--- a/web/src/components/nav.css
+++ b/web/src/components/nav.css
@@ -73,6 +73,10 @@ footer a:hover, footer button:hover {
 }
 
 @media (--mobile) {
+    #help-links {
+        height: 6rem;
+    }
+
     #help-links .divider {
         display: none;
     }


### PR DESCRIPTION
Intends to fix issue #714 by removing the dividers, reducing icon and text size by 20%, and making the subfooter shorter. These changes only apply on mobile devices. Screenshot: 
![screen shot 2017-12-06 at 07 43 47](https://user-images.githubusercontent.com/24497353/33664429-3a28993c-da59-11e7-89a6-cdad3aa065cc.png)
