### PR TITLE
Improve FTL and l10n support

### DIFF
--- a/l10n.toml
+++ b/l10n.toml
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+basepath = "."
+
+[env]
+    l = "{l10n_base}/web/locales/{locale}/"
+
+[[paths]]
+    reference = "web/locales/en/**"
+    l10n = "{l}**"

--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -36,7 +36,11 @@ help-us-explain = Press play, listen & tell us: did they accurately speak the se
 status-title = Overall project status: see how far we’ve come!
 status-contribute = Contribute Your Voice
 status-loading = Loading…
-status-hours = { $hours } validated hours so far!
+status-hours =
+    { $hours ->
+        [one] One validated hours so far!
+       *[other] { $hours } validated hours so far!
+    }
 status-goal = Next Goal: { $goal }
 status-more-soon = More languages coming soon!
 

--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -13,7 +13,7 @@ share-title = Help us find others to donate their voice!
 
 ## Home Page
 home-title =
-  The Common Voice project is Mozilla's initiative to help teach machines how real people speak.
+  The Common Voice project is Mozilla’s initiative to help teach machines how real people speak.
 home-cta = Speak up, contribute here!
 wall-of-text-start =
   Voice is natural, voice is human. That’s why we’re fascinated with creating usable voice
@@ -33,7 +33,7 @@ help-us-title = Help us validate sentences!
 help-us-explain = Press play, listen & tell us: did they accurately speak the sentence below?
 
 ## ProjectStatus
-status-title = Overall project status: see how far we've come!
+status-title = Overall project status: see how far we’ve come!
 status-contribute = Contribute Your Voice
 status-loading = Loading…
 status-hours = { $hours } validated hours so far!
@@ -45,7 +45,7 @@ profile-form-email =
     .label = Email
 profile-form-username =
     .label = User Name
-profile-form-emails = Yes, send me emails. I'd like to stay informed about the Common Voice Project.
+profile-form-emails = Yes, send me emails. I’d like to stay informed about the Common Voice Project.
 profile-form-language =
     .label = Language
 profile-form-more-languages = More languages coming soon!
@@ -61,7 +61,7 @@ faq-title = Frequently Asked Questions
 faq-what-q = What is Common Voice?
 faq-what-a = Voice recognition technology could revolutionize the way we interact with machines, but the currently available systems are expensive and proprietary. Common Voice is a project to make voice recognition technology easily accessible to everyone. People donate their voices to a massive database that will let anyone quickly and easily train voice-enabled apps. All voice data will be available to developers.
 faq-important-q = Why is it important?
-faq-important-a = Voice is natural, voice is human. It’s the easiest and most natural way to communicate. We want developers to be able to build amazing things from real-time translators to voice-enabled administrative assistants. But right now there isn't enough publicly available data to build these kinds of apps. We hope that Common Voice will give developers what they need to innovate.
+faq-important-a = Voice is natural, voice is human. It’s the easiest and most natural way to communicate. We want developers to be able to build amazing things from real-time translators to voice-enabled administrative assistants. But right now there isn’t enough publicly available data to build these kinds of apps. We hope that Common Voice will give developers what they need to innovate.
 faq-get-q = How can I get the Common Voice data?
 faq-get-a = The dataset is available now on our <downloadLink>download page</downloadLink> under the <licenseLink>CC-0</licenseLink> license.
 faq-mission-q = Why is Common Voice part of the Mozilla mission?
@@ -75,7 +75,7 @@ faq-quality-a = We want the audio quality to reflect the audio quality a speech-
 faq-hours-q = Why is 10,000 hours the goal for capturing audio?
 faq-hours-a = This is approximately the number of hours required to train a production STT system.
 faq-source-q = Where does the source text come from?
-faq-source-a1 = The current sentences come from contributor donations, as well as dialogue from public domain movie scripts like <italic>It's a Wonderful Life.</italic>
+faq-source-a1 = The current sentences come from contributor donations, as well as dialogue from public domain movie scripts like <italic>It’s a Wonderful Life.</italic>
 faq-source-a2 = You can view our source sentences in <dataLink>this GitHub folder</dataLink>.
 
 ## Profile
@@ -84,7 +84,7 @@ profile-why-content = By providing some information about yourself, the audio da
 
 ## NotFound
 notfound-title = Not found
-notfound-content = I'm afraid I don't know what you're looking for.
+notfound-content = I’m afraid I don’t know what you’re looking for.
 
 ## Privacy
 privacy-title = Common Voice Privacy Notice
@@ -109,11 +109,11 @@ terms-contributions-content = By submitting your recordings, you waive all copyr
 terms-communications-title = Communications
 terms-communications-content = If you subscribe to receive our newsletters or register for an account in connection with Common Voice, you may receive emails from us in connection with your account (for example, legal, privacy, and security updates).
 terms-general-title = General
-terms-general-liability1 = Disclaimer; Limitation of Liability: COMMON VOICE AND ALL INCLUDED RECORDINGS ARE PROVIDED ON AN "AS IS" BASIS WITHOUT WARRANTY OF ANY KIND, WHETHER EXPRESS OR IMPLIED. MOZILLA TAKES NO RESPONSIBILITY AND ASSUMES NO LIABILITY FOR ANY RECORDINGS THAT YOU OR ANY OTHER USER OR THIRD PARTY POSTS OR TRANSMITS USING COMMON VOICE.
+terms-general-liability1 = Disclaimer; Limitation of Liability: COMMON VOICE AND ALL INCLUDED RECORDINGS ARE PROVIDED ON AN “AS IS” BASIS WITHOUT WARRANTY OF ANY KIND, WHETHER EXPRESS OR IMPLIED. MOZILLA TAKES NO RESPONSIBILITY AND ASSUMES NO LIABILITY FOR ANY RECORDINGS THAT YOU OR ANY OTHER USER OR THIRD PARTY POSTS OR TRANSMITS USING COMMON VOICE.
 terms-general-liability2 = MOZILLA SPECIFICALLY DISCLAIMS ANY AND ALL WARRANTIES AND CONDITIONS OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT, AND ANY WARRANTIES ARISING OUT OF COURSE OF DEALING OR USAGE OF TRADE.
-terms-general-liability3 = TO THE EXTENT PERMITTED BY APPLICABLE LAW, YOU AGREE TO RELEASE AND HOLD HARMLESS MOZILLA CORPORATION AND ITS RESPECTIVE PARENT, SUBSIDIARIES, AFFILIATES, DIRECTORS, OFFICERS, EMPLOYEES, AND AGENTS (THE "MOZILLA PARTIES"), FROM ANY AND ALL LIABILITY FOR ANY DAMAGE, LOSS OR DELAY (INCLUDING PERSONAL INJURY, DEATH, OR PROPERTY DAMAGE) RESULTING IN WHOLE OR IN PART, DIRECTLY OR INDIRECTLY, FROM YOUR PARTICIPATION IN COMMON VOICE.
+terms-general-liability3 = TO THE EXTENT PERMITTED BY APPLICABLE LAW, YOU AGREE TO RELEASE AND HOLD HARMLESS MOZILLA CORPORATION AND ITS RESPECTIVE PARENT, SUBSIDIARIES, AFFILIATES, DIRECTORS, OFFICERS, EMPLOYEES, AND AGENTS (THE “MOZILLA PARTIES”), FROM ANY AND ALL LIABILITY FOR ANY DAMAGE, LOSS OR DELAY (INCLUDING PERSONAL INJURY, DEATH, OR PROPERTY DAMAGE) RESULTING IN WHOLE OR IN PART, DIRECTLY OR INDIRECTLY, FROM YOUR PARTICIPATION IN COMMON VOICE.
 terms-general-liability4 = EXCEPT AS REQUIRED BY LAW, MOZILLA AND THE MOZILLA PARTIES WILL NOT BE LIABLE FOR ANY INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL, OR EXEMPLARY DAMAGES ARISING OUT OF OR IN ANY WAY RELATING TO THESE TERMS OR THE USE OF OR INABILITY TO USE THE SERVICES, INCLUDING WITHOUT LIMITATION DIRECT AND INDIRECT DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, LOST PROFITS, LOSS OF DATA, AND COMPUTER FAILURE OR MALFUNCTION, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES AND REGARDLESS OF THE THEORY (CONTRACT, TORT, OR OTHERWISE) UPON WHICH SUCH CLAIM IS BASED. THE COLLECTIVE LIABILITY OF MOZILLA AND THE MOZILLA PARTIES UNDER THIS AGREEMENT WILL NOT EXCEED $500 (FIVE HUNDRED DOLLARS). SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL, CONSEQUENTIAL, OR SPECIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
-terms-general-updates = Updates: Mozilla may update these Terms from time to time to address a new feature of the Services or to clarify a provision. The updated Terms will be posted online. If the changes are substantive, we will announce the update through Mozilla's usual channels for such announcements such as blog posts and forums. Your continued use of the Services after the effective date of such changes constitutes your acceptance of such changes. To make your review more convenient, we will post an effective date at the top of this page.
+terms-general-updates = Updates: Mozilla may update these Terms from time to time to address a new feature of the Services or to clarify a provision. The updated Terms will be posted online. If the changes are substantive, we will announce the update through Mozilla’s usual channels for such announcements such as blog posts and forums. Your continued use of the Services after the effective date of such changes constitutes your acceptance of such changes. To make your review more convenient, we will post an effective date at the top of this page.
 terms-general-termination = Termination: We may suspend or terminate your access to the Services at any time for any reason, we will make reasonable efforts to notify you by the email address associated with your account or the next time you attempt to access the Services. Regardless of any termination, all recordings that you submit to Mozilla will continue to be publicly available.
 terms-general-law = Governing Law: These Legal Terms constitute the entire agreement between you and Mozilla concerning Common Voice and are governed by the laws of the state of California, U.S.A.
 
@@ -137,7 +137,7 @@ data-bundle-description = Common Voice data plus all other voice datasets above.
 license = License: <licenseLink>{ $license }</licenseLink>
 
 ## Record Page
-record-platform-not-supported = We're sorry, but your platform is not currently supported.
+record-platform-not-supported = We’re sorry, but your platform is not currently supported.
 record-platform-not-supported-desktop = On desktop computers, you can download the latest:
 record-platform-not-supported-ios = <bold>iOS</bold> users can download our free app:
 record-must-allow-microphone = You must allow microphone access.

--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -41,6 +41,8 @@ status-hours =
         [one] One validated hours so far!
        *[other] { $hours } validated hours so far!
     }
+# Variables:
+# $goal - number of hours representing the next goal
 status-goal = Next Goal: { $goal }
 status-more-soon = More languages coming soon!
 

--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -31,6 +31,7 @@ wall-of-text-more-desktop =
 show-wall-of-text = Read More
 help-us-title = Help us validate sentences!
 help-us-explain = Press play, listen & tell us: did they accurately speak the sentence below?
+
 ## ProjectStatus
 status-title = Overall project status: see how far we've come!
 status-contribute = Contribute Your Voice
@@ -40,19 +41,19 @@ status-goal = Next Goal: { $goal }
 status-more-soon = More languages coming soon!
 
 ## ProfileForm
-profile-form-email
+profile-form-email =
     .label = Email
-profile-form-username
+profile-form-username =
     .label = User Name
 profile-form-emails = Yes, send me emails. I'd like to stay informed about the Common Voice Project.
-profile-form-language
+profile-form-language =
     .label = Language
 profile-form-more-languages = More languages coming soon!
-profile-form-accent
+profile-form-accent =
     .label = Accent
-profile-form-age
+profile-form-age =
     .label = Age
-profile-form-gender
+profile-form-gender =
     .label = Gender
 
 ## FAQ
@@ -62,7 +63,7 @@ faq-what-a = Voice recognition technology could revolutionize the way we interac
 faq-important-q = Why is it important?
 faq-important-a = Voice is natural, voice is human. It’s the easiest and most natural way to communicate. We want developers to be able to build amazing things from real-time translators to voice-enabled administrative assistants. But right now there isn't enough publicly available data to build these kinds of apps. We hope that Common Voice will give developers what they need to innovate.
 faq-get-q = How can I get the Common Voice data?
-faq-get-a =  The dataset is available now on our <downloadLink>download page</downloadLink> under the <licenseLink>CC-0</licenseLink> license.
+faq-get-a = The dataset is available now on our <downloadLink>download page</downloadLink> under the <licenseLink>CC-0</licenseLink> license.
 faq-mission-q = Why is Common Voice part of the Mozilla mission?
 faq-mission-a = Mozilla is dedicated to keeping the web open and accessible for everyone. To do it we need to empower web creators through projects like Common Voice. As voice technologies proliferate beyond niche applications, we believe they must serve all users equally well. We see a need to include more languages, accents and demographics when building and testing voice technologies. Mozilla wants to see a healthy, vibrant internet. That means giving new creators access to voice data so they can build new, extraordinary projects. Common Voice will be a public resource that will help Mozilla teams and developers around the world.
 faq-native-q = I am a non-native English speaker and I speak with an accent, do you still want my voice?

--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -38,7 +38,7 @@ status-contribute = Contribute Your Voice
 status-loading = Loading…
 status-hours =
     { $hours ->
-        [one] One validated hours so far!
+        [one] One validated hour so far!
        *[other] { $hours } validated hours so far!
     }
 # Variables:

--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -35,7 +35,7 @@ help-us-explain = Press play, listen & tell us: did they accurately speak the se
 ## ProjectStatus
 status-title = Overall project status: see how far we've come!
 status-contribute = Contribute Your Voice
-status-loading = Loading...
+status-loading = Loading…
 status-hours = { $hours } validated hours so far!
 status-goal = Next Goal: { $goal }
 status-more-soon = More languages coming soon!


### PR DESCRIPTION
I can drop the change to single unicode character if you prefer, but that's what is usually used across Mozilla projects.

The new FTL syntax also has an equal sign when the value is empty

```properties
foo =
    .title = bar
```

**l10n.toml**
You can use it get the status of locales, find errors, etc.

Install [compare-locales](https://pypi.python.org/pypi/compare-locales), then run `compare-locales l10n.toml . en ab-CD` (where `ab-CD` is a locale code). You can also run it on multiple locales, as part of automation, etc.

CC @pike