### PR TITLE
Fix issue #828: When sentences can't be loaded, the error message displays improperly.

### DIFF
--- a/web/src/components/pages/record/record.css
+++ b/web/src/components/pages/record/record.css
@@ -46,6 +46,13 @@
     transition: transform 0.4s var(--easing);
 }
 
+.text-box.no-sentences-error {
+    background-color: white;
+}
+.text-box.no-sentences-error p {
+    opacity: .3;
+}
+
 .text-box.left, .text-box.right {
     position: absolute;
     top: 0;

--- a/web/src/components/pages/record/record.tsx
+++ b/web/src/components/pages/record/record.tsx
@@ -19,8 +19,11 @@ import Review from './review';
 const MIN_RECORDING_LENGTH = 300; // ms
 const MAX_RECORDING_LENGTH = 10000; // ms
 const MIN_VOLUME = 1;
-const ERR_SENTENCES_NOT_LOADED =
-  'Sorry! Sentences are being loaded, please wait or try again shortly.';
+const ERR_SENTENCES_NOT_LOADED = (
+  <div className="text-box no-sentences-error">
+    <p>Sorry! Sentences are being loaded, please wait or try again shortly.</p>
+  </div>
+);
 const RECORD_DEBOUNCE_MS = 300;
 
 const UnsupportedInfo = () => (
@@ -374,7 +377,8 @@ class RecordPage extends React.Component<RecordProps, RecordState> {
             )}
           </div>
           <p id="recordings-count">
-            {!reRecordSentence && <span>{recordingsCount + 1} of 3</span>}
+            {areSentencesLoaded &&
+              !reRecordSentence && <span>{recordingsCount + 1} of 3</span>}
           </p>
           {areSentencesLoaded && (
             <Localized id="record-help">


### PR DESCRIPTION
- Wrap the "sentences are being loaded" error message in a `<div>` and `<p>`
  that give it a solid background, as well as fading the text to give a
  visual indication that something is missing. This is the same as what
  the validation box does when there are no sentences to validate.
- Remove the "1 of 3" text when there are no sentences to read.