### PR TITLE
Enable multi-language on production

### DIFF
--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -109,7 +109,6 @@ status-hours =
 # Variables:
 # $goal - number of hours representing the next goal
 status-goal = Next Goal: { $goal }
-status-more-soon = More languages coming soon!
 english = English
 
 ## ProfileForm

--- a/web/src/components/layout/nav.tsx
+++ b/web/src/components/layout/nav.tsx
@@ -1,6 +1,5 @@
 import { Localized } from 'fluent-react';
 import * as React from 'react';
-import { isProduction } from '../../utility';
 import URLS from '../../urls';
 import { ContributableLocaleLock, LocaleNavLink } from '../locale-helpers';
 
@@ -16,11 +15,9 @@ export default ({ children, ...props }: { [key: string]: any }) => (
     <Localized id="datasets">
       <LocaleNavLink to={URLS.DATA} exact />
     </Localized>
-    {!isProduction() && (
-      <Localized id="languages">
-        <LocaleNavLink to={URLS.LANGUAGES} exact />
-      </Localized>
-    )}
+    <Localized id="languages">
+      <LocaleNavLink to={URLS.LANGUAGES} exact />
+    </Localized>
     <Localized id="profile">
       <LocaleNavLink to={URLS.PROFILE} exact />
     </Localized>

--- a/web/src/components/pages/home/project-status.tsx
+++ b/web/src/components/pages/home/project-status.tsx
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import { Localized } from 'fluent-react';
 import { trackNavigation } from '../../../services/tracker';
 import URLS from '../../../urls';
-import { isProduction } from '../../../utility';
 import ProgressBar from '../../progress-bar/progress-bar';
 import API from '../../../services/api';
 import StateTree from '../../../stores/tree';
@@ -82,30 +81,21 @@ class ProjectStatus extends React.Component<Props, State> {
             </div>
           </div>
 
-          {isProduction() ? (
-            <div>
-              <Localized id="status-more-soon">
-                <span />
-              </Localized>
-              <div className="progress-bar" />
-            </div>
-          ) : (
-            <div className="request-language">
-              <Hr style={{ marginBottom: '2rem' }} />
+          <div className="request-language">
+            <Hr style={{ marginBottom: '2rem' }} />
 
-              <Localized id="request-language-text">
-                <div />
-              </Localized>
+            <Localized id="request-language-text">
+              <div />
+            </Localized>
 
-              <br />
+            <br />
 
-              <Localized id="request-language-button">
-                <Button rounded onClick={this.props.onRequestLanguage} />
-              </Localized>
+            <Localized id="request-language-button">
+              <Button rounded onClick={this.props.onRequestLanguage} />
+            </Localized>
 
-              <br />
-            </div>
-          )}
+            <br />
+          </div>
         </div>
       </div>
     );

--- a/web/src/services/localization.ts
+++ b/web/src/services/localization.ts
@@ -3,11 +3,14 @@ const { MessageContext } = require('fluent');
 const { negotiateLanguages } = require('fluent-langneg');
 import ISO6391 from 'iso-639-1';
 const locales = require('../../../data/locales.json');
+const completedLocales = require('../../../data/completed_locales.json');
 import { isProduction } from '../utility';
 import API from './api';
 
 export const DEFAULT_LOCALE = 'en';
-export const LOCALES = isProduction() ? [DEFAULT_LOCALE] : Object.keys(locales);
+export const LOCALES = isProduction()
+  ? (completedLocales as string[])
+  : Object.keys(locales);
 export const CONTRIBUTABLE_LOCALES = ['en'];
 
 const localeNations: any = {


### PR DESCRIPTION
- get list of "completed" locales from `completed_locales.json` (which is updated by running `import-pontoon-locales.json` based on locales with >= 95% translation)
- show Languages in Nav
- show Help Translate Modal on Home