### PR TITLE
Some keys required by ObsMoz added to contribute.json

### DIFF
--- a/contribute.json
+++ b/contribute.json
@@ -3,17 +3,23 @@
     "description": "The Common Voice project is Mozilla’s initiative to help teach machines how real people speak by receiving and validating voice donations.",
     "repository": {
         "url": "https://github.com/mozilla/voice-web",
-        "license": "MPL2"
+        "license": "MPL2",
+        "tests": "https://travis-ci.org/mozilla/voice-web/"
     },
     "participate": {
         "home": "https://voice.mozilla.org",
         "docs":"https://github.com/mozilla/voice-web/blob/master/CONTRIBUTING.md",
         "forum": "https://discourse.mozilla.org/c/voice",
-        "chat": "https://common-voice-slack-invite.herokuapp.com/"
+        "slack": "https://common-voice.slack.com/",
+        "slack-invite": "https://common-voice-slack-invite.herokuapp.com/"
     },
     "bugs": {
         "list": "https://github.com/mozilla/voice-web/issues",
         "report": "https://github.com/mozilla/voice-web/issues/new"
+    },
+    "urls": {
+        "prod": "https://voice.mozilla.org",
+        "stage": "https://voice.allizom.org"
     },
     "keywords": [
         "asr",


### PR DESCRIPTION
Added **"urls"** and "repository":{**"tests"**}. Also changed "participate":{"chat"} to "participate":{"slack" and "slack-invite"}.

This was done based on issue #1003 and following advise from @Gregoor.