### PR TITLE
Handle multiple environments for aws_db_parameter_group

### DIFF
--- a/nubis/terraform/main.tf
+++ b/nubis/terraform/main.tf
@@ -47,7 +47,7 @@ module "dns" {
 }
 
 resource "aws_db_parameter_group" "slow_query_enabled" {
-  name   = "${var.service_name}-slow_query-${var.environment}-{$var.region}"
+  name   = "${var.service_name}-slow_query-${var.environment}-${var.region}"
   family = "mysql5.6"
 
   parameter {

--- a/nubis/terraform/main.tf
+++ b/nubis/terraform/main.tf
@@ -46,6 +46,16 @@ module "dns" {
   target       = "${module.load_balancer.address}"
 }
 
+resource "aws_db_parameter_group" "slow_query_enabled" {
+  name   = "${var.service_name}-slow_query-${var.environment}-{$var.region}"
+  family = "mysql5.6"
+
+  parameter {
+    name  = "slow_query_log"
+    value = "1"
+  }
+}
+
 module "database" {
   source                 = "github.com/nubisproject/nubis-terraform//database?ref=v2.0.1"
   region                 = "${var.region}"
@@ -55,7 +65,7 @@ module "database" {
   monitoring             = true
   service_name           = "${var.service_name}"
   client_security_groups = "${module.worker.security_group}"
-  parameter_group_name   = "cv-parameter-group"
+  parameter_group_name   = "${aws_db_parameter_group.slow_query_enabled.id}"
   instance_class         = "db.t2.small"
 }
 

--- a/nubis/terraform/users.tf
+++ b/nubis/terraform/users.tf
@@ -34,13 +34,3 @@ resource "aws_iam_user_policy" "clips_bucket" {
 }
 EOF
 }
-
-resource "aws_db_parameter_group" "cv-parameter-group" {
-  name   = "cv-parameter-group"
-  family = "mysql5.6"
-
-  parameter {
-    name  = "slow_query_log"
-    value = "1"
-  }
-}


### PR DESCRIPTION
- Don't hard-code a resource's name, instaed build it up with environment, region, etc
 - link resources with their internal IDs instead of hard-coding names