### PR TITLE
Scrolling shouldn't be disabled

### DIFF
--- a/ios/voicebank-ios-wrapper/ViewController.swift
+++ b/ios/voicebank-ios-wrapper/ViewController.swift
@@ -32,7 +32,6 @@ class ViewController: UIViewController, WKScriptMessageHandler, WKNavigationDele
         webView?.isHidden = true
         webView?.navigationDelegate = self
         webView?.configuration.userContentController.add(self, name: "scriptHandler")
-        webView?.scrollView.isScrollEnabled = UIDevice.current.userInterfaceIdiom == .pad
         self.view.addSubview(webView!)
         let url = URL(string: "https://voice.mozilla.org/")
         let request = URLRequest(url: url!)


### PR DESCRIPTION
Looking through the commit history, I'm not sure why scrolling is only enabled on iPads.

This pull request resolves #819.