### PR TITLE
fix: #608 expect to one touch and do rerecord

### DIFF
--- a/web/src/components/listen-box/listen-box.tsx
+++ b/web/src/components/listen-box/listen-box.tsx
@@ -110,7 +110,6 @@ export default class ListenBox extends React.Component<Props, State> {
     if (this.state.playing) {
       this.el.pause();
       this.setState({ playing: false });
-      return;
     }
 
     this.props.onDelete && this.props.onDelete();


### PR DESCRIPTION
The `return` statement blocked further code execution, which is why user needs to click twice in order to rerecord. Essentially, the first time for "pausing" the playback, and the second time to actually switch view to rerecord. 