### PR TITLE
Fix #908

### DIFF
--- a/web/src/components/layout/nav.css
+++ b/web/src/components/layout/nav.css
@@ -370,6 +370,7 @@ footer a:hover, footer button:hover {
     pointer-events: none;
     transform: translateY(-100vh);
     transition: all 0.55s var(--easing);
+    visibility: hidden;
 }
 
 #navigation-modal.active {
@@ -377,6 +378,7 @@ footer a:hover, footer button:hover {
     transform: translateY(0);
     pointer-events: all;
     transition-duration: 0.4s;
+    visibility: visible;
 }
 
 #navigation-modal .nav-list {


### PR DESCRIPTION
Fixes issue #908: On short, wide screens, the bottom of the mobile navigation menu shows

On screens that are short, but wide enough not to trigger the mobile
layout, the bottom of mobile navigation modal still showed up. This
fixes the problem by setting the modal to `visibility: hidden` when it
is not active.