### PR TITLE
WIP - Remove display-table to on modal css to resolve issue 990

### DIFF
--- a/web/src/components/modal/modal.css
+++ b/web/src/components/modal/modal.css
@@ -1,5 +1,5 @@
 .ReactModal__Overlay {
-    display: table;
+    /* display: table; */
     z-index: var(--top-z-index);
     width: 100%;
     height: 100%;


### PR DESCRIPTION
This seems to resolve a display issue (#990) that I investigated with @mikehenrty at the voice sprint.

The `display-table` property here causes an issue where text flow on the language flows off the bottom of the modal you can see this in the screenshot from #990 (this affected mobile firefox and chrome when we looked into it together):


![before-modal-borkage](https://user-images.githubusercontent.com/17906/39878952-e42c36c4-5479-11e8-95ec-a035d0245eb9.jpg)

Removing the `display-table` property resolves it, but I understand this to be used for vertical centering normally, and I'm not sure what layouts this is likely to affect.

Is there chance someone give me an idea of where i might look, to see if fixing this issue breaks things elsewhere?

