### PR TITLE
Replace Ubuntu's default upstart logrotate config with one that restarts fluent's td-agent afterwards

### DIFF
--- a/nubis/puppet/files/upstart.logrotate
+++ b/nubis/puppet/files/upstart.logrotate
@@ -1,0 +1,12 @@
+/var/log/upstart/*.log {
+  daily
+  missingok
+  rotate 7
+  compress
+  notifempty
+  nocreate
+  postrotate
+    /bin/rm -f /var/log/upstart/*.pos
+    /sbin/restart td-agent
+  endscript
+}

--- a/nubis/puppet/logs.pp
+++ b/nubis/puppet/logs.pp
@@ -13,3 +13,13 @@ fluentd::source { 'node-output':
     'pos_file'       => "/var/log/upstart/${project_name}.pos",
   },
 }
+
+# Workaround for https://github.com/fluent/fluentd/issues/1734
+# restart td-agent after log rotation
+file { '/etc/logrotate.d/upstart':
+  ensure => file,
+  owner  => root,
+  group  => root,
+  mode   => '0644',
+  source => 'puppet:///nubis/files/upstart.logrotate',
+}


### PR DESCRIPTION
Also, cleanup .pos files

Works around fluent/fluentd#1734

Fixes #847