### PR TITLE
Fixed punctuation marks in german and french sentences

### DIFF
--- a/server/data/de/jf99.txt
+++ b/server/data/de/jf99.txt
@@ -29,8 +29,8 @@ Stecker sollten niemals am Kabel aus der Steckdose gezogen werden.
 Planfeststellungsverfahren ist doch ein wunderbares deutsches Wort.
 Die Sache hat allerdings einen Haken.
 Wenn du das Handtuch so aufhängst, wird es morgen immer noch nicht trocken sein.
-Heute gibt es "Asterix und Kleopatra" im Fernsehen.
-Auf Kika läuft gerade "Jim Knopf und Lukas der Lokomotivführer".
+Heute gibt es Asterix und Kleopatra im Fernsehen.
+Auf Kika läuft gerade Jim Knopf und Lukas der Lokomotivführer.
 Geschrieben von Michael Ende und gespielt von der Augsburger Puppenkiste.
 Als Kind hatte ich alle Folgen vom Sams auf Kassette.
 Heutzutage wissen die Kinder wahrscheinlich gar nicht mehr, was eine Kassette ist.
@@ -90,7 +90,7 @@ Bremen und die anderen Stadtstaaten sind mal wieder die Schlusslichter der PISA-
 Otto kommt aus Ostfriesland.
 Heißt du wirklich Uli, oder ist das die Abkürzung für Ulrich?
 Trotz seiner relativ geringen Größe hat Brandenburg an der Havel immerhin eine Straßenbahn und zwei Hochschulen.
-"Meinen Bachelor in Mathematik habe ich zuvor in Jena gemacht", erzählte Anton.
+Meinen Bachelor in Mathematik habe ich zuvor in Jena gemacht, erzählte Anton.
 Berta hat uns zu einer Weinprobe nach Kaiserslautern eingeladen.
 Trier ist die älteste Stadt Deutschlands und wurde ursprünglich von den Römern gegründet.
 Gaius Julius Cäsar kannte sie jedoch noch nicht.
@@ -108,7 +108,7 @@ Freiburg im Breisgau gilt als relativ fahrradfreundliche Stadt.
 Ich bezweifle, dass dieses Gesetz in Karlsruhe als verfassungsgemäß anerkannt wird.
 Warum wollen eigentlich alle ausländischen Touristen nach Heidelberg?
 Das ZDF hat seinen Hauptsitz in Mainz.
-"Sylt ist mir einfach zu teuer", argumentierte Paula.
+Sylt ist mir einfach zu teuer, argumentierte Paula.
 Die Form seines Kiels ist entscheidend für die Kursstabilität eines Schiffes.
 Auweia, das gibt mindestens drei Punkte in Flensburg.
 Ab wann muss man zum Idiotentest?
@@ -456,7 +456,7 @@ Mir ist schlecht.
 Bist du auf Diät?
 Das bietet sich in der Fastenzeit doch an.
 Hat Friederike das Buch wirklich schon durch?
-"Ich glaube, ohne Piepser könnte ich überhaupt nicht mehr rückwärts einparken", gab Ulrike zu.
+Ich glaube, ohne Piepser könnte ich überhaupt nicht mehr rückwärts einparken, gab Ulrike zu.
 Bettina hat mal wieder Migräne.
 Es ist schon faszinierend, dass Regenwürmer und Seesterne abgetrennte Körperteile einfach regenerieren können.
 Der Ebola-Patient ist bereits auf der Quarantänestation.
@@ -569,7 +569,7 @@ Denken Sie nochmal darüber nach, wer wirklich Ihre Zielgruppe ist.
 Wahnsinn, diese Beschleunigung!
 Warum gehen mir immer alle Typen fremd?
 Erika war am Boden zerstört.
-"Mein Enkel ist ein tüchtiger Bursche", erzählte der Großvater stolz.
+Mein Enkel ist ein tüchtiger Bursche, erzählte der Großvater stolz.
 Der Konflikt war doch vorprogrammiert.
 Julia fühlte sich unterfordert.
 Ich habe meine Brille vergessen.
@@ -905,7 +905,7 @@ Der Dialog zwischen ihm und der alten Frau war einfach zum Totlachen!
 Was gibt es da zu lachen?
 Eigentlich war es eher ein Monolog.
 Die Truppen ziehen sich zurück.
-Weil der Begriff "Rückzug" verboten war, wurde stets nur von Frontbegradigung gesprochen.
+Weil der Begriff Rückzug verboten war, wurde stets nur von Frontbegradigung gesprochen.
 Das ist natürlich purer Selbstbetrug.
 Es ist ein Spiel mit gezinkten Karten.
 Dieser perfide Angriff basiert auf gezinkten Primzahlen.
@@ -992,8 +992,8 @@ Danke, das ist sehr aufmerksam von Ihnen.
 Handelt es sich also um eine kraftschlüssige oder formschlüssige Verbindung?
 Beim Löten verbinden sich zwei Metalle stoffschlüssig.
 Der grüne Opel fuhr bei Tiefrot über die Haltelinie.
-"Ich wollte testen, ob du am Stoppschild auch wirklich anhältst", erklärte der Fahrlehrer.
-"Der Röhrenfernseher war damals aber viel schwerer als heutige Flachbildschirme", gab Nicole zu bedenken.
+Ich wollte testen, ob du am Stoppschild auch wirklich anhältst, erklärte der Fahrlehrer.
+Der Röhrenfernseher war damals aber viel schwerer als heutige Flachbildschirme, gab Nicole zu bedenken.
 Beim diesjährigen Krippenspiel mussten Maria und Joseph improvisieren, weil sie den Text nicht gelernt hatten.
 Meine Mutter hat schon einen Adventskranz besorgt.
 Wir kaufen die Tannenzweige immer so und binden den Kranz selber.
@@ -1079,7 +1079,7 @@ Dort gewähren wir Ihnen einen einmaligen Blick hinter die Kulissen.
 Die Angaben sind wie immer ohne Gewähr.
 In diesem Fall muss der Hersteller seiner Gewährleistungspflicht nachkommen.
 Welches Gewehr nimmst du diese Runde?
-"Wie bitte?", fragte der Bereitschaftspolizist und klappte sein Visier hoch.
+Wie bitte?, fragte der Bereitschaftspolizist und klappte sein Visier hoch.
 Wir haben Gesellschaft!
 Die Ratten verlassen das sinkende Schiff.
 Manchmal scheint es, als wärt ihr telepathisch veranlagt.
@@ -1121,16 +1121,16 @@ Keine Polizei, keine Tricks – sonst sterben die Geiseln.
 Der Einsatz von Glyphosat ist weiterhin umstritten.
 Weißt du noch damals, als wir noch jung waren?
 Wir alle müssen jetzt den Gürtel enger schnallen.
-"Ich kann das Geschwafel dieses sogenannten Wirtschaftsexperten nicht mehr hören", beschwerte sich Monika.
+Ich kann das Geschwafel dieses sogenannten Wirtschaftsexperten nicht mehr hören, beschwerte sich Monika.
 Der Beamte griff zum Telefonhörer und wählte eine Nummer.
 Tut mir leid, dann sind Sie falsch verbunden.
 Man bot mir die Aufnahme ins Zeugenschutzprogramm an, unter der Bedingung, dass ich auspacke.
 Oma Gertrud schielte vorsichtig durch den Türspion.
-"Wer ist da?", fragte sie mit zittriger Stimme.
+Wer ist da?, fragte sie mit zittriger Stimme.
 Das Online-Geschäft ist mittlerweile unser stärkstes Zugpferd.
 Trotzdem sollten Sie sich ein zweites Standbein aufbauen.
 Ich verstehe nicht, worauf Sie hinaus wollen.
-Etwa hundert User hatten "Erster" als Kommentar zu dem Video gepostet.
+Etwa hundert User hatten Erster als Kommentar zu dem Video gepostet.
 In Anbetracht des Alkoholpegels verlief die Diskussion auf sehr hohem Niveau.
 Nun überhole den Schleicher endlich.
 Elektrische Fensterheber funktionieren nur, wenn die Zündung an ist.
@@ -1224,7 +1224,7 @@ Es ist nicht leicht, mit fünf Kindern über die Runden zu kommen.
 Astrid fürchtet um ihren Job.
 Derzeit zerbrechen in meinem Freundeskreis überall Beziehungen.
 Peinlich berührt blickte er zu Boden.
-"Ich habe ihn umgebracht", gestand er mit gesenktem Blick.
+Ich habe ihn umgebracht, gestand er mit gesenktem Blick.
 Sonja errötete vor Scham.
 Am liebsten würde sie im Boden versinken.
 Meike hatte ihr von Anfang an davon abgeraten.
@@ -1269,7 +1269,7 @@ Lügendetektoren lassen viel mehr Interpretationsspielraum zu, als man allgemein
 Gehen wir nochmal alles durch.
 Hätte das nicht auffallen müssen?
 Satz mit X, das war wohl nix.
-Regeln wie "Frauen und Kinder zuerst" sind auch nicht mehr zeitgemäß.
+Regeln wie Frauen und Kinder zuerst sind auch nicht mehr zeitgemäß.
 Nicht schon wieder eine Sexismus-Debatte!
 Ich erwarte gar kein Mitleid, aber ich möchte, dass du mich verstehst.
 Woher wussten Sie von dem Plan?
@@ -1285,7 +1285,7 @@ Sein Lebensmotto war: Sicherungen sind Evolutionsbremsen.
 Kaum ist Weihnachten vorbei, nehmen die Supermärkte bereits Osterdekoration in ihr Sortiment auf.
 Als es im späten September noch einmal richtig warm wurde, schmolzen die Weihnachtsmänner aus Schokolade in den Regalen.
 Wer etwas dagegen einzuwenden hat, möge jetzt das Wort ergreifen oder ewig schweigen.
-"Fürchtet euch nicht", sprach der Bengel und griff an.
+Fürchtet euch nicht, sprach der Bengel und griff an.
 Das ist ein Hinterhalt.
 Hannelore isst kein Nutella mehr, denn es enthält Palmöl.
 Verzichten muss sie trotzdem nicht.
@@ -1385,8 +1385,8 @@ Die Südseite des Bürogebäudes ist komplett verglast.
 Hin und wieder verenden Vögel, weil sie die Reflexion für den echten Himmel halten.
 Die Kollision mit der Fensterscheibe hat meist schwere Verletzungen zur Folge.
 Ein flugunfähiger Vogel ist Fressfeinden, wie zum Beispiel Katzen, hilflos ausgeliefert.
-"Ich bin doch nicht blöd", antwortete der Alte und wusste nicht, ob er beleidigt sein sollte.
-"Lassen Sie den Jungen in Ruhe", knurrte ich den Fremden an.
+Ich bin doch nicht blöd, antwortete der Alte und wusste nicht, ob er beleidigt sein sollte.
+Lassen Sie den Jungen in Ruhe, knurrte ich den Fremden an.
 Um der Verwendung Ihrer Daten zu Werbezwecken zu widersprechen, genügt eine formlose Mail.
 Gegen eine Gruppe von drei Erwachsenen, die noch dazu bewaffnet sind, hat man als einzelner keine Chance.
 Da muss man sich nichts vormachen.
@@ -1416,7 +1416,7 @@ Da kann man nur den Hut ziehen.
 Der japanische Staatsgast deutete eine Verbeugung an.
 Tausende sind heute auf die Straße gegangen, um entweder für oder gegen die Homoehe zu demonstrieren.
 Wer nicht mitgeholfen hat, darf anschließend auch nicht meckern.
-Tatsächlich ist "der Krake" korrekt, auch wenn das Substantiv umgangssprachlich feminin verwendet wird.
+Tatsächlich ist der Krake korrekt, auch wenn das Substantiv umgangssprachlich feminin verwendet wird.
 Steht so im Duden.
 Legen Sie nun die zweite CD ein.
 Auch die CD ist ein digitaler Datenträger.
@@ -1466,12 +1466,12 @@ Im ganzen Norden haben wir derzeit Temperaturen nahe dem Gefrierpunkt.
 Es ist mit Eis und Glätte zu rechnen, fahren Sie daher besonders vorsichtig.
 Das war der NDR-zwei Verkehrsservice.
 Kommen Sie wie immer gut und sicher ans Ziel.
-"Ich weiß gar nicht, wie man die Nebelschlussleuchte einschaltet", gab Hanna zu.
+Ich weiß gar nicht, wie man die Nebelschlussleuchte einschaltet, gab Hanna zu.
 Nur Warengruppe eins ist rabattfähig.
 Wenn die Lok hinter den Waggons fährt, handelt es sich genau genommen nicht mehr um einen Zug sondern um einen Schub.
 Auf dem Pannenstreifen steht ein defekter LKW.
 Wenn man Gegenstände auf die Lüftungsschlitze von elektrischen Geräten stellt, kann es passieren, dass diese überhitzen.
-"Vier-K-Displays sind genauer als meine Augen", stellt Christian fest.
+Vier-K-Displays sind genauer als meine Augen, stellt Christian fest.
 Sport ist Mord, aber Sportler scheinen viele Leben zu haben.
 Die Berichterstattung ist zwar nicht falsch aber unausgewogen.
 Das wäre wie ein Sechser im Lotto.
@@ -1489,11 +1489,11 @@ Meine Hose rutscht.
 Die linke Wange prägte ein Muttermal.
 Sie hatte blaue Augen, wobei der dunkle Lidstrich auffiel.
 Bea braucht mal wieder eine halbe Stunde, um sich zu schminken.
-"Dein Lippenstift färbt ab", beklagte sich Johannes.
+Dein Lippenstift färbt ab, beklagte sich Johannes.
 Welches Parfüm benutzt du?
 Was soll an dicken Lippen schön sein?
 Jetzt kommt Werbung.
-"Ich bräuchte eine Handcreme gegen trockene Haut", erklärte Simone ihr Anliegen.
+Ich bräuchte eine Handcreme gegen trockene Haut, erklärte Simone ihr Anliegen.
 Haben Sie schon unser neuestes Puder ausprobiert?
 Haben wir Puderzucker auf Vorrat?
 Kosmetik ist im Grunde genau so unnötig wie Werbung, weil sie ja eine Form der Werbung ist.
@@ -1620,11 +1620,11 @@ Man merkt dem Forum an, dass Freitag ist.
 Ja, welches Forum meine ich wohl?
 Trolle füttert man mit Fischen oder Keksen.
 Der Verkäufer blickte mich skeptisch an.
-"Was haben Sie denn damit vor?", wollte er wissen.
-"Ich baue eine Machtübernahmemaschine", antwortete ich unverzüglich.
+Was haben Sie denn damit vor?, wollte er wissen.
+Ich baue eine Machtübernahmemaschine, antwortete ich unverzüglich.
 Aber psst, das ist geheim.
-"Jetzt nicht mehr", erwiderte er und griff zum Telefonhörer.
-"Sie werden doch nicht etwa", setzte ich zum Protest an, doch es war bereits zu spät.
+Jetzt nicht mehr, erwiderte er und griff zum Telefonhörer.
+Sie werden doch nicht etwa, setzte ich zum Protest an, doch es war bereits zu spät.
 Buchhandlung Lupe hier, schönen guten Tag.
 Geben Sie mir bitte den Präsidenten, wir haben ein dysfunktionales Strukturfabrikat der Pflegestufe drei.
 Einen Moment lang sagte er nichts, dabei machte sich Verwunderung auf seinem Gesicht breit.
@@ -1634,22 +1634,22 @@ Ich packte ihn am Kragen.
 Nennen Sie mir einen Grund, warum ich Sie am Leben lassen sollte.
 Wir sind hier allein.
 Niemand wird Ihre Hilfeschreie hören.
-"Ich, ich kann Ihnen helfen", bot er kleinlaut an.
+Ich, ich kann Ihnen helfen, bot er kleinlaut an.
 Das ist schließlich mein Beruf.
-"Mit solchen Maschinen kenne ich mich zufällig aus, ich habe nämlich auch schon einmal", fuhr er fort.
+Mit solchen Maschinen kenne ich mich zufällig aus, ich habe nämlich auch schon einmal, fuhr er fort.
 Doch dann flog die Tür auf und unterbrach ihn.
 Der Postbote stürmte herein, rannte so schnell er konnte zum Tresen und stellte ein Paket ab.
-"Expresslieferung", hechelte er, völlig außer Atem.
+Expresslieferung, hechelte er, völlig außer Atem.
 Wenn Sie hier kurz unterschreiben würden.
 Der Verkäufer kritzelte irgendwas auf das Gerät, dass ihm hingehalten wurde.
 Dann machte er dem Boten deutlich, dass er wieder verschwinden solle.
-"Schauen Sie, was in diesem Karton ist", ergriff der Buchhändler nun wieder das Wort.
+Schauen Sie, was in diesem Karton ist, ergriff der Buchhändler nun wieder das Wort.
 Das kommt sehr gelegen.
 Sie werden es brauchen.
 Gemeinsam rissen wir das Paket auf.
 Eingewickelt in Polstermaterial lagen drei Flaschen, gefüllt mit einer durchsichtigen Flüssigkeit, in dem Karton.
-"Das braucht man für die Maschine?", fragte ich ungläubig.
-"Allerdings", erklärte er mit bedeutungsvoller Miene.
+Das braucht man für die Maschine?, fragte ich ungläubig.
+Allerdings, erklärte er mit bedeutungsvoller Miene.
 Wenn man diese geheime Zutat weglässt, funktioniert es nicht.
 Dieser Fehler ist mir bei meinem letzten Versuch unterlaufen.
 Die Folge war eine schwere Verletzung und damit bin ich noch glimpflich davon gekommen.
@@ -1664,13 +1664,13 @@ Wütend riss ich ihm den Wälzer aus der Hand und schmetterte ihn an die Wand.
 Sie versuchen aber auch wirklich jede Situation zu nutzen, um Produkte an den Mann zu bringen, nicht wahr?
 Der Ladenbesitzer lief rot an, weil er merkte, dass er ertappt wurde.
 Unsere wirtschaftliche Situation ist derzeit wirklich schwierig, wissen Sie.
-"Ich werde keines Ihrer Drecksbücher kaufen", stellte ich klar.
+Ich werde keines Ihrer Drecksbücher kaufen, stellte ich klar.
 Kommen Sie zum Punkt.
 Wie heißt die Flüssigkeit?
-"Na gut", gab sich mein Gesprächspartner geschlagen.
+Na gut, gab sich mein Gesprächspartner geschlagen.
 Es handelt sich um Dihydrogenmonoxid.
 Man kann es in jeder Apotheke für etwa fünfundzwanzig Euro pro Liter kaufen.
-"Na also", nickte ich zufrieden.
+Na also, nickte ich zufrieden.
 Die Details interessieren mich nicht.
 Kein Wort zu niemandem, haben Sie verstanden?
 Gerade wollte ich eine Drohung aussprechen, da ging die Tür erneut auf und ein Kunde trat herein.
@@ -1680,7 +1680,7 @@ Eine Lüge wird auch dann nicht wahr, wenn man sie oft wiederholt.
 Ziemlich viel Aufwand für ein kleines Geschenk, finden Sie nicht?
 Bartstoppeln sind wirklich praktisch, wenn man sich mal kurz kratzen muss.
 Das Problem ist bekannt, nur über Ausmaß und Relevanz herrscht Uneinigkeit.
-"Christine hat ein viel größeres Planschbecken", erzählt Marie.
+Christine hat ein viel größeres Planschbecken, erzählt Marie.
 Die Beeren sind noch nicht reif.
 Viele Früchte werden unreif geerntet und reifen während des Transportes nach.
 Wenn dir langweilig ist, kannst du mal in den Garten gehen und Johannisbeeren pflücken.
@@ -1692,7 +1692,7 @@ Sven hat eine Eichel gefunden.
 Schau mal, dort liegen noch mehr.
 Auch ein kleiner Funken kann einen großen Brand entfachen.
 Das Orakel hatte in Gleichnissen gesprochen.
-"Meine Lieblingsfarbe ist schwarz", sagte Lola.
+Meine Lieblingsfarbe ist schwarz, sagte Lola.
 Schwarz wie meine Seele.
 Das Bleichgesicht lügt!
 Unsere Haut ist verschieden, doch unser Blut ist rot und unsere Lungen sind schwarz.
@@ -1705,7 +1705,7 @@ Der Medizinmann stand im Mittelpunkt des Geschehens.
 Woran denkst du, wenn du einschläfst?
 Du meinst wohl an wen?
 Von mir aus auch das.
-"Ich bin platt wie eine Flunder", stieß Markus erschöpft aus und ließ sich aufs Sofa fallen.
+Ich bin platt wie eine Flunder, stieß Markus erschöpft aus und ließ sich aufs Sofa fallen.
 Die Paketverwaltung hat eine zyklische Abhängigkeit entdeckt.
 Der Weihnachtsmann holte ein weiteres Geschenk aus seinem Sack und wandte sich an Florian.
 Wart ihr auch immer alle schön brav?
@@ -1747,7 +1747,7 @@ Auf diese Weise hat schon der eine oder andere Handwerker einen Daumen verloren.
 Wir haben die Bullen im Nacken.
 Mit der Tabulatortaste wird die Autovervollständigung aktiviert.
 Das spart viel Tipparbeit.
-"Guten Morgen, Frau Schäfer", raunte die ganze Klasse wenig motiviert im Chor.
+Guten Morgen, Frau Schäfer, raunte die ganze Klasse wenig motiviert im Chor.
 Zur morgendlichen Begrüßung ließ die Lehrerin immer alle aufstehen.
 Menschen sind schlechte Zufallsgeneratoren.
 Es ist wahnsinnig schwierig, sich nicht nach irgendeinem Muster zu verhalten.
@@ -1780,9 +1780,9 @@ Beate denkt inzwischen ernsthaft über eine Scheidung nach.
 Vielleicht wäre es für alle das Beste.
 Du bist die letzte, die Schuldgefühle haben sollte.
 Aaron wollte den anderen nicht die gute Laune verderben.
-"Ich muss mal wieder zum Frisör", bekundete Lars selbstkritisch nach einem Blick in den Spiegel.
+Ich muss mal wieder zum Frisör, bekundete Lars selbstkritisch nach einem Blick in den Spiegel.
 Der Kopf war an den Seiten kahl geschoren, die anderen Haare waren dafür umso länger.
-"In meinen Augen ist Gustav vom Scheitel bis zur Sohle ein frommer Christ", urteilte Pastor Sigmund.
+In meinen Augen ist Gustav vom Scheitel bis zur Sohle ein frommer Christ, urteilte Pastor Sigmund.
 Soll ich Ihnen etwas Gel in die Haare machen?
 Benjamin schüttelte energisch den Kopf.
 Da sie die Hände nicht frei hatte, versuchte Zora sich die Haare aus dem Gesicht zu pusten.
@@ -1854,23 +1854,23 @@ Eigentlich sind das keine Kabelschellen, sondern Kabelbinder.
 Der Pillendreher ist ein Käfer, der für seine Körpergröße riesige Kugeln hinter sich her rollt.
 Keine Ahnung, wie ich jetzt darauf komme.
 An seinem Sicherungsgurt hatte der Kletterer mehrere Karabiner, um sich alle paar Meter einhaken zu können.
-"Ich finde, das sieht bescheuert aus", äußerte sich jetzt Steven, der bisher noch gar nichts gesagt hatte.
+Ich finde, das sieht bescheuert aus, äußerte sich jetzt Steven, der bisher noch gar nichts gesagt hatte.
 Wenn Sie sich schon betrinken müssen, dann tun Sie das wenigstens mit einem Wein, den Sie sich leisten können.
 Verärgert nahm Heidi dem Mann die edle Flasche aus der Hand.
-"Sprechen Sie nicht von oben herab zu mir", lallte dieser.
+Sprechen Sie nicht von oben herab zu mir, lallte dieser.
 Ich bin nicht der Penner, für den Sie mich halten.
 Mir gehört der Laden quasi.
 Arno nahm die Artikel aus dem Einkaufswagen und verstaute sie in seinem Rucksack.
 Dann prüfte er noch den Bon.
 Dort stand: Sie sind unser hunderttausendster Kunde.
 Lösen Sie einfach den unten stehenden Gewinncode ein und freuen Sie sich auf einen Karibikurlaub.
-"Gut, dass ich den Beleg nicht weggeworfen habe", schmunzelte er in sich hinein.
+Gut, dass ich den Beleg nicht weggeworfen habe, schmunzelte er in sich hinein.
 Wahrscheinlich ist es Kalkül, dass die meisten die Quittung gar nicht lesen.
 Während er in Gedanken bereits die Reisetasche packte, verließ er das Geschäft.
 Am Ausgang ertönte plötzlich die Alarmanlage und Arno blieb verdutzt stehen.
 Er hatte doch überhaupt nichts geklaut.
 Außerdem klang der Alarm irgendwie nach … Wecker!
-"Ah!", stöhnte er und schlug auf das lärmende Gerät neben seinem Bett.
+Ah!, stöhnte er und schlug auf das lärmende Gerät neben seinem Bett.
 Auf dem Ziffernblatt stand fünf Uhr zwei.
 Das heißt, er hatte zwei Minuten gebraucht, um wach zu werden.
 Das ist eigentlich ungewöhnlich, denn aus dem REM-Schlaf wacht man vergleichsweise schnell auf.
@@ -1885,11 +1885,11 @@ Mein Urgroßvater stammte von einem einflussreichen Adelsgeschlecht ab.
 Die Naht ist nicht gut geworden.
 Wer billig kauft, kauft zweimal.
 Das hat schon meine Urgroßmutter gesagt.
-"Ich will kein Model, sondern ein normales Mädel als Freundin", sagt Tim.
+Ich will kein Model, sondern ein normales Mädel als Freundin, sagt Tim.
 Wer Unzufriedenheit ausstrahlt, wirkt auf andere unattraktiv.
 Von den Medien propagierten Schönheitsidealen nachzueifern macht unzufrieden.
 Mein Waffeleisen produziert Waffeln in Herzchenform.
-"Das ist sehr nett, aber mein Herz ist leider schon vergeben", bedauerte Simone.
+Das ist sehr nett, aber mein Herz ist leider schon vergeben, bedauerte Simone.
 Diese Prozedur muss auf Herz und Nieren getestet werden.
 Leber und Nieren tragen wesentlich zur Entgiftung des Blutes bei.
 Georg bestreicht eine Brötchenhälfte mit Leberwurst und die andere mit Marmelade.
@@ -1909,10 +1909,10 @@ Wer an Lungenkrebs stirbt, hat sich diese Form des Todes meistens vorher ausgesu
 Rauchern Krankenkassenleistungen zu kürzen wäre der erste Schritt zur Abschaffung des Solidaritätsprinzips.
 Vielleicht wäre es aber auch der zehnte.
 Der Kampfhund fletschte angriffslustig seine Zähne.
-"Wartet auf uns!", brüllte Christoph aus voller Kehle.
-"Wir müssen intubieren", meinte der Notfallsanitäter zu seiner Kollegin.
+Wartet auf uns!, brüllte Christoph aus voller Kehle.
+Wir müssen intubieren, meinte der Notfallsanitäter zu seiner Kollegin.
 Auf dem MRT kann man den Hirntumor sehen.
-"Jetzt müssen wir mal unsere grauen Zellen anstrengen", sagte Anton und kratzte sich am Kopf.
+Jetzt müssen wir mal unsere grauen Zellen anstrengen, sagte Anton und kratzte sich am Kopf.
 Einen Energieverbraucher wie das Gehirn kann sich nur leisten, wessen Nahrungsversorgung sichergestellt ist.
 Gleichzeitig ermöglichte das Gehirn die geplante Beschaffung von Nahrung.
 Energie wird niemals verbraucht, höchstens umgewandelt.
@@ -2025,7 +2025,7 @@ Ausgerechnet diese Nacht haben wir Neumond.
 Der Treiber hält sich strikt an die OpenGL-Spezifikation.
 Es liegt in Ihrem Ermessen, wie Sie die Regeln auslegen.
 Eine gute Spezifikation lässt keinen Spielraum für Interpretationen.
-"Das ist eine echte Dampflok", staunte Pit.
+Das ist eine echte Dampflok, staunte Pit.
 Hauke nimmt zum ersten Mal an der Schauspiel-AG teil.
 Es ist ein Kompromiss zwischen hohem Durchsatz und geringer Latenz.
 Lydia sitzt schon den ganzen Tag vor dem Fernseher.
@@ -2035,7 +2035,7 @@ Haben Sie schon versucht, das Gerät aus- und wieder einzuschalten?
 Wer ist die entzückende Begleitung an deiner Seite?
 Fabian kann so viele Stimmen imitieren, dass es eine Freude ist, ihm beim Vorlesen zuzuhören.
 Durch seine glaubhafte Betonung haucht er den Geschichten Leben ein.
-"Da steht ein Einbrecher auf dem Balkon", flüsterte sie ängstlich in mein Ohr.
+Da steht ein Einbrecher auf dem Balkon, flüsterte sie ängstlich in mein Ohr.
 Kettenfahrzeuge fahren Kurven, indem sie die Ketten unterschiedlich schnell laufen lassen.
 Du sprichst mir aus der Seele.
 Hört euch die weisen Worte meines Freundes Leon an!
@@ -2047,7 +2047,7 @@ Viktor will sich das Gelaber nicht länger anhören.
 Das Testergebnis war negativ.
 Die Gegenhypothese kann nicht widerlegt werden.
 Frank ist mit der Gesamtsituation unzufrieden.
-"Kreative Köpfe wie dich brauchen wir", ermutigte Anja ihn.
+Kreative Köpfe wie dich brauchen wir, ermutigte Anja ihn.
 Wohnst du etwa noch bei deinen Eltern?
 Kleinvieh macht auch Mist.
 Langsam begriff der Autor, dass es zu einer Sprache beinahe so viele Redewendungen wie Vokabeln gibt.
@@ -2064,7 +2064,7 @@ Zwei der Satelliten sind leider nicht auf der vorgesehenen Umlaufbahn.
 Friederike hatte das Fieberthermometer schon in der Hand.
 Bist du mir jetzt böse?
 Und noch ein Satz.
-"Der jedoch keiner ist, weil ihm das Prädikat fehlt", korrigiert mich der Besserwisser.
+Der jedoch keiner ist, weil ihm das Prädikat fehlt, korrigiert mich der Besserwisser.
 Weil die Liegezeiten extrem teuer sind, werden die Schiffe tags und nachts von Kränen beladen.
 Der Hafen bietet mit all seinen Lichtern einen einzigartigen Anblick bei Nacht.
 Ich muss offen zugeben, dass ich kein Fan von diesem Finanzierungsmodell bin.
@@ -2073,7 +2073,7 @@ Die Spinne hat mehr Angst vor dir als du vor ihr.
 Der Drucker zeigt an, dass die Farbe Magenta nachgefüllt werden muss.
 Hast du noch eine Ersatzpatrone?
 Wegen des Kopierschutzes ließ sich die Blu-ray nicht abspielen.
-"Wenn sich Netflix nur mit proprietärer Software nutzen lässt, dann eben ohne mich", sagt Hannes trotzig.
+Wenn sich Netflix nur mit proprietärer Software nutzen lässt, dann eben ohne mich, sagt Hannes trotzig.
 Bei variabler Bitrate geht immer die Synchronisation zwischen Audio und Untertiteln verloren.
 Bitte nicht stören!
 Die Täterin wurde offenbar unterbrochen.
@@ -2205,7 +2205,7 @@ Um Verluste durch Wirbelströme zu vermeiden, ist der Eisenkern des Transformato
 Ist diese Technik nicht geil?
 Ja, aber jener Gleichstrommotor ist nicht bürstenlos.
 In der Fabrik muss jeglicher Funkenflug unbedingt vermieden werden.
-"Das hört sich nach einem Schaden im Kugellager an", schätzte Aaron und kratzte sich am Kinn.
+Das hört sich nach einem Schaden im Kugellager an, schätzte Aaron und kratzte sich am Kinn.
 Auf Boje einhundertneunundvierzig ist ein Sensor ausgefallen.
 Wir schicken sofort ein Team zur Reparatur los.
 Eltern haften für ihre Kinder.
@@ -2224,7 +2224,7 @@ Der typische Chlorgeruch entsteht erst dann, wenn Badegäste ins Becken pinkeln.
 Corinna fühlt sich vom Xenon-Licht geblendet.
 Uran-zweihundertfünfunddreißig hat eine Halbwertszeit von über siebenhundert Millionen Jahren.
 Dem Schurkenstaat ist es offenbar gelungen, waffenfähiges Plutonium anzureichern.
-Seine SMS an Katrin beendet Sören immer mit einem vielsagenden "hdgdl".
+Seine SMS an Katrin beendet Sören immer mit einem vielsagenden hdgdl.
 Laura kreischte entsetzt, als ihr aus der Toilette eine Ratte entgegenkam.
 Der Dealer hat das Heroin mit Rattengift gestreckt.
 Uns fehlen genaue Informationen zur Sachlage.
@@ -2239,7 +2239,7 @@ Die empirisch erhobenen Daten lassen eine solche Schlussfolgerung nicht zu.
 Am Ende scheitert es am Geld.
 Das hat die Kommission so entschieden.
 Dieses Exemplar zeigt bereits Resistenzen gegen drei der sieben Wirkstoffe.
-"Ich denke das Risiko können wir in Kauf nehmen", urteilte Ulrike.
+Ich denke das Risiko können wir in Kauf nehmen, urteilte Ulrike.
 Die Ausstellung besteht im Wesentlichen aus ausgestopften Tieren.
 Den Aspekt hat man bei der Planung einfach ignoriert.
 Guter Einwand, Ulrich.
@@ -2395,7 +2395,7 @@ Lass dich nicht provozieren.
 Spiel dich nicht so auf.
 Gelinde gesagt hat Gerlinde versagt.
 Am einfachsten löst man das Problem, indem man es in mehrere kleine Teilprobleme spaltet.
-Das Prinzip heißt "teile und herrsche".
+Das Prinzip heißt teile und herrsche.
 Die Milch ist schon vor einer Woche abgelaufen.
 Ich würde das nicht mehr trinken.
 Drum esse jeder was er kann, nur nicht seinen Nebenmann.
@@ -2450,8 +2450,8 @@ Weißt du, was zu tun ist?
 Marcel ist gut in Informatik.
 Der Zaubertrank macht dich für fünfzehn Sekunden unbesiegbar.
 Lou konnte sich gar nicht wieder einkriegen.
-"Ich habe dem Tod schon mehrfach ins Auge gesehen", leitete Holger zu seinen Heldenstorys über.
-"Was für ein Angeber", dachte Horst im Stillen.
+Ich habe dem Tod schon mehrfach ins Auge gesehen, leitete Holger zu seinen Heldenstorys über.
+Was für ein Angeber, dachte Horst im Stillen.
 Das Bauteil hat sich plastisch verformt.
 Das ist doch hervorragend!
 Es ist ein Wunder, dass nichts passiert ist.
@@ -2482,7 +2482,7 @@ Haben Sie das Vorfahrtsschild nicht gesehen?
 Hier gilt rechts vor links.
 Empfindest du denn auch etwas für sie?
 Der Konzern ist gigantisch.
-"Das versteht sich ja von selbst", kommentiert Norbert.
+Das versteht sich ja von selbst, kommentiert Norbert.
 Und dann haben wir, ich sag mal, ein paar Nettigkeiten ausgetauscht.
 Schon gut, mehr wollte ich gar nicht.
 Sie wollten eine bescheidene Hütte aufstellen und jetzt haben Sie einen Tempel errichtet!
@@ -2504,11 +2504,11 @@ Ich glaube, ich bin im falschen Film.
 Da hilft nur Augen zu machen und immer nach vorne blicken.
 Drück mal auf die Tube.
 Mit Vollgas donnerten die beiden Verrückten auf die Spielstraße zu.
-"Wir beschreiben die Verformung gegenüber der kanonischen Repräsentation mit einem Tensorfeld", erklärte Ulla.
+Wir beschreiben die Verformung gegenüber der kanonischen Repräsentation mit einem Tensorfeld, erklärte Ulla.
 Andrea ist alleinerziehende Mutter von zwei Kindern.
 Gibt es dafür eine politisch korrekte Bezeichnung?
 Den Freistoß hat er völlig versemmelt.
-"Mit eurer Gleichgültigkeit habt ihr uns das alles erst eingebrockt", schimpfte Timo.
+Mit eurer Gleichgültigkeit habt ihr uns das alles erst eingebrockt, schimpfte Timo.
 Albert ist ein genialer Erfinder.
 Früh wie jeden Morgen ging Bettina mit ihrem Bernhardiner Gassi.
 Weil er nichts besseres zu tun hat, poliert Herr Schröder schon wieder sein Auto.
@@ -2577,7 +2577,7 @@ Ohne Fleiß kein Preis.
 Ein Greis stolperte über das Gleis.
 Was ist mit deiner Dienstuniform?
 Wie wäre es mit einem Kompromiss?
-"Ich weiß, wo ein Schatz versteckt ist", flüsterte mir mein Mithäftling ins Ohr.
+Ich weiß, wo ein Schatz versteckt ist, flüsterte mir mein Mithäftling ins Ohr.
 Ich bin unermesslich reich.
 Dieser einzelne Diamant ist so kostbar wie dreiundvierzig Goldbarren.
 Dr. Schneider träumt davon, eine eigene Praxis zu eröffnen, doch noch fehlt ihm das nötige Kapital.
@@ -2613,8 +2613,8 @@ Benzin oder Selbstzünder?
 Der Pressesprecher sprach von bedauernswerten Einzelfällen.
 Jetzt sind wir an dem Punkt angelangt, wo es sich nicht mehr rentiert.
 Mit einer historischen Wasserstoffexplosion war die Ära der Luftschiffe beendet.
-"Seriöse Aussagen können wir zu diesem Zeitpunkt noch nicht treffen", konstatierte Tom.
-"Daran kann ich beim besten Willen keinen Gefallen finden", sagte Silja mit einem ernsten Gesichtsausdruck.
+Seriöse Aussagen können wir zu diesem Zeitpunkt noch nicht treffen, konstatierte Tom.
+Daran kann ich beim besten Willen keinen Gefallen finden, sagte Silja mit einem ernsten Gesichtsausdruck.
 Zu Ihren Stärken gehören Teamfähigkeit und Durchsetzungsvermögen.
 Mit Essen spielt man nicht.
 Diese Kaminstreichhölzer sind überaus praktisch, auch für Kerzen im Glas.
@@ -2637,12 +2637,12 @@ Der Regen prasselte auf das Zelt und erzeugte eine einzigartige Atmosphäre im I
 Seit Gerda gegangen ist, fühlt Uwe sich einsam.
 Hast du das ganz alleine gemacht?
 Es war Pia, die den Druck abgelassen hatte.
-"Brauche ich heute einen Regenschirm?", fragte Theodora ihren digitalen Assistenten.
+Brauche ich heute einen Regenschirm?, fragte Theodora ihren digitalen Assistenten.
 Welche Termine liegen nächste Woche an?
 Der Termin am Donnerstag wurde unverbindlich vorgemerkt.
 Dann warf Theresa einen Blick auf den Kalender.
 Nach ein wenig Säbelrasseln wird sich die Lage wieder entspannen.
-"Na gut, wir kämpfen mit den Fäusten", stimmte der Ritter zu und steckte das Schwert wieder in die Scheide.
+Na gut, wir kämpfen mit den Fäusten, stimmte der Ritter zu und steckte das Schwert wieder in die Scheide.
 Die Rüstung schepperte blechern.
 Ein Bogenschütze hatte ihn bereits im Visier.
 Mit der rechten Maustaste kannst du Kimme und Korn benutzen.
@@ -2667,7 +2667,7 @@ Es bestand noch ein letzter Funken Hoffnung.
 Uwe holt die Fliegenklatsche.
 Der Typ hat doch einen an der Klatsche!
 Sag Fridolin und all den anderen Spinnern, dass sie das alleine machen müssen.
-"Ralf ist ein alter Knacker", sprach Clemens wenig respektvoll.
+Ralf ist ein alter Knacker, sprach Clemens wenig respektvoll.
 Karla machte eine vorwurfsvolle Miene.
 Sie fand das Gemälde irgendwie unästhetisch.
 Was ist denn alles im Museum ausgestellt?
@@ -2684,9 +2684,9 @@ Bernd ist mit ein paar Freunden zum Minigolfspielen verabredet.
 Treffpunkt ist die Sporthalle auf der Nordseite.
 Gaby suchte ausgiebig einen Schattenparkplatz.
 Dennoch sind die Maßnahmen nur ein Tropfen auf den heißen Stein.
-"Ihr seid alle eingeladen", verkündete Ralf mit einem Lächeln.
+Ihr seid alle eingeladen, verkündete Ralf mit einem Lächeln.
 Die Forscher berichten von steigender seismischer Aktivität in der abgesperrten Zone.
-"Hat jemand eine violette Haarspange gesehen?", fragt Elli in die Runde.
+Hat jemand eine violette Haarspange gesehen?, fragt Elli in die Runde.
 Schließlich begaben sich Finja und Gaby gemeinsam zum Fundbüro.
 Wow, schau dir mal den Skater mit dem Basecap an!
 Erst jetzt wurde ihr klar, wie wertvoll das Geschenk von Henrik eigentlich gewesen war.
@@ -2694,12 +2694,12 @@ Diese Schreibweise ist mir neu.
 Angewidert wich sie zurück.
 Mitten in dem dicht besiedelten Stadtviertel musste eine Bombe aus dem Zweiten Weltkrieg entschärft werden.
 Die Betroffenen wurden mit Bussen in Notunterkünfte gebracht.
-"Das kann kein Dauerzustand sein", stellte ein Sprecher vor laufenden Kameras klar.
+Das kann kein Dauerzustand sein, stellte ein Sprecher vor laufenden Kameras klar.
 Insgeheim wusste er natürlich, dass es nicht anders ging.
 Er legte seinen Strahlenschutzanzug an und nahm den Geigerzähler aus seiner Tasche.
-"Kann mich jemand hören?", sprach er in sein Funkgerät.
-"Lass mal den Profi ran", kommandierte Lennart in einem ironischen Tonfall.
-"Und wer muss es am Ende wieder reparieren?", fragt Robert, obwohl er die Antwort natürlich schon weiß.
+Kann mich jemand hören?, sprach er in sein Funkgerät.
+Lass mal den Profi ran, kommandierte Lennart in einem ironischen Tonfall.
+Und wer muss es am Ende wieder reparieren?, fragt Robert, obwohl er die Antwort natürlich schon weiß.
 Das ist eine rhetorische Frage, oder?
 Er zückte seine Kamera und hielt die Bildschirmausgabe auf einem Foto fest.
 Erwin möchte von Freitag auf Samstag bei Peer übernachten.
@@ -2721,7 +2721,7 @@ Die Füllhöhe kann transportbedingt schwanken.
 Vertrauen ist gut, Kontrolle ist besser.
 Offenbar erwarten die Aktionäre ein dickes Umsatzplus im nächsten Quartal.
 Und nun schalten wir wieder zu unserem Korrespondenten an der Börse in Frankfurt.
-"Ich kann mich noch immer nicht zwischen Volvo und VW entscheiden", seufzt Gernot.
+Ich kann mich noch immer nicht zwischen Volvo und VW entscheiden, seufzt Gernot.
 Manchmal ist irgendeine Entscheidung besser als gar keine Entscheidung.
 Wer nicht selbst entscheidet, für den entscheiden andere.
 Keine Antwort ist auch eine Antwort.
@@ -2731,7 +2731,7 @@ Einhundert Dezibel, das ist so laut wie ein Presslufthammer.
 Es kommt auf die Entfernung an.
 Das Mädchen in dem lilanen Kleid heißt Annika.
 Patrick jobbt nachts an einer Tankstelle.
-"Hast du noch Kontakt zu Mandy?", erkundigte sich Sebastian.
+Hast du noch Kontakt zu Mandy?, erkundigte sich Sebastian.
 Jule studiert Jura im vierten Semester.
 Ich glaube, Patrick hat sich in Michelle verknallt.
 Sie ist voll verliebt in Bodo.
@@ -2756,10 +2756,10 @@ Kommst du auch zur Party bei Jule?
 Davon wusste ich noch gar nichts.
 Nur der Gastgeber hat das Recht, weitere Leute einzuladen.
 Anne hat keine Manieren.
-"Du solltest nicht so viel über andere lästern", sagt Rudolf zu Moni.
-"Vielleicht kann Hannelore euch beraten", schlug Marius vor.
+Du solltest nicht so viel über andere lästern, sagt Rudolf zu Moni.
+Vielleicht kann Hannelore euch beraten, schlug Marius vor.
 Christian stimmte als einziger dagegen.
-"Benimm dich anständig!", mahnte Christiane an.
+Benimm dich anständig!, mahnte Christiane an.
 Jetzt muss Justin doch eine Ermahnung aussprechen.
 Was geht ab?
 Chantal hat bereits große Fortschritte am Keyboard gemacht.
@@ -2770,14 +2770,14 @@ Die dümmsten Fragen kommen mal wieder von den Lehrämtlern, die sich als schlec
 Hat euch mal jemand gesagt, dass ihr unglaublich mitteilungsbedürftig seid?
 Ich wische jetzt die Tafel, währenddessen könnt ihr reden.
 Sobald sich der Dozent zur Tafel dreht, geht das Geplapper los.
-"Papperlapapp!", widersprach Elke.
+Papperlapapp!, widersprach Elke.
 Noch im Bademantel schlurfte er zum Kühlschrank und griff sich einen Jogurt.
 Verschlafen rieb er sich die Augen.
 Auf einem Teller, den niemand weggeräumt hatte, lagen die stinkenden Gräten vom Vorabend.
 Christopher sieht sich in seiner Ehre verletzt.
 Auf dem Weg zum Vollbart gibt es eine Phase, in der es höllisch juckt.
 Das musst du aushalten.
-"Nach zwei Wochen ist es vorbei", versprach Christoph.
+Nach zwei Wochen ist es vorbei, versprach Christoph.
 Alexandra hört das Lied seit zwei Stunden in Dauerschleife.
 Hast du schon dein Seepferdchen gemacht, Alex?
 Wenn auf Bilderkennung trainierte, neuronale Netze träumen, erzeugen sie kunstvolle Bilder.
@@ -2794,7 +2794,7 @@ Lichtquellen mit hoher Farbtemperatur werden allgemein als kalt empfunden.
 Die Beleuchtung ist mir zu grell.
 Es empfiehlt sich, beim Beenden des Browsers alle Cookies zu löschen.
 Wie kannst du bei so vielen Tabs die Übersicht behalten?
-"Bemerkenswert", staunte Kurt.
+Bemerkenswert, staunte Kurt.
 Aus seinem Rucksack nahm er einen Adapter von HDMI auf DVI.
 Für den Beamer brauchen wir ein VGA-Kabel.
 Kann ich mir deinen Laserpointer ausleihen?
@@ -2803,7 +2803,7 @@ Es ist eine Lithium-Knopfzelle mit drei Volt.
 So eine müsste ich noch in Reserve haben.
 Mal sehen, was sie auf Lager hat.
 Die Schrift ist nur undeutlich zu erkennen.
-"Ich bin gerade voll im Workflow", teilte Alexandra mit.
+Ich bin gerade voll im Workflow, teilte Alexandra mit.
 MetaGer ist die wohl bekannteste deutsche Meta-Suchmaschine.
 Meta-Suchmaschinen bündeln die Ergebnisse mehrerer unabhängiger Suchmaschinen.
 Kupferdiebe hatten die Regenrinne fachmännisch demontiert.
@@ -2817,21 +2817,21 @@ Gerald kaute auf einem Stück Knorpel herum, bis er es schließlich ausspuckte.
 Bei ihren Ausführungen blieb Nadine relativ vage.
 Können Sie ein konkretes Beispiel nennen?
 Wir brauchen einen größeren Löffel.
-"Gewöhne dir endlich mal an, deinen Arbeitsplatz sauber und ordentlich zu hinterlassen", schnauzte Franz ihn an.
-"Nichts von dem, was du tust, hat Hand und Fuß", monierte Regina.
-"Konstruktive Kritik sieht anders aus", kritisierte Walter wenig konstruktiv.
+Gewöhne dir endlich mal an, deinen Arbeitsplatz sauber und ordentlich zu hinterlassen, schnauzte Franz ihn an.
+Nichts von dem, was du tust, hat Hand und Fuß, monierte Regina.
+Konstruktive Kritik sieht anders aus, kritisierte Walter wenig konstruktiv.
 Können Sie den Motor bitte für mich anlassen?
 Die alte Klapperkiste?
 Als Rainer den Posten übernahm, musste er erst einmal für Zucht und Ordnung sorgen.
 Alter, lass mich in Ruhe!
 Die Verbesserungsvorschläge sind für uns nur begrenzt brauchbar.
 Das ist nicht übertragbar auf unser Problem.
-"Brauchen Sie Starthilfe?", bot Fritz hilfsbereit an.
+Brauchen Sie Starthilfe?, bot Fritz hilfsbereit an.
 Wo hat der seinen Führerschein gemacht?
 Dabei gehe ich immer ganz gerne chronologisch vor.
 Hast du eine bestimmte Reihenfolge, in der du das machst?
 Selina lebt hauptsächlich von BAföG.
-"Mann, geht mir das alles auf den Zeiger", brummte Fritz genervt.
+Mann, geht mir das alles auf den Zeiger, brummte Fritz genervt.
 Der große Durchbruch lässt weiterhin auf sich warten.
 Am Freitag will die Geschäftsführung Bilanz ziehen.
 Das Boot ist kurz vor dem Kentern.
@@ -2841,11 +2841,11 @@ Ich verstehe gar nicht, weshalb darum so ein Hype gemacht wird.
 Die Veranstaltung verursacht aus meiner Sicht zu viel Trubel.
 Lasst euch nichts aufschwatzen.
 Herrschaftszeiten, hier wird nicht geflucht!
-"Der einzige Lichtblick war das gute Essen", fand Judith.
+Der einzige Lichtblick war das gute Essen, fand Judith.
 Es ist bequem, sich immer in die Opferrolle zu begeben.
 Wissen wir schon, wer das Opfer ist?
 Ach, den kann ich ruhig opfern.
-"Eine Packung" ist keine geeignete Mengenangabe, wenn man ein Rezept weitergeben will.
+Eine Packung ist keine geeignete Mengenangabe, wenn man ein Rezept weitergeben will.
 Wir können jederzeit abbrechen.
 Ist sie nicht hübsch?
 Die Akquisition der Daten ist nur der erste Schritt.
@@ -2853,7 +2853,7 @@ Von Kreuzvalidierung hatte Brigitte vorher noch nie gehört.
 Er lügt, dass sich die Balken biegen.
 Wenn Angelika sich im Dunkeln kämmt, kann man Funken fliegen sehen.
 Toni reibt einen Luftballon an seinen Haaren, woraufhin ihm letztere zu Berge stehen.
-"Runter von meinem Baum", krächzte der Rabe.
+Runter von meinem Baum, krächzte der Rabe.
 Dieser Remix gefällt Gerald nicht so gut.
 Die Hellseherin warf einen Blick in die Kristallkugel.
 Das ist reine Kaffeesatzleserei.
@@ -2868,56 +2868,56 @@ Dürfen wir auch mit Filzstiften malen?
 Wer hat diese Zeichnung angefertigt?
 Christina muss einen Tunnelblick gehabt haben.
 Erwarten Sie von dem Hanf im Hanfbier keine berauschende Wirkung.
-"Wollen wir nicht ein Stück Sacher Torte essen, wenn wir schon einmal in Wien sind?", schlug Toni vor.
+Wollen wir nicht ein Stück Sacher Torte essen, wenn wir schon einmal in Wien sind?, schlug Toni vor.
 Das müssen wir feiern.
-"Stellst du die Musik bitte auf Zimmerlautstärke, Albert?", rief seine Mutter.
+Stellst du die Musik bitte auf Zimmerlautstärke, Albert?, rief seine Mutter.
 Der Krach ist ja nicht auszuhalten.
 Mit welchem Resultat?
 Der Trommler gefällt mir am besten.
 Beim Kauf der neuen Waschmaschine achtete Brigitte auf die Energieeffizienzklasse.
 Achim achtet neuerdings auf seine Ernährung.
-"Du hast es doch nicht etwa verschlampt?", hakte Adam nach.
+Du hast es doch nicht etwa verschlampt?, hakte Adam nach.
 Alwin, Nadja und Andrea spielen Verstecken.
 Wann wollte Natalie kommen?
 Doch Nele will sich nicht mit fremden Federn schmücken.
-"Das ist sehr ehrenwert", nickte Benny anerkennend.
+Das ist sehr ehrenwert, nickte Benny anerkennend.
 Mittlerweile ist das Erasmus-Programm dreißig Jahre alt.
 Waldemar zog den Stöpsel.
 Um schnell Muskeln aufzubauen, ernährt Willi sich übertrieben eiweißreich.
 Er ist ein richtiger Protein-Junkie.
-"Ist der Kaffee überhaupt noch warm?", erkundigt sich Daniel.
+Ist der Kaffee überhaupt noch warm?, erkundigt sich Daniel.
 Bruno steht auf Country-Musik.
 Nadja demonstriert ihre selbst erfundene Schlangenfalle.
-"Ich muss morgen früh aufstehen", entschuldigte sich Alwin.
+Ich muss morgen früh aufstehen, entschuldigte sich Alwin.
 Über das lange Wochenende planen Natalie und Benny das gesamte Obergeschoss zu renovieren.
-"Ob sie das schaffen werden?", stellt Waldemar das Vorhaben infrage.
+Ob sie das schaffen werden?, stellt Waldemar das Vorhaben infrage.
 Schöne Grüße von Bernhard!
-"Birnen habe ich leider gerade nicht da", bedauerte Bruno.
+Birnen habe ich leider gerade nicht da, bedauerte Bruno.
 Konstantin ist schon mit Konrad verabredet.
-"Erstellen Sie mir eine Kopie im DIN-A-drei Format", bat Guido seine Sekretärin.
-"Das muss ich unbedingt Simon zeigen", rief Heike aufgeregt.
-"Und damit sind wir auch schon am Ende der Sendung", leitete der Moderator zum nächsten Thema über.
+Erstellen Sie mir eine Kopie im DIN-A-drei Format, bat Guido seine Sekretärin.
+Das muss ich unbedingt Simon zeigen, rief Heike aufgeregt.
+Und damit sind wir auch schon am Ende der Sendung, leitete der Moderator zum nächsten Thema über.
 Zum Schluss noch eine Frage mit der Bitte um eine kurze und knackige Antwort.
 Unter der Bettdecke war es so schön warm und kuschelig, dass es Tobias schwer fiel aufzustehen.
 Als Heike das erste Mal in die Sauna ging, war sie völlig schockiert, dass dort alle nackig waren.
 Danielas BH passt optisch nicht zum Unterteil ihres Bikinis.
 Einen anderen hat sie nun mal nicht.
-"Die Zeit vergeht wie im Fluge", stellte Jasmin fest.
+Die Zeit vergeht wie im Fluge, stellte Jasmin fest.
 Nahe Lichtgeschwindigkeit verlangsamt sich die Zeit.
 Wenn Sie Hin- und Rückfahrt gleichzeitig buchen, erlassen wir Ihnen zehn Prozent der Kosten.
 Selbstverständlich übernehmen wir die Kosten für An- und Abfahrt.
 Der Versand findet nur innerhalb der EU und der Schweiz statt.
-"Dann lass uns das Meeting auf morgen verschieben", meint Marvin.
-"Das Event wird in Reutlingen stattfinden", gab Guido bekannt.
-"Ich kenne Klaas aber nur flüchtig", schränkte Tobias sogleich ein.
+Dann lass uns das Meeting auf morgen verschieben, meint Marvin.
+Das Event wird in Reutlingen stattfinden, gab Guido bekannt.
+Ich kenne Klaas aber nur flüchtig, schränkte Tobias sogleich ein.
 Nativ werden nur C und C-plus-plus unterstützt.
 Es gibt aber auch Portierungen auf Java und Python.
 Unsere Tiefkühltruhe hat die Energieeffizienzklasse A-plus-plus-plus.
-"Die Truhe müsste auch mal wieder abgetaut werden", seufzt Dietmar.
-"Den wievielten haben wir heute?", wollte Gerrit wissen.
+Die Truhe müsste auch mal wieder abgetaut werden, seufzt Dietmar.
+Den wievielten haben wir heute?, wollte Gerrit wissen.
 Die Stornogebühren sind unverschämt hoch.
 Heiner möchte den Flug stornieren.
-"Ich kann mich nicht einloggen", wendet sich Kai an den Administrator.
+Ich kann mich nicht einloggen, wendet sich Kai an den Administrator.
 Sie war stets bemüht, ihre Aufgaben in der vorgegebenen Zeit zu erledigen.
 Volker hat am vierzehnten März Geburtstag.
 Wie heißt eigentlich eine männliche Krankenschwester?
@@ -2926,16 +2926,16 @@ Wir müssen los.
 Ich bin dein größter Fan!
 Sei kein schlechtes Vorbild.
 Sei nicht so egoistisch!
-"Gut Ding will Weile haben", beschwichtigte Edmund.
+Gut Ding will Weile haben, beschwichtigte Edmund.
 Henning ist ein herzensguter Mensch.
 In ihrer Herzensgüte teilte Jasmin ihren Vorrat mit Konstantin.
-"Wenn meine Großeltern sich miteinander unterhalten, schnacken sie platt", berichtet Gerhard.
+Wenn meine Großeltern sich miteinander unterhalten, schnacken sie platt, berichtet Gerhard.
 Während des Konfirmationsunterrichts machten sich Melvin und Dominik die ganze Zeit über den Dialekt des Pfarrers lustig.
 Joachim lispelt etwas.
 Als Therapie gegen das Stottern hat die Ärztin Manuel empfohlen zu singen.
 Frau Doktor, es gibt Komplikationen.
-"Freilich haben auch Tiere Gefühle", sagt Hubert.
-"Die Aufgabe ist ziemlich schwierig, gell?", versuchte Kai ein Gespräch mit Helena aufzubauen.
+Freilich haben auch Tiere Gefühle, sagt Hubert.
+Die Aufgabe ist ziemlich schwierig, gell?, versuchte Kai ein Gespräch mit Helena aufzubauen.
 Komm schon, Charlie, du kannst das!
 Leider skaliert der Algorithmus schlecht mit der Anzahl der CPU-Kerne.
 Das Verfahren wird anschaulich, wenn man die Aufgabe als geometrisches Problem auffasst.
@@ -2951,12 +2951,12 @@ Damals lag Turbo-Pascal voll im Trend.
 Oskar schwelgte in Erinnerungen.
 Den Kommentar konnte Lena sich nicht verkneifen.
 Genüsslich radelte Eckhart an den Autos vorbei, die im morgendlichen Stau nicht voran kamen.
-"Selbst schuld", dachte er und konnte seine Schadenfreude kaum verbergen.
+Selbst schuld, dachte er und konnte seine Schadenfreude kaum verbergen.
 Nicht alles, was hinkt, ist ein Vergleich.
 Marvin versucht sich daran, den erweiterten euklidischen Algorithmus in Haskell zu implementieren.
-"Funktionale Programmierung ist nicht so mein Ding", räumte Melvin ein.
+Funktionale Programmierung ist nicht so mein Ding, räumte Melvin ein.
 Das muss sich doch automatisieren lassen.
-"Beim Wrestling ist alles nur Show", behauptet Willi.
+Beim Wrestling ist alles nur Show, behauptet Willi.
 Das könnte ich auch.
 Nele wäre zweifellos eine sehr gute Schauspielerin.
 He, laut Drehbuch küssen sich Valentina und Manuel erst im letzten Akt!
@@ -2971,23 +2971,23 @@ Deswegen rechnet man mit CO-zwei-Äquivalenten.
 Die Emissionen sind um neunhundert Millionen Tonnen zurückgegangen, das entspricht einem Minus von siebenundzwanzig Prozent.
 Wolfgang glaubt nicht mehr an Gott.
 Ich glaube, ich falle vom Glauben ab.
-"Ob katholisch oder evangelisch ist mir nicht wichtig", erläuterte Valentina.
+Ob katholisch oder evangelisch ist mir nicht wichtig, erläuterte Valentina.
 De jure gibt es ein Verbot, das aber de facto nicht umgesetzt wird.
-"Was soll ich in der Großstadt mit einem PKW?", stellte Gregor eine rhetorische Frage.
+Was soll ich in der Großstadt mit einem PKW?, stellte Gregor eine rhetorische Frage.
 Hier gibt es doch Öffis.
 Als Bert nicht mehr weiter wusste, wandte er sich an den Verbraucherschutz.
 Wechselwarme Tiere haben bei Kälte einen reduzierten Stoffwechsel.
 Das macht sie einerseits träge, spart andererseits aber Energie.
 Um den Akku zu schonen und sich keiner unnötigen Strahlung auszusetzen, stellt Moritz sein Handy nachts immer auf Flugmodus.
-"In welchem Ressort würden Sie bevorzugt arbeiten?", fragte der Personalchef den Junior-Redakteur.
-"Du hast meine uneingeschränkte Unterstützung", versicherte Hermann.
+In welchem Ressort würden Sie bevorzugt arbeiten?, fragte der Personalchef den Junior-Redakteur.
+Du hast meine uneingeschränkte Unterstützung, versicherte Hermann.
 Fast ein Fünftel der Bevölkerung ist offline-süchtig.
 Zu diesem schockierenden Ergebnis kommt das statistische Bundesamt in seinem Abschlussbericht.
 Die größten Streitpunkte sind noch ungeklärt.
 Eckhart suchte eine esoterische Heilerin auf.
 Überqueren Sie diese Kreuzung und biegen Sie direkt danach links ab.
 Geht nicht, das ist eine Einbahnstraße.
-"Da muss ich mich vertan haben", grübelte Kunibert.
+Da muss ich mich vertan haben, grübelte Kunibert.
 Folgen Sie mir unauffällig.
 Das Gebäude wurde gerade erst aufwendig saniert.
 Hermann schlug die Hände über dem Kopf zusammen.
@@ -3408,7 +3408,7 @@ Mathematik ist die Kunst, das Rechnen zu vermeiden.
 Auf seinem Server betreibt Nikolai ein Debian-Derivat.
 Bei der Erziehung ihrer Sprösslinge ist Daniela äußerst konsequent.
 Ist der dritte Teil auch so sehenswert wie die ersten zwei?
-In der nächsten Folge stirbt Olafundefined, spoilert Edgar.
+In der nächsten Folge stirbt Olaf, spoilert Edgar.
 Nach erneuten Übergriffen werden Rufe nach Konsequenzen laut.
 Manuela macht keinen Hehl daraus, dass sie von dem Kompromiss nicht viel hält.
 Seit zweitausendfünf hat die Stadt wieder verstärkt mit Kriminalität zu kämpfen.
@@ -3435,9 +3435,9 @@ Wasch mich, aber mach mich nicht nass.
 Valentin hat das Handtuch geworfen.
 Nach dem Essen schüttelt Nicola die Tischdecke aus.
 Spielt Alina auch im Bläser-Orchester?
-Wenn dein Großvater das wüsste, würde er sich im Grab umdrehen
+Wenn dein Großvater das wüsste, würde er sich im Grab umdrehen!
 Simon hat eine Zahnlücke, dank der er so laut pfeifen kann wie kein Zweiter.
-Wie niedlich
+Wie niedlich!
 Wieso sind so gut wie alle digitalen Assistenten weiblich?
 Wozu das Rad neu erfinden, wenn man auch Magnetschwebetechnik einsetzen kann?
 Olaf trägt eine Perücke.
@@ -3458,14 +3458,14 @@ Um den Teig fluffiger zu machen, kann man auch einen Schuss Sprudel hinzugeben.
 Nick sprudelte vor Ideen.
 Der Vorgang wurde durch den Benutzer abgebrochen.
 Es wird nach defekten Sektoren gesucht.
-Spanne uns nicht so auf die Folter
+Spanne uns nicht so auf die Folter!
 In Ordnung, dann möchte ich eure Geduld nicht länger strapazieren.
 Der Bruch lässt sich auf gewöhnliche Materialermüdung zurückführen.
 Bei seiner Arbeit untertage muss Norbert stets einen Helm tragen.
 Kaum jemand nahm Notiz von ihm.
-Pfirsich-Maracuja ist meine Lieblingssorte
+Pfirsich-Maracuja ist meine Lieblingssorte, sagt Rabea.
 Die anderen Fahrgäste versuchten möglichst unbeteiligt dreinzublicken, so als hätten sie nichts bemerkt.
-Früher hätte man uns dafür den Hintern versohlt, rief Rüdiger aufgebracht.
+Früher hätte man uns dafür den Hintern versohlt!, rief Rüdiger aufgebracht.
 Sara spricht Klingonisch.
 Sowas hätte es früher nicht gegeben.
 Udo hat Bärbel missverstanden.
@@ -3474,9 +3474,9 @@ Ist das offensichtlich oder bedarf es einer Erläuterung?
 Anita hat den Aushang am schwarzen Brett gesehen und sofort reagiert.
 Freitags sieht man immer Muslime in großen Menschenmengen zum Freitagsgebet in die Moschee strömen.
 Im September wird Rüdiger mit ein paar Freunden zum Wandern in die Alpen fahren.
-Meistens träume ich nicht, aber wenn, dann sind es Albträume
+Meistens träume ich nicht, aber wenn, dann sind es Albträume.
 Die Psychologie-Prüfung wird am zweiundzwanzigsten Februar um neun Uhr stattfinden.
-April, April
+April, April!
 Diese Partei kann man nicht wählen, weil sie durch und durch korrupt ist.
 Das Mädchen verbarg mit den Händen sein Gesicht und schluchzte.
 Jungs sind doof, sagt Antje.
@@ -3505,7 +3505,7 @@ Gib mir mal den Nussknacker.
 Kommen wir nun zum Knackpunkt.
 Mückenstiche sollte man nicht aufkratzen.
 Werner schert sich nicht darum.
-Das interessiert mich nicht die Bohne
+Das interessiert mich nicht die Bohne.
 Die Leute mit den schlechtesten Augen sitzen immer in der letzten Reihe.
 Ulf setzte eine Maske auf.
 Das Moment berechnet sich als Kreuzprodukt von Radius und Kraft.
@@ -3525,7 +3525,7 @@ Durch die Erkennung von Symmetrien kann der Suchraum erheblich eingeschränkt we
 Am Ende ihrer Arbeit hatten die Maurer noch ein paar Ziegelsteine über.
 Die Gegend ist komplett verwüstet.
 Alle Häuser wurden in Schutt und Asche gelegt.
-Sei nicht so kindisch
+Sei nicht so kindisch!
 Barbara pfeffert ihre Jacke achtlos in die Ecke.
 Udo ist ein Morgenmuffel.
 Egal wie viel Fisch du isst, Helene ist Fischer.
@@ -3557,12 +3557,12 @@ Was wir hier lernen ist doch völlig sinnlos, wirft Emilia ein.
 Warte nur ab, versucht Herr Eduard abzuwiegeln.
 Dieser Projektor ist kaputt.
 Sie müssen einen anderen nehmen.
-Dankeschön für den wertvollen Tipp
+Dankeschön für den wertvollen Tipp!
 Wackelpudding schwabbelt immer so.
 Nordseekrabben sind mittlerweile abartig teuer, obwohl sie in Polen gepult werden.
 Wieso seid ihr alle so sensationsgeil?, fragte Fiona vorwurfsvoll.
 Sensationell, würde die rasende Reporterin jetzt sagen.
-Lecker, es gibt Weintrauben
+Lecker, es gibt Weintrauben!
 Vor dem Rathaus hat es derweil Tumulte gegeben.
 Isabel fallen die ersten Milchzähne aus.
 Übung macht den Meister.
@@ -3588,7 +3588,7 @@ Diesen Zickenkrieg ertrage ich nicht länger, platzte es dem Vater heraus.
 Wie ist der aktuelle Status?
 Janina folgt weitestgehend dem Pfad ihrer Vorgängerin.
 Wer stets nur den Fußstapfen eines anderem folgt, wird nie seinen eigenen Weg finden.
-Willkommen zur Einführung in die objektorientierte Programmierung
+Willkommen zur Einführung in die objektorientierte Programmierung!
 Mein Name ist Ronald und ich werde Ihr Ansprechpartner sein.
 Desktop ist zum Beispiel ein Objekt der Klasse Ordner.
 Wie war noch gleich das Datum?
@@ -3622,7 +3622,7 @@ Wie war eure Tour?, erkundigte sich Emanuela.
 Solche Machos kennt Cassandra nur zu gut.
 Lotte lässt sich leicht verunsichern.
 Dagmar hat das Bewusstsein verloren.
-Keine Panik auf der Titanic
+Keine Panik auf der Titanic!
 Dürfen wir eine Formelsammlung verwenden?, meldete sich Meike zu Wort.
 Bei einer Stromstärke von mehr als zwei Ampere brennt die Sicherung durch.
 Vorsichtig, es ist eine flinke Sicherung.
@@ -3649,7 +3649,7 @@ Uns bleibt nur eine kurze Zeit, dann sind sie zur Gewalt bereit.
 Dem König, noch beschwipst vom Wein, fiel direkt ein Ausweg ein.
 Wir wollen beenden diesen Jammer, darum öffnen wir die Speisekammer.
 Zuvor wollen wir versehen das Brot mit giftigem Arsen.
-Wer aufbegehrt mit Gier, der soll leiden wie ein Tier
+Wer aufbegehrt mit Gier, der soll leiden wie ein Tier!
 Und schon ertönt sehr laut der Gong, der König betritt den Balkon.
 Hört zu, ihr Arbeiter und Bauern, bald gibt es nichts mehr zu bedauern.
 Ich erkenne eure Not und teile mit euch mein letztes Brot.
@@ -3662,7 +3662,7 @@ Mein Herr vergebt mir wenn ich sage: Es ist eine verzwickte Lage.
 Die Bauern krank, die Müller tot, sagt wer backt dem König jetzt sein Brot?
 Euer Einfall war auf lange Sicht, am Ende doch so weise nicht.
 Der Herrscher stimmte diesem zu, denn er erkannte das Dilemma im Nu.
-Wie töricht kann man sein, wenn man getrunken hat zu viel Wein
+Wie töricht kann man sein, wenn man getrunken hat zu viel Wein!
 Aus meinen Fehlern will ich lernen, von alten Bräuchen mich entfernen.
 Und da beschloss der Regent: Ab heute lebe ich abstinent.
 Weil Ilse nicht erkannt werden will, wurde ihre Stimme technisch verzerrt.
@@ -3670,10 +3670,10 @@ Dein Gesicht machen wir in der Nachbearbeitung unkenntlich.
 Dieses Experiment beweist, dass unsere Sprache viel redundante Information enthält.
 Die Entropie ist also wesentlich geringer als die Kodierungslänge.
 Den Namen Rebecca muss ich hier noch einfügen.
-Da wird Rebecca sich aber freuen
-Hier ist der Teufel los
-Och nö
-Ich habe geträumt, dass du stirbst
+Da wird Rebecca sich aber freuen!
+Hier ist der Teufel los!
+Och nö!
+Ich habe geträumt, dass du stirbst!
 Nur die dümmsten Kälber wählen ihre Schlächter selbst.
 Wenn man einen Gedanken verdrängen will, kann es helfen, Assoziationsketten zu bilden.
 Das hilft auch beim Einschlafen.
@@ -3693,14 +3693,14 @@ Krabben werden noch auf dem Kutter gekocht.
 Damit Tanzen gut aussieht, braucht es Profis und eine Choreografie.
 Der Dichter nahm einen Schluck, wurde noch dichter und gab sich einen Ruck.
 Lasst uns noch ein bisschen bleiben und Sätze für Mozilla schreiben.
-Trinkt das, was man trinken kann, denn es regt den Geiste an
+Trinkt das, was man trinken kann, denn es regt den Geiste an!
 Die Arena ist heut' ausverkauft, man will sehen, wer sich rauft.
 Es tritt im Ring zum Kampfe an: Der Papst und wer zuletzt gewann.
 Ein Boxkampf gegen alle Trends: Der Meister gegen seine Abstinenz.
 Fäuste fliegen, die Erde bebt, der Meister hat ihn flachgelegt.
-Alle rufen laut: Chapeau, es ist ein technischer K.o.
+Alle rufen laut: Chapeau, es ist ein technischer K.o.!
 Der Kuchen ist lecker.
-Ich hoffe das war nicht zu gemein, denn ein bisschen Spaß muss sein
+Ich hoffe, das war nicht zu gemein, denn ein bisschen Spaß muss sein!
 Und Nora bekommt noch ein paar Küsse für ihre poetischen Ergüsse.
 Es regt sich was.
 Sibylle hat angerufen und wollte dich sprechen.
@@ -3711,7 +3711,7 @@ In ihren Händen hielt Lotte den aktuellen Katalog.
 Melanie wedelte bereitwillig mit dem Kontoauszug, um sich einen Vorteil zu verschaffen.
 Es ist eine perfide, aber effektive Strategie.
 Wikipedia hat mit einem Autorenschwund zu kämpfen.
-Mein lieber Scholli
+Mein lieber Scholli!
 Annabel knurrt der Magen.
 Wo zum Henker sind wir?
 Was hat Ingrid sich da für eine Pille eingeworfen?
@@ -3719,15 +3719,15 @@ Karina meint, dass sich die Misere noch weiter fortsetzen wird.
 Gott sei Dank hat Judith einen Kompass.
 Die Truppe wird heute zehn Kilometer marschieren.
 So kann es nicht weitergehen.
-Zügeln Sie Ihre Zunge
+Zügeln Sie Ihre Zunge!
 Pauline ist nicht in der Stimmung, Gefangene zu machen.
 Inhaltlich hat Nora noch nicht wirklich etwas gesagt.
 Was ist hier eigentlich die Taktik?
-Jessica, das war spitze
+Jessica, das war spitze!
 Eine gemeinsame Lösung ist alternativlos.
 Eine Zivilperson wurde im Kreuzfeuer getötet.
 Paula plädiert für Maßnahmen, um solche Kollateralschäden in Zukunft zu vermeiden.
-Auf zur nächsten Etappe
+Auf zur nächsten Etappe!
 Der Seifenspender ist fast leer.
 Alles hat ein Ende, nur die Wurst hat zwei.
 Im Interview zeigt sich Karoline zuversichtlich.
@@ -3754,7 +3754,7 @@ Bei dem Versuch, sich die Funktionsweise eines Planetengetriebes vorzustellen, w
 Ich glaube, Sabrina ist absolut schwindelfrei.
 Susanne hat Höhenangst.
 Für klaustrophobe Menschen wie Sibylle wäre das nichts.
-Knallharter Bodycheck
+Knallharter Bodycheck!
 Linda führt ein Doppelleben.
 Versuchen Sie, einen Tag lang auf Anglizismen zu verzichten, schlug Cornelia vor.
 Es wird Ihnen nicht gelingen.
@@ -3763,7 +3763,7 @@ Jetzt hat Jessica die Zügel in der Hand.
 Ich denke, insgeheim hat Stefanie sich schon so etwas gedacht.
 Durch vernünftige Planung kann man effektiv verhindern, dass man Lebensmittel wegschmeißen muss.
 Für Singles ist es besonders einfach.
-Ach, das sind alles Ausreden, widersprach Veronika energisch.
+Ach, das sind alles Ausreden!, widersprach Veronika energisch.
 Ich leih mir ein Fahrrad beim Hotel, meinte sie.
 Wenn Computer von Menschen lernen, dann lernen sie oft auch Vorurteile.
 Dreimal im Jahr gibt es unangekündigte Kontrollen.
@@ -3779,14 +3779,14 @@ Sprachverarbeitende Software muss diesen Umstand erkennen.
 Der Fall ist klar wie Kloßbrühe.
 Jetzt muss Linda auch ihren Senf dazugeben.
 Silvana musste viel Kritik für ihre Salamitaktik einstecken.
-Verflixt und zugenäht
+Verflixt und zugenäht!
 Weil es ihr zu bunt wurde, hat Ute nun eine Petition eingereicht.
 Wo zum Kuckuck steckt Valerie?
-Coole Karre, Kumpel
+Coole Karre, Kumpel!
 Der antike Traktor hatte eine Fehlzündung.
-Nee, so doch nicht
+Nee, so doch nicht!
 Tamara kommt beruflich viel herum.
-Sie können meine Aussage doch nicht so aus dem Zusammenhang reißen
+Sie können meine Aussage doch nicht so aus dem Zusammenhang reißen!
 Aufgabe der Schule ist Bildung, nicht Ausbildung, erinnert der Direktor die Eltern.
 Mein rechter Platz ist frei, ich wünsche mir Marleen herbei.
 Jeanette ist passionierte Seglerin.
@@ -3802,7 +3802,7 @@ Das sollten wir bekanntgeben.
 Lass uns diskutieren.
 Mach doch selber, entgegnete Vanessa trotzig.
 Silvia fühlt sich fit wie ein Turnschuh.
-Labere mich nicht voll.
+Labere mich nicht voll!
 Ohne Murren ließ Jeanette die Prozedur über sich ergehen.
 Der Wärter nuschelte irgendwas in seinen Bart, gewährte den Touristen dann aber Zutritt.
 Nun halt endlich deinen Mund, du Plappertasche, zischte Silvia verärgert.
@@ -3815,7 +3815,7 @@ Diese Provokation konnte Maja nicht auf sich sitzen lassen.
 Wenn Melinda und Irene miteinander telefonieren, plaudern sie üblicherweise stundenlang.
 Von all dem Gequassel hatte Tamara Kopfschmerzen bekommen.
 Manchmal konnte Elisabeth echt anstrengend sein.
-Nun halt mal die Luft an
+Nun halt mal die Luft an!
 Fanny referiert über eine vom Aussterben bedrohte südostasiatische Vogelart.
 Ihr sabbelt mir zu viel.
 Melissa redet viel, wenn der Tag lang ist.
@@ -3833,7 +3833,7 @@ Maren hat aus Notwehr gehandelt.
 Diese Stiefel möchte ich gerne umtauschen.
 Haben Sie noch den Kassenbon?
 Wenn das Geld nichts mehr Wert ist, gewinnen Tauschgeschäfte mit Naturalien an Bedeutung.
-Ich flehe dich an, gib mir eine letzte Chance
+Ich flehe dich an, gib mir eine letzte Chance!
 Wir sind einem Mythos auf der Spur.
 Vielleicht ist es der größte Mythos der Menschheitsgeschichte.
 Bei solchen Temperaturen können giftige Dämpfe entstehen.
@@ -3841,9 +3841,9 @@ Hier haben die Handwerker ganz klar gepfuscht.
 Pfusch am Bau ist keine Seltenheit.
 Xenia ist leidenschaftliche Tänzerin.
 Margot reibt sich vor Vorfreude die Hände.
-Du hättest dein Gesicht sehen sollen
-Nicht anfassen
-Nichtmal angucken
+Du hättest dein Gesicht sehen sollen!
+Nicht anfassen!
+Nichtmal angucken!
 Das System ist narrensicher.
 Kinder genießen sowieso Narrenfreiheit.
 Möchten Sie einchecken?
@@ -3859,30 +3859,30 @@ Was zum Geier ist hier nur los?
 Aha, so ist das also.
 Nelly hat sich fast die Finger geklemmt.
 Sie haben eine leichte Gehirnerschütterung.
-Finden Sie es heraus
+Finden Sie es heraus!
 Lass uns alles abfackeln.
-Der Typ ist vollkommen irre
+Der Typ ist vollkommen irre!
 Der Flug wurde annulliert.
 Es bricht mir das Herz.
 Wer ist dieses Mädel?
 Das wirft ein schlechtes Licht auf mich.
 Du bist ein Krümelmonster.
 Unser Wagen ist dann wohl Schrott.
-Untersteh dich
+Untersteh dich!
 Kneif mich mal.
-Wartet, Jungs
+Wartet, Jungs!
 Patricia schläft tief und fest.
 Tatjana ist total verstrahlt.
 Das Blatt hat sich gewendet.
 Hier muss eine Verwechslung vorliegen.
-Du Schlingel
+Du Schlingel!
 Die drei Rabauken hatten schon wieder die nächste Rauferei begonnen.
 Das Verhalten der Geschäftsführerin ist skandalös.
 Wenn das rauskommt, werden Köpfe rollen, das kann ich dir garantieren.
-Vorwärts, aber zack zack
+Vorwärts, aber zack zack!
 Schere, Stein, Papier.
 Elisabeth reibt sich verwundert die Augen.
-Sieh mich an, ich sehe aus wie der letzte Dorftrottel
+Sieh mich an, ich sehe aus wie der letzte Dorftrottel!
 Wie Sie also sehen, ist das Ergebnis zumindest nicht komplett hanebüchen.
 Wir wollen Margot einen Streich spielen.
 Yvonne wurde in eine Talkshow eingeladen.
@@ -3890,14 +3890,14 @@ Mit ihrer Firma ist Tatjana ordentlich am Kohle scheffeln.
 Meine Armbanduhr ist wasserdicht.
 Der Tankwart sah zottelig aus und hatte deutlich sichtbare Augenringe.
 Sachte, sachte, rief Maren.
-Mach mal hinne.
+Mach mal hinne!
 Wiebke befestigt die Leine am Halsband und geht mit ihrem Hund vor die Tür.
 Das ist doch kein Grund so auszuflippen, erwiderte Olga.
 Das ist ja der springende Punkt.
 Ehe sie sich versahen, stand der Knecht bereits vor ihnen.
 Molly krallte sich sogleich eine Schachtel Zigaretten.
 Entschuldigen Sie, fährt dieser Zug nach Rosenheim?
-Ist ja widerlich
+Ist ja widerlich!
 Herr Hildebrand sitzt vor einem Kreuzworträtsel und sucht ein Dschungeltier mit fünf Buchstaben.
 Der Auftritt von Marissa war phänomenal.
 Das Moderatoren-Duo ist für seine Sticheleien und Seitenhiebe bekannt.
@@ -3926,7 +3926,7 @@ Der Steuermann lehnt sich über die Reling.
 Gegen Mittag muss der Frachter mit einer Nussschale kollidiert sein.
 Bis dahin dürften sich die Wogen geglättet haben.
 Das Band muss wirklich straff gezogen werden.
-Ist anklopfen zu viel verlangt?
+Ist Anklopfen zu viel verlangt?
 An der Litfaßsäule hängt noch immer die selbe Reklame wie vor einem Jahr.
 Verächtlich blickte ich den Jäger an.
 Aus einem Zimmer war ein elendes Wimmern zu vernehmen.
@@ -3937,7 +3937,7 @@ Nach einer langen Jagd wäre eine Stärkung doch sicherlich angebracht.
 Ist doch alles nur Fassade.
 Der Kobold naschte vom grüngelben Schleim.
 Jetzt habe ich den Faden verloren.
-Zusammen sind wir stark
+Zusammen sind wir stark!
 Am Ende wird es wieder in eine Fressorgie ausarten.
 In Besprechungen stellt sie ihr Handy immer auf Vibration.
 Vom anfänglichen Glanz ist nicht mehr viel übrig.
@@ -3946,7 +3946,7 @@ Die Würfel sind gefallen.
 Allianz ist ein gutes Stichwort.
 Apropos Kosmos.
 Wann wurden die Nomaden sesshaft?
-Und jetzt machen wir alle den Hampelmann
+Und jetzt machen wir alle den Hampelmann!
 Sein Ferrari hat Flügeltüren.
 Haben wir noch genügend Rohstoffe?
 Der Befund ist ohne Makel.
@@ -3954,7 +3954,7 @@ Man kann Karotten auch roh essen.
 Die Helferin nahm eine Ampulle aus dem Schrank und zog eine Spritze auf.
 Ich lasse mir nicht von anderen vorschreiben, ob ich einen Minirock tragen darf.
 Wie sollen die Möbel aufgestellt werden?
-Man sollte digitale Technik nicht nutzen um ihre Nutzer zu versklaven.
+Man sollte digitale Technik nicht nutzen, um ihre Nutzer zu versklaven.
 Woher hat der Knabe nur seine Aggressionen?
 Er ist ein psychisches Wrack.
 Es ist eine Schande, was passiert ist.
@@ -3966,13 +3966,13 @@ Dein Smartphone hat vibriert, als du weg warst.
 Ich rauche nicht seit zwei Jahren.
 So ist es nichts halbes und nichts ganzes.
 Seine Rede kann man nur als zynisch bezeichnen.
-Genaues Zielen ist erforderlich, also volle Konzentration
+Genaues Zielen ist erforderlich, also volle Konzentration!
 Die Wunde wird verheilen, aber eine Narbe wird bleiben.
 Jeder ist seines eigenen Glückes Schmied.
 Mittlerweile hat sich eine Kruste gebildet.
 Es ist pervers, dass derlei Schandtaten immer noch als Kavaliersdelikt angesehen werden.
 Der gesamte Innenbereich war in mühevoller Fleißarbeit blitzblank geputzt worden.
-Ihr seid doch total durchgeknallt
+Ihr seid doch total durchgeknallt!
 Sie ist mitnichten eifersüchtig.
 Ich wünschte, ich könnte mich klonen.
 Dreh mir bitte keinen Strick daraus.
@@ -3983,16 +3983,16 @@ Ach, ist das öde.
 Betrachte es als Investition.
 Jawohl, so soll es geschehen.
 Das Mädel hat Talent.
-Nee, Fräulein, so nicht
+Nee, Fräulein, so nicht!
 Manche neigen zu Überheblichkeit gegenüber der Jugend, wenn sie alt werden.
-Dir stehen doch alle Möglichkeiten offen
-Welch ein haarsträubender Fehler
+Dir stehen doch alle Möglichkeiten offen!
+Welch ein haarsträubender Fehler!
 Um Haaresbreite wäre die Flucht misslungen.
 Niemand kann sich dem Fluch des Alterns entziehen.
 Der Tod ist eine Notwendigkeit im Kreislauf des Lebens.
 In seiner Schusseligkeit bewirkte der Magier das Gegenteil von dem, was er wollte.
 Du bist aber auch dusselig.
-Doch sei gewarnt, das Pendel wird eines Tages mit voller Wucht zurückschwingen
+Doch sei gewarnt, das Pendel wird eines Tages mit voller Wucht zurückschwingen!
 Das ist sehr metaphorisch gesprochen.
 Aber was heißt das im Klartext?
 Ob ich den Code je in seiner vollen Tiefe durchdringen werde, erscheint fraglich.
@@ -4011,7 +4011,7 @@ Andernfalls bekommt man am eigenen Leib zu spüren, was der Begriff Schallmauer 
 Für den Landeanflug konnte die Concorde ihre Nase absenken.
 Sehr verehrte Fluggäste, machen Sie sich auf Turbulenzen gefasst.
 Wie kann man nur seine eigene Kreditkarte verschlampen?
-Asche auf mein Haupt
+Asche auf mein Haupt!
 Zur Einrückung werden Leerzeichen verwendet, nicht Tabulatoren.
 Nun zum Inhalt.
 Das Attribut wurde nicht gesetzt.
@@ -4025,7 +4025,7 @@ Achtung, der Poller hebt und senkt sich automatisch.
 Sei Epsilon kleiner als Null.
 Wir können die Position genauso gut als Radius R und Winkel Phi beschreiben.
 Aus Lärmschutzgründen hat man neben der Hauptverkehrsader einen Wall aufgeschüttet.
-Lehnen Sie sich nicht über die Schranke
+Lehnen Sie sich nicht über die Schranke!
 Frankfurt ist eines der Drehkreuze für internationalen Luftverkehr.
 Neunzehnhundertzweiundachtzig wurde der Staudamm errichtet.
 Am Ende des Gleises befindet sich ein Prellbock.
@@ -4067,12 +4067,12 @@ In ihrer Verzweiflung gab sie ihr Kind in der Babyklappe ab.
 Oma liegt noch in der Rehabilitierungsklinik.
 Im Altenheim wird fleißig Bingo und Kniffel gespielt.
 Wer hat Lust auf eine Runde Bullshit-Bingo?
-Willkommen im Club
+Willkommen im Club!
 In einem alten Wasserturm der Stadt hat man nun ein Planetarium errichtet.
 Ich suche das Tierheim.
 Die türkische befindet sich gleich neben der slowakischen Botschaft.
 In Hamburg sind die Mülleimer mit kreativen Sprüchen bemalt.
-Komm her, du faule Socke
+Komm her, du faule Socke!
 Die Vermittlungsgebühr für den Makler hätte sie sich gerne gespart.
 Sind Sie auf der Suche nach einer Immobilie?
 Wir stehen hier mitten in der Wüste.
@@ -4080,7 +4080,7 @@ Der Saunabereich ist textilfreie Zone.
 Um die Verletzungsgefahr zu verringern, nehmt bitte euren Schmuck ab.
 Wie wär's mit einer Tasse Kräutertee?
 Dekoration darf niemals die Funktionalität beeinträchtigen.
-Was für eine hässliche Lampe
+Was für eine hässliche Lampe!
 Lass uns noch Fliesen für das Wohnzimmer aussuchen.
 Schwamm drüber.
 Das ist Schnee von gestern.
@@ -4117,15 +4117,15 @@ Dein Timing ist denkbar schlecht.
 Mach gefälligst die Tür zu.
 Wo bitteschön steht das?
 Wie kann man nur so lernresistent sein?
-Volltreffer
+Volltreffer!
 Der hat gesessen.
 Kümmern Sie sich gefälligst um Ihren eigenen Kram.
 Basti ist vieles, aber bestimmt kein Geizhals.
 Schließlich einigte man sich auf einen Kompromiss.
 Schnuffi muss erst noch sein Revier markieren.
 Legen Sie eine notariell beglaubigte Kopie des Zeugnisses bei.
-Oh Gott, ein Monster
-Wir werden alle sterben
+Oh Gott, ein Monster!
+Wir werden alle sterben!
 Niemand wird gezwungen.
 Von freiwillig kann nicht die Rede sein.
 Es duftet nach frischem Kaffee.
@@ -4144,7 +4144,7 @@ Habe ich denn eine Wahl?
 Die Zeichenkodierung kommt nicht mit Umlauten klar.
 Für Quelltext ist bitte immer die UTF-acht-Kodierung zu verwenden.
 Meine Erinnerung daran ist schon sehr verblasst.
-Aus Mitleid kaufte Henrike dem frierendem Obdachlosen eine Jacke.
+Aus Mitleid kaufte Henrike dem frierenden Obdachlosen eine Jacke.
 Der Hausmeister hat uns gerade noch gefehlt.
 Ich gebe zu, dass es ein unkonventionelles Verkehrsmittel ist.
 Aber ohne meinen Raketenrucksack fühle ich mich wie ein Sterblicher.
@@ -4161,7 +4161,7 @@ Die Zahnärztin versuchte vergeblich, den hartnäckigen Belag zu entfernen.
 Wir haben alles an Textilien, was Sie sich nur vorstellen können.
 Der Mönch führte uns zur Gruft nahe des Klosters.
 Der Ingenieur betrat das Dock und inspizierte den Schaden am Bug.
-Ihr könnt mich doch nicht einfach zurücklassen
+Ihr könnt mich doch nicht einfach zurücklassen!
 Aussehen ist nicht alles.
 Die Blondine da drüben ist sehr attraktiv.
 Ariane hat sich in einer Konditorei beworben.
@@ -4190,7 +4190,7 @@ Teil der Ausstellung ist ein mittelalterliches Katapult.
 Auch sonst ist die Vorstellung sehr eindrucksvoll gewesen.
 Verzeiht mir meine Obszönitäten.
 Womit hast du die Ravioli gefüllt?
-Mit Rinderfleisch
+Mit Rinderfleisch!
 Egal, es ist echt lecker.
 Jetzt wirst du aber unsachlich.
 Frau Hoppe fühlt sich ausgelaugt und lässt sich daher eine Massage geben.
@@ -4265,7 +4265,7 @@ Frau Binder, Sie haben die aufgeführten Gründe des Monopolisten als fadenschei
 Die Kriterien der Akademie gehören auf den Prüfstand.
 Deshalb sollten wir für mehr Akzeptanz werben.
 Die Betroffenen leiden oft jahrzehntelang an den traumatischen Erlebnissen.
-Zeigen Sie klare Kante
+Zeigen Sie klare Kante!
 Das Gummi ist nicht mehr zu gebrauchen, denn es ist mürbe.
 Hier wird fälschlicherweise der Eindruck vermittelt, man hätte die eierlegende Wollmilchsau gefunden.
 Die andere Prozedur berechnet die inverse Projektionsmatrix.
@@ -4304,7 +4304,7 @@ Da er keine Mütze hat, setzt Samuel seine Kapuze auf.
 Vor Inbetriebnahme muss die Zapfsäule geeicht werden.
 Ist die Präzision ausreichend?
 Bei wie viel Grad wird Milch pasteurisiert?
-Wer sich nicht an den Kodex hält, muss sterben
+Wer sich nicht an den Kodex hält, muss sterben!
 Wir können noch einen weiteren Term eliminieren.
 Maximilian ist im Grunde ihrer Willkür ausgesetzt.
 Unsere Schraubenschlüssel sind unverwüstlich.
@@ -4318,7 +4318,7 @@ Josephine hat die Aufgabe komplett nach Schema F gelöst.
 Der Sog hinterm Laster kann echt tückisch sein.
 Bei vier Leuten bietet sich eine Raute als Aufstellung an.
 Von Sandro und Johann hörte man nur pubertäres Gekicher.
-Danke für den Gedankenanstoß
+Danke für den Gedankenanstoß!
 In dem Gerümpel sollen wir die Skulptur finden?
 Fett schwimmt oben, weil es eine geringere Dichte als Wasser hat.
 Bist du fit in linearer Algebra?
@@ -4332,9 +4332,9 @@ Diese Woche ernähre ich mich rein vegetarisch.
 Mit solch einer Standardfloskel kannst du nie etwas verkehrt machen.
 Beim Empfang werden Häppchen verteilt.
 Steffen zeigt sich flexibel.
-Reiß dich am Riemen
+Reiß dich am Riemen!
 Mit deiner Vorgesetzten habe ich sowieso noch ein Hühnchen zu rupfen.
-Was für ein Kaiserwetter, schwärmte der Österreicher.
+Was für ein Kaiserwetter!, schwärmte der Österreicher.
 Ich habe gestern meine Steuern bezahlt.
 Die Späher werden sicher schnell eine seichte Stelle im Gewässer gefunden haben.
 Du musst jetzt ganz tapfer sein.
@@ -4343,7 +4343,7 @@ Sehen ist ein passiver Vorgang.
 Helft bitte mit, die Tanne zu schmücken.
 Fein, erwidert Josephine, dann gib mir ein Stück Kreide.
 Ein Sockel aus Beton sorgt für die nötige Stabilität.
-Ganz großes Tennis
+Ganz großes Tennis!
 Was ist achtundzwanzig geteilt durch sieben?.
 So drastisch würde ich es nicht ausdrücken.
 Ich will keinen Mucks hören, verstanden?
@@ -4380,7 +4380,7 @@ Umwege erhöhen die Ortskenntnis.
 Das besagt ein altes chinesisches Sprichwort.
 Das Personal ist hier aber wirklich aufdringlich.
 Durch den Kauf der neuen Anlage sind die Schulden dramatisch gestiegen.
-Kommunizieren Sie mit mir
+Kommunizieren Sie mit mir!
 Durch einen elektrisierten Weidezaun ist die Koppel begrenzt.
 Auf der Weide grasen auch Ziegen.
 Insgesamt ist die Ziege ein genügsames Tier.
@@ -4399,9 +4399,9 @@ Stress macht krank.
 Das war doppelt gemoppelt.
 Dank Schnellspanner ist die Demontage eine Frage von Sekunden.
 Der Pulli ist leider eingelaufen.
-Und nächstes Mal sind Sie gefälligst pünktlich
-Hau bloß ab
-Junge, bist du groß geworden
+Und nächstes Mal sind Sie gefälligst pünktlich!
+Hau bloß ab!
+Junge, bist du groß geworden!
 Ich habe stopp gesagt.
 Rudi will nicht den ganzen Tag zu Hause hocken.
 Wir haben alle Ausgänge versiegelt.
@@ -4414,7 +4414,7 @@ Spiel das Hologramm nochmal ab.
 Wenn ihn jemand zur Vernunft bringen kann, dann Verena.
 Die Antwort liegt doch auf der Hand.
 Bevor Sie mir Ihre Dienstmarke gezeigt haben, glaube ich Ihnen gar nichts.
-Bleib locker, Mann
+Bleib locker, Mann!
 Selbstredend haben wir auf Sicherheitsglas bestanden.
 Der Auswahlvorgang sollte interaktiver gestaltet werden, schlägt Saskia vor.
 Die Vorwürfe sind völlig absurd.
@@ -4486,11 +4486,11 @@ Hinter dieser Klausel verbergen sich versteckte Kosten.
 Durch wen wurde die Operation autorisiert?
 Das nenne ich einen ausgefuchsten Plan.
 Das Ergebnis sollte ein Skalar sein, kein Vektor.
-Lasst uns virtuell in die Steinzeit eintauchen
+Lasst uns virtuell in die Steinzeit eintauchen!
 Der Kerl macht einen kognitiv überforderten Eindruck.
 Er hat eine deftige Absage erhalten.
 Heraus kommt eine homogene Emulsion.
-Kaum zu glauben
+Kaum zu glauben!
 Mel benimmt sich flegelhaft.
 Das ist aber sehr salopp ausgedrückt.
 Die Möglichkeiten sind mannigfaltig.
@@ -4510,7 +4510,7 @@ Auch mir wurde das Kochen nicht in die Wiege gelegt.
 Weißt du, was kurios ist?
 Was bitteschön befähigt ihren Gatten zu diesem Amt?
 Kann das Viech mal aufhören so zu schnurren?
-Schau mir in die Augen
+Schau mir in die Augen!
 Dafür gehört ihm ein Orden verliehen.
 Gewöhnen Sie sich schon einmal an die Notation mit dem Nabla-Operator.
 Bei einem Täuschungsversuch wird die gesamte Arbeit mit ungenügend bewertet.
@@ -4521,8 +4521,8 @@ Lass uns mal ein paar Würstchen schnorren gehen.
 Jeder hat seine Geschichte.
 Was tut man gegen ein fusselndes Handtuch?
 Offenbar hat er im Affekt gehandelt.
-Moin, Kollegen
-Moin, moin
+Moin, Kollegen!
+Moin, moin!
 Wie handhabt man das in der ambulanten Pflege?
 Aber die sind nun mal hässlich wie die Nacht.
 Der Sprecher zieht mal wieder über seine Kollegen her.
@@ -4533,7 +4533,7 @@ Es läuft wie am Schnürchen.
 Wer es lutscht, hat länger etwas davon, als wer es kaut.
 Wer möchte alles einen Lolli?
 Wer tapfer ist, bekommt zur Belohnung ein Gummibärchen.
-Du hast es versprochen
+Du hast es versprochen!
 Für den Laien wirkt der Begriff etwas sperrig.
 Irgendwann lohnt sich das Feilschen nicht mehr, weil auch Zeit einen Wert hat.
 Der neue Chef ist ein abgebrühter Kerl.
@@ -4558,7 +4558,7 @@ Ein boshaftes Lachen erschallte.
 Eine Elektrifizierung der Trasse scheint dringend notwendig.
 Wenn Synchronsprecher gestikulieren, klingen sie authentischer.
 Eine Kampagne soll ihn diskreditieren, damit ihm niemand mehr glaubt.
-Er hat dich doch nur gekost
+Er hat dich doch nur gekost!
 Sie meint es nur gut.
 Sie liebkoste ihn.
 Du hast da einen Fussel im Haar.
@@ -4577,19 +4577,19 @@ Der Poet proklamierte.
 Damit ist der Beschluss nichtig.
 Hilf mir bitte beim Schälen der Kartoffeln.
 Wie heißt das Zauberwort?
-Erzählen Sie auch anderen von Common Voice
+Erzählen Sie auch anderen von Common Voice!
 Es ist eine bescheidene Bude, aber mehr brauche ich nicht.
 Wir wollen der Website eine optische Auffrischung verpassen.
-Ihr könntet euch ruhig auch mal beteiligen
+Ihr könntet euch ruhig auch mal beteiligen!
 Haben Sie zollpflichtige Ware dabei?
 Musstest du unbedingt die miefenden Socken auf die Heizung legen?
 Sonst trocknen sie nicht.
 Einundsechzig sind dafür, dreiundfünfzig dagegen, keine Enthaltungen.
 Da müssen wir wohl oder übel selbst Hand anlegen.
 Na also, warum nicht gleich so?
-Kein Grund, gleich handgreiflich zu werden
-Man sollte sie alle übers Knie legen
-So ein Erbsenzähler
+Kein Grund, gleich handgreiflich zu werden!
+Man sollte sie alle übers Knie legen!
+So ein Erbsenzähler!
 Entferne bitte alle störenden Knackser.
 Grüner wird's nicht.
 Das ist halt der Unterschied zwischen Theorie und Praxis.
@@ -4630,9 +4630,9 @@ Mein Handy zeigt mir einen Anruf in Abwesenheit an.
 Ungeduldig zerrte er an meinem Ärmel.
 Wie kommst du darauf?
 Die Autokorrektur ist keine große Hilfe.
-Ahoi, ihr Landratten
+Ahoi, ihr Landratten!
 Wir haben euch schon erwartet.
-Wirf mal das Tuch rüber
+Wirf mal das Tuch rüber!
 Besonders hervorstechend ist der sechste Vers.
 Das Gerüst wäre mir zu wackelig.
 Um Energie zu sparen, wird im Leerlauf die Taktfrequenz gedrosselt.
@@ -4642,7 +4642,7 @@ Sich so zu bücken ist schlecht für den Rücken.
 Wir müssen es gar nicht weiter aufdröseln.
 Als Folge verengen sich die Blutgefäße.
 Wollt ihr einzeln oder zusammen bezahlen?
-Brust raus, Bauch rein und stets lächeln
+Brust raus, Bauch rein und stets lächeln!
 Die Werkstatt hat sich diversifiziert und repariert jetzt mehrere Automarken.
 Wenn du dieses Bild präsentierst, wird sich ein Aha-Effekt einstellen.
 Der Unterschied zwischen Tomographie und Projektion lässt sich am einfachsten grafisch erklären.
@@ -4659,7 +4659,7 @@ Eigentum verpflichtet.
 Aber wozu eigentlich?
 Sie fühlt sich schlapp.
 Ich werde noch bekloppt dabei.
-Aber nicht mogeln
+Aber nicht mogeln!
 Jedes Jahr unternimmt die Biolehrerin mit den Schülern eine Exkursion ins Moor.
 Vor dem Einschlafen setzt sie stets ihre Zahnspange ein.
 Die Zeremonie wurde feierlich vom Rektor eröffnet.
@@ -4670,7 +4670,7 @@ Auf diesem gummierten Spezialboden hat man mehr Grip als auf Asphalt.
 Die Ansaugmenge wird durch die Drosselklappe bestimmt.
 Alle Verbrenner dieser Modellreihe sind zwangsbeatmet.
 Verschlafen blinzelte sie.
-Sehr schöne Illustration
+Sehr schöne Illustration!
 Das hat er ganz prima gemacht.
 Du kannst da doch nicht in Jogginghose erscheinen.
 Da haben wir den Salat.
@@ -4713,12 +4713,12 @@ Schau mal in der Legende nach.
 Wir rotieren einmal gegen den Uhrzeigersinn.
 Daraufhin erklärt ihr die einzelnen Stationen.
 Wir können doch Freunde bleiben.
-Wenn ihr euch unbedingt darum kloppen wollt, nur zu
+Wenn ihr euch unbedingt darum kloppen wollt, nur zu!
 Man wächst mit seinen Aufgaben.
 Die zwei Jahre im Ausland haben dich sehr verändert.
 So eine miese Qualitätskontrolle käme durch keine Qualitätskontrolle, außer durch sich selbst natürlich.
-Noch ein kleines bisschen nach vorn, bitte
-Passt schon
+Noch ein kleines bisschen nach vorn, bitte!
+Passt schon!
 Soll das alles sein?
 Dem wollen wir nun ein für alle Mal einen Riegel vorschieben.
 Mit aller Kraft versuchten die beiden Freunde, das Tor aufzustoßen.
@@ -4739,7 +4739,7 @@ Sie zeigt ihr, wie man den Degen richtig hält.
 Bist du in einer schlagenden Studentenverbindung?
 In die Steuerungselektronik haben sie eine Menge Hirnschmalz hineingesteckt.
 Ihr fehlt das nötige Fingerspitzengefühl.
-Onkel Dagobert grüßt seinen Neffen, der in dem harmlos anmutenden Inserat stand.
+Onkel Dagobert grüßt seinen Neffen, hieß es in dem harmlos anmutenden Inserat.
 Nazivergleiche sind hier unangebracht.
 Jemand hat mir mein Portmonee geklaut.
 Belassen wir es dabei.
@@ -4769,10 +4769,10 @@ Die Bezahlung richtet sich nach dem jeweiligen Tarif des öffentlichen Dienstes.
 Reinhold hat einen richtig dicken Oschi aus dem Teich gezogen.
 Auf der logarithmischen Skala ist das die Mitte.
 Der General behält in jedem Fall die Entscheidungshoheit.
-Quatsch mit Soße
+Quatsch mit Soße!
 Ich muss den Bass fühlen.
 So wie Liebe Menschen glücklich macht, kann sie sie auch zutiefst unglücklich machen.
-Und, meine Damen und Herren, das alles rendern wir in Echtzeit
+Und, meine Damen und Herren, das alles rendern wir in Echtzeit!
 Wer vor allen Herausforderungen wegrennt, wird nie eine meistern.
 Das ist eine Binsenweisheit.
 Davon wird die Welt nicht untergehen.
@@ -4848,7 +4848,7 @@ Jetzt wollen wir die Kirche aber mal im Dorf lassen.
 Falls Sie noch etwas Training brauchen, steht Ihnen der Übungsplatz zur Verfügung.
 Alle standen auf und legten im Chor den vereinbarten Schwur ab.
 Der Schlick stellt für unseren Jeep durchaus ein Hindernis dar.
-Also das ist ja wirklich der Gipfel
+Also das ist ja wirklich der Gipfel!
 Hat der Hauptmann seine Erlaubnis gegeben?
 Sie hat Angst, sich zu blamieren.
 Kannst du reiten?
@@ -4873,7 +4873,7 @@ Ignoriere sie einfach.
 Kennst du Cheats für dieses Spiel?
 Entschuldigt bitte meine Verspätung.
 Ich habe den Bus verpasst.
-Eine Sekunde
+Eine Sekunde!
 Seit jenem Tag plagen sie Gewissensbisse.
 An der örtlichen Schule werden die Fünftklässler nach alter Tradition als Sextaner bezeichnet.
 Ein Kind aus der Klasse ist versetzungsgefährdet.
@@ -4883,7 +4883,7 @@ Vorher muss ich noch ganz schnell was erledigen.
 Man erntet, was man sät.
 Es sind auch andere Äcker zur Saat da.
 Immer, wenn der Wärter das Häuschen betritt, hebt er die Fußmatte an.
-Na dann schieß los
+Na dann schieß los!
 Dein Cousin hat es im Leben zu was gebracht.
 Bei uns ist das Alltag.
 Das sagt meine Nichte auch immer.
@@ -4891,7 +4891,7 @@ Was schätzt du, wie alt bin ich?
 Wie auch immer.
 Jetzt ist Ärmel hochkrempeln angesagt.
 Tabea biss sich auf die Zunge.
-Und ab geht die Post
+Und ab geht die Post!
 Frustriert knallt der Verwalter seinem Vorgesetzten den Stapel Akten auf den Schreibtisch.
 Mein Boxsack hilft mir, meinen alltäglichen Frust abzubauen.
 Worauf Sie sich verlassen können.
@@ -4904,7 +4904,7 @@ Der Filter ist verstopft.
 Bitte reinigen Sie den Luftfilter.
 Wer nicht hören will, der muss fühlen.
 Warum gehorcht der Bursche nie?
-Dass ich das noch erleben darf
+Dass ich das noch erleben darf!
 Sie ballte die Hand zu einer Faust.
 Wir berechnen die Zwischenwerte stumpf durch lineare Interpolation.
 Per Kommandozeilenparameter lassen sich die Warnungen unterdrücken.
@@ -4913,10 +4913,10 @@ Beim unüberwachten Lernen spart man sich die separate Trainingsphase.
 Fachlich hat sie viel drauf, aber ihre Didaktischen Fähigkeiten sind noch ausbaufähig.
 An einem Stand werden Waffeln verkauft, um die Vereinskasse aufzubessern.
 Sie stellt Nüsse, Salzstangen und anderen Knabberkram auf den Tisch.
-Bedient euch
+Bedient euch!
 Quantensprünge sind entgegen der landläufigen Meinung etwas winziges.
 Wie sicher wird unsere heutige Kryptographie noch sein, wenn Quantencomputer massentauglich werden?
-Mein Schlitten hat Chromfelgen
+Mein Schlitten hat Chromfelgen!
 Er verhält sich wie eine Eidechse im freien Fall.
 Wie ist das nur gemeint?
 Woher kommt der Drang, sich prestigeträchtiges Eigentum zuzulegen?
@@ -4926,7 +4926,7 @@ Es ist eigentlich eher ein Trapez.
 Wie werden sie reagieren, wenn wir ihnen einen Ernstfall vorgaukeln?
 Neben Quecksilber ist Brom das einzige Element, das im Normalzustand flüssig ist.
 Als Werkstoff ist Gold relativ wertlos.
-Und ich Idiot dachte, es wäre ein guter Deal
+Und ich Idiot dachte, es wäre ein guter Deal!
 Sehen wir uns nachher beim Handballtraining?
 Manchmal ist ihr Assistent schwer von Begriff.
 Aber jetzt geht ihm ein Licht auf.
@@ -4988,7 +4988,7 @@ Geräuschvoll zog sie an Hebeln und Schaltern.
 Augenblicklich leuchteten alle Lampen gleichzeitig auf.
 Dann rumpelte es im Innern und es gab einen Ruck.
 Aber wir wollen die Pferde ja auch nicht unnötig scheu machen.
-Immer ruhig mit den jungen Pferden
+Immer ruhig mit den jungen Pferden!
 Na ja, aber ich wollte natürlich auch nicht alle naselang Halt machen.
 Etwa um eins waren alle Mann versammelt.
 Er gilt als dünnhäutig und egozentrisch.

--- a/server/data/fr/gerard-majax.txt
+++ b/server/data/fr/gerard-majax.txt
@@ -13,10 +13,10 @@ Il y a là une forme d’inégalité.
 La parole est à Monsieur le secrétaire d’État.
 Encore une fois, je partage la philosophie de cet amendement.
 Ce sera un moyen de traiter la question que vous évoquez.
-Je demande la parole
+Je demande la parole!
 On ne répond pas au Gouvernement.
 Vous aurez beaucoup d’autres occasions de vous exprimer.
-Alors je demande une suspension de séance
+Alors je demande une suspension de séance!
 La séance est suspendue.
 La séance est reprise.
 La parole est à Monsieur François Pupponi, pour soutenir l’amendement numéro six cent soixante-quatorze.
@@ -44,67 +44,67 @@ La parole est à Monsieur Éric Coquerel.
 C’est un peu l’heure de vérité.
 Mais ce que vous faites ne sera pas indolore.
 Cela ne tient pas la route.
-Prenez l’argent là où il est
+Prenez l’argent là où il est!
 Merci de conclure, cher collègue.
 Je termine.
-Très bien
-C’est clair
+Très bien!
+C’est clair!
 Cet amendement était inévitable.
-En effet
+En effet!
 Monsieur le secrétaire d’État, pour moi, les comptes n’y sont pas.
 Tout cela fait deux virgule deux milliards.
-En substitution
+En substitution!
 La parole est à Monsieur Stéphane Peu.
 Je le dis pour ceux d’entre vous qui n’auraient pas eu cette information.
-C’est ce qu’on a dit hier soir
+C’est ce qu’on a dit hier soir!
 Cet amendement ne va donc aucunement faciliter ou accélérer les négociations.
 Ma deuxième remarque, c’est que tout cela revient au même.
 Veuillez conclure, monsieur Peu.
 Je vais conclure, monsieur le président.
-Bravo
+Bravo!
 La parole est à Monsieur Rémy Rebeyrotte.
 et fait en sorte de les accompagner.
 Or, près de dix ans se sont écoulés, et rien ne s’est passé.
-C’est faux
-Regardez le nombre de logements construits
+C’est faux!
+Regardez le nombre de logements construits!
 Au bout du compte, la réponse n’a pas été à la hauteur des enjeux.
 L’USH le reconnaît d’ailleurs lorsqu’elle déclare qu’il va falloir se mettre en mouvement.
-C’est vrai
+C’est vrai!
 Le scrutin est annoncé dans l’enceinte de l’Assemblée nationale.
 La parole est à Monsieur Patrick Mignola.
 Or, je le rappelle, il est bel et bien urgent d’agir.
 Je vous prie de conclure, monsieur Mignola.
 Je vous demande de conclure, monsieur Mignola.
 La parole est à Monsieur Adrien Quatennens.
-Ben voyons
-Il a raison
-Eh oui
+Ben voyons!
+Il a raison!
+Eh oui!
 Et vous avez de multiples autres possibilités.
 Nous sommes tous d’accord.
 La parole est à Madame Amélie de Montchalin.
-Justement, vous les pénalisez
+Justement, vous les pénalisez!
 Mais ce système s’est stratifié depuis quarante ans.
-On refait le rapport
+On refait le rapport!
 Applaudissements sur les bancs du groupe REM.
 Nous savons donc que ce système ne sera pas pérenne.
 Nous convenons donc tous qu’il faut faire quelque chose.
 Cela fait donc plus de quatre mois et demi que nous discutons avec eux.
-Ce n’est pas vrai
+Ce n’est pas vrai!
 Nous nous accordons tous à dire que dix-huit milliards d’APL, ce n’est pas tenable.
-Vous n’êtes pas sérieux
+Vous n’êtes pas sérieux!
 Alors, que faire?
 Nous avons des convictions.
-Si l’on touche aux allocations, ils seront forcément affectés dans leurs conditions de vie
+Si l’on touche aux allocations, ils seront forcément affectés dans leurs conditions de vie!
 Chaque année, huit mille nouvelles personnes bénéficient d’un logement social.
-Demandez à des experts comme Monsieur Peu si ces prêts ne sont pas utiles
+Demandez à des experts comme Monsieur Peu si ces prêts ne sont pas utiles!
 C’est pour cela que les bailleurs sociaux nous demandent de réfléchir à ce sujet.
-Cela nous laisserait le temps de trouver une solution
+Cela nous laisserait le temps de trouver une solution!
 On ne réglerait qu’un problème budgétaire en apportant une solution pour réduire le déficit.
 Mais j’entends votre point de vue et nous pourrons en reparler dans le détail.
 Je ne raisonne pas sous l’angle des APL mais sous celui des loyers.
 Si les loyers diminuent, les APL diminuent de facto.
 Notre seul objectif est d’améliorer la situation pour que les loyers diminuent.
-Ce ne sera pas une diminution des loyers pour les locataires
+Ce ne sera pas une diminution des loyers pour les locataires!
 Vous avez également évoqué le sujet du FNAP, qui me tient particulièrement à cœur.
 Deuxièmement, il a été beaucoup question d’accession sociale.
 Les outils existants ne permettent pas de discerner.
@@ -113,14 +113,14 @@ Vous avez raison, le sens de l’histoire, c’est de territorialiser la politiq
 Il doit donc être revu au cours du premier semestre de deux mille dix-huit.
 Je suis totalement d’accord avec vous, il faudra aller plus loin, à terme.
 Enfin, la mutualisation se fait aujourd’hui à deux titres.
-Cela me fait plaisir de l’entendre
+Cela me fait plaisir de l’entendre!
 Aujourd’hui, les offices et les sociétés se trouvent dans des situations très différentes.
 Cette mutualisation fera donc l’objet d’une prochaine discussion au cours de la navette.
 La parole est à Monsieur François Pupponi, pour soutenir l’amendement numéro trois cent cinquante-sept.
 Ce surloyer sera donc très vite appliqué dans un certain nombre de territoires.
 Or tout le monde sait que c’est une machine à casser la mixité sociale.
 La présence de locataires disposant d’un certain revenu favorise la mixité dans les quartiers.
-N’aggravez pas une situation qui est déjà compliquée dans des quartiers extrêmement ghettoïsés
+N’aggravez pas une situation qui est déjà compliquée dans des quartiers extrêmement ghettoïsés!
 La parole est à Monsieur Stéphane Peu, pour soutenir l’amendement numéro trois cent quatre-vingt-quinze.
 La parole est à Monsieur François Jolivet, pour soutenir l’amendement numéro six cent soixante-treize.
 L’appliquer au premier euro peut être une bonne solution dans certains cas.
@@ -158,7 +158,7 @@ La parole est à Monsieur Marc Fesneau, pour soutenir l’amendement numéro qua
 Par cohérence, je retire cet amendement.
 Je suis saisi de plusieurs amendements portant article additionnel après l’article cinquante-deux.
 Si c’était possible, j’aimerais sous-amender l’amendement du Gouvernement.
-Parlons-en et travaillons ensemble sur ce sujet
+Parlons-en et travaillons ensemble sur ce sujet!
 La parole est à Madame Christelle Dubos, pour soutenir l’amendement numéro trois cent quatre-vingt-dix-neuf.
 La parole est à Monsieur François Pupponi, pour les soutenir.
 Ces trois amendements sont défendus.
@@ -169,15 +169,15 @@ Monsieur Pupponi et d’autres députés proposent par exemple d’introduire un
 Une telle mesure se traduit donc par une perte sèche pour l’ensemble des allocataires.
 L’avis du Gouvernement est défavorable.
 Nous sommes en désaccord, monsieur le secrétaire d’État.
-Ce sont deux choses différentes
+Ce sont deux choses différentes!
 Voilà ce qui nous différencie.
 Vous dites que vous ne voulez pas affecter le pouvoir d’achat des locataires.
 Certains allocataires sont donc parfois pénalisés.
-La mesure s’appliquera en deux mille dix-huit
-Tout à fait
+La mesure s’appliquera en deux mille dix-huit!
+Tout à fait!
 Nos approches sont différentes.
 Intellectuellement, je comprends la réforme que vous proposez.
-Toute réforme fait des perdants
+Toute réforme fait des perdants!
 La question qui nous occupe est de savoir comment inverser cette tendance.
 J’y souscris toutefois pleinement, pour trois raisons.
 La troisième raison est que cette proposition figure dans mon rapport spécial.
@@ -214,7 +214,7 @@ Nous en reparlerons dans les prochains jours.
 La parole est à Monsieur François Pupponi, pour soutenir l’amendement numéro trois cent soixante-quatre.
 La parole est à Monsieur Stéphane Peu, pour soutenir l’amendement numéro trois cent soixante-dix-sept.
 Je partage complètement les propos de Madame Le Meur.
-Pas seulement dans ces quartiers, dans les campagnes aussi
+Pas seulement dans ces quartiers, dans les campagnes aussi!
 Il faut vraiment s’y attaquer, même si cette mesure n’y suffira sans doute pas.
 Je voudrais souligner que l’on gagne en efficacité.
 Ensuite, on parle d’, emplois francs.
@@ -226,26 +226,26 @@ C’est effectivement de discrimination qu’il s’agit, mais aussi d’inégal
 La parole est à Madame Annaïg Le Meur, rapporteure pour avis.
 Je remercie tout d’abord les personnes qui m’ont accompagnée pendant la rédaction de rapport.
 Il y a eu de belles rencontres.
-C’est du caporalisme
-Nous comprenons la même chose
+C’est du caporalisme!
+Nous comprenons la même chose!
 Quid de votre amendement, monsieur Pupponi?
 Moi aussi, je m’y perds un peu.
 C’est une vraie question juridique et réglementaire.
 Sur le fond, nous sommes tous d’accord pour adopter une telle mesure.
-La rapporteure pour avis ne peut pas retirer le sien
+La rapporteure pour avis ne peut pas retirer le sien!
 Cela a été toléré dans le passé.
-Il n’y a pas d’histoire qui tienne
+Il n’y a pas d’histoire qui tienne!
 Est-ce réglementaire?
-C’est en tout cas jupitérien
+C’est en tout cas jupitérien!
 Sourires.
-Ça suffit, on vous a compris
+Ça suffit, on vous a compris!
 Mes chers collègues, je vous propose de suspendre la séance quelques minutes.
 Voici une clarification sur ce qu’un rapporteur peut faire ou non.
 Il peut donc tout à fait décider de retirer un amendement.
 À ce propos, je suis heureux, madame la ministre, que vous les avez reçus.
 Je vous répondrez néanmoins sur quatre points, monsieur Pupponi.
 Je préfère donc retirer l’amendement numéro deux cent quatre-vingt-douze à son profit.
-Bien sûr
+Bien sûr!
 Nous ne sommes qu’au début du processus.
 Chacun pourra y trouver son compte, y compris en termes d’affichage.
 La parole est à Monsieur Mohamed Laqhila, rapporteur spécial.
@@ -268,20 +268,20 @@ La difficulté vient de ce que la Constitution impose aujourd’hui de général
 L’éducation et la sécurité en sont deux exemples.
 Les acteurs de la politique de la ville attendent donc un message.
 Ces amendements d’appel ont ainsi pour objectif d’instaurer le dialogue.
-Entendez ce qui s’est passé à Grigny, monsieur le secrétaire d’État
-Exactement
+Entendez ce qui s’est passé à Grigny, monsieur le secrétaire d’État!
+Exactement!
 Nous devions en parler.
 Aujourd’hui, Jacques Mézard est absent de cet hémicycle parce qu’il est à Grigny.
-Je pensais qu’il était fatigué
+Je pensais qu’il était fatigué!
 J’attends donc l’appel de Grigny.
-Oui, vous l’entendez, mais vous ne faites rien
+Oui, vous l’entendez, mais vous ne faites rien!
 Certains élus locaux et associations de ces quartiers sont aujourd’hui épuisés.
 Le rôle de l’État est de les accompagner le plus possible.
 La parole est à Monsieur Adrien Quatennens, pour soutenir l’amendement numéro trois cent vingt-neuf.
 Elle a enfin recommandé à la France de faire davantage d’efforts sur ce plan.
 Pour ces raisons, mon avis est défavorable.
 Aujourd’hui, dans ce domaine, nous avons tout ce qu’il faut pour agir.
-Tout, peut-être pas
+Tout, peut-être pas!
 Ce n’est pas un énième rapport qui va nous indiquer ce qu’il faut faire.
 La réalité, la voilà.
 Un comité interministériel du handicap s’est tenu il y a quelques semaines.
@@ -290,7 +290,7 @@ La mobilisation de tous et l’organisation d’un débat dans l’hémicycle on
 Voilà pourquoi, à titre personnel, je voterai cet amendement.
 La parole est à Madame Mathilde Panot.
 Voilà pourquoi nous demandons ce rapport.
-Il faut arrêter la caricature deux minutes
+Il faut arrêter la caricature deux minutes!
 Nous, nous les avons beaucoup vus, et nous avons travaillé avec eux.
 Voilà le résultat du travail que nous avons mené avec les associations.
 Alors, s’il vous plaît, pas de caricature à ce sujet.
@@ -300,7 +300,7 @@ Avis défavorable, même si, quant au fond, je partage votre point de vue.
 Comme souvent, La parole est à Monsieur Stéphane Peu.
 J’en citerai un seul exemple, parmi bien d’autres.
 La parole est à Monsieur Alexis Corbière, pour soutenir l’amendement numéro trois cent trente-cinq.
-Le spécialiste des zones rurales
+Le spécialiste des zones rurales!
 Le ministre a installé un groupe de travail sur le sujet.
 Il ne nous paraît pas légitime d’ajouter des indicateurs aux outils existants.
 Avis défavorable à titre personnel, cet amendement n’ayant pas été présenté en commission.
@@ -359,7 +359,7 @@ séance est ouverte.
 Ce matin, l’Assemblée a commencé d’entendre les orateurs inscrits dans la discussion générale.
 La parole est à Monsieur Denys Robiliard.
 Ensuite, quand on veut restaurer un dispositif, peut-être faut-il se pencher sur ses résultats.
-Depuis votre arrivée, c’est déjà quatre cents 000 de plus
+Depuis votre arrivée, c’est déjà quatre cents 000 de plus!
 Monsieur Borloo nous taxait tout à l’heure d’erreur idéologique.
 Je m’en explique.
 Cela, vous le savez depuis janvier deux mille neuf.
@@ -370,51 +370,51 @@ D’abord, celui du Conseil des prélèvements obligatoires.
 C’est vrai.
 Or nous savons, vous comme moi, la différence entre la moyenne et la médiane.
 On reste dans la redistribution négative.
-Heureusement, vous êtes là
+Heureusement, vous êtes là!
 Vous persistez dans ce cynisme avec cette proposition.
-Plus le revenu monte, moins ça baisse
+Plus le revenu monte, moins ça baisse!
 Vous économisez mal.
-Vive la hausse de la TVA
+Vive la hausse de la TVA!
 Les emplois d’avenir, c’est ça.
-Les vrais chiffres seront connus ce soir
+Les vrais chiffres seront connus ce soir!
 Leurs bénéficiaires sont sortis de l’école sans formation valable sur le marché de l’emploi.
 Quelques-uns seulement bénéficient du RSA.
-Ce soir, il y aura des bons chiffres
+Ce soir, il y aura des bons chiffres!
 Cette politique semble commencer à porter ses fruits.
 C’est visible depuis cinq mois maintenant sur le chiffre du chômage des jeunes.
 Elle pèsera nécessairement sur les chiffres du chômage dans leur globalité.
 Je souhaite que vous ayez raison.
 Votre proposition de loi est une pure opération de communication.
 Elle est à désespérer de l’opposition.
-N’importe quoi
+N’importe quoi!
 Ne riez pas, monsieur, ils ne méritent pas les quolibets.
 L’industrie française connaît de grandes difficultés, de même que ma région.
-Je confirme
+Je confirme!
 Il n’y tient pas le même discours.
 Je n’en doute pas, monsieur le rapporteur, vous qui pouvez en témoigner.
 C’est en effet, pour être tout à fait honnête, une vraie question.
-On attend la réponse
+On attend la réponse!
 J’ai visité hier après-midi une usine de plastique dans l’Ain.
 À Oyonnax.
 Exactement, chez notre collègue Damien Abad.
 Vous parliez tout à l’heure de preuves et de rapports.
-voici les explications
+voici les explications!
 L’espoir que vous avez porté est démenti.
 aux dîners avec les ouvriers de France.
-Gardez vos insultes pour vous
-Il faut savoir, Il s’enfonce, le camarade
+Gardez vos insultes pour vous!
+Il faut savoir, Il s’enfonce, le camarade!
 distinguer très concrètement l’idéologie du pragmatisme.
 Je ne suis pas votre camarade mais, éventuellement, votre compagnon, cher ami.
 Son collègue Laurent Grandguillaume, votre camarade, cher monsieur Sebaoun, a partagé ce constat-là.
 Qui a le plus bénéficié de cette somme?
-Les ménages les plus modestes
+Les ménages les plus modestes!
 Ce n’est pas vrai.
-Parce que lorsque l’on paie des impôts, on est aisé
-Descendons aux trente-deux heures
-C’est sûr
+Parce que lorsque l’on paie des impôts, on est aisé!
+Descendons aux trente-deux heures!
+C’est sûr!
 Ce sera déjà moins bien.
 Depuis que Monsieur Hollande est aux responsabilités, tous les indicateurs sont au rouge.
-Monsieur le ministre, écoutez les chefs d’entreprise, écoutez les artisans, écoutez les salariés
+Monsieur le ministre, écoutez les chefs d’entreprise, écoutez les artisans, écoutez les salariés!
 Venez dans l’Yonne, à Auxerre ou en Puisaye, et je vous en présenterai.
 Ils n’en peuvent plus.
 Oui, monsieur le ministre, il y a urgence à changer de politique.
@@ -422,119 +422,119 @@ Vous avez commis une triple faute, à la fois sociale, économique, et morale.
 Hélas, c’était, tristement, un mensonge.
 La vérité, c’est que cette mesure funeste n’a pas créé d’emplois.
 C’est une évidence.
-Vous enfilez des perles
-Il n’a pas corrigé grand-chose
+Vous enfilez des perles!
+Il n’a pas corrigé grand-chose!
 En effet.
 C’est une aberration économique, qui coûte plus qu’elle ne rapporte.
-Nous avons seulement voulu soutenir nos entreprises
-Pas tous
-Tous, sauf un
-Sauf trois dont le porte-parole du groupe
+Nous avons seulement voulu soutenir nos entreprises!
+Pas tous!
+Tous, sauf un!
+Sauf trois dont le porte-parole du groupe!
 Nous finançons également l’activité partielle.
 C’est pourquoi nous voterons contre cette proposition de loi.
-C’est implacable
+C’est implacable!
 La parole est à Madame Annie Le Houerou.
-Personne n’a oublié la chimère
-Travailler plus pour gagner plus
+Personne n’a oublié la chimère!
+Travailler plus pour gagner plus!
 Or c’est la première de nos préoccupations, et notamment l’emploi des jeunes.
 Ainsi, chaque salarié avait systématiquement quatre à cinq heures supplémentaires chaque semaine.
 Les salariés s’en satisfaisaient, car elles constituaient un complément de revenu défiscalisé.
-J’ai dit qu’elles les payaient en partie, ne caricaturez pas mes propos
-C’est beaucoup mieux
-Cela ne se décrète pas, l’emploi
+J’ai dit qu’elles les payaient en partie, ne caricaturez pas mes propos!
+C’est beaucoup mieux!
+Cela ne se décrète pas, l’emploi!
 Je rappelle à ce propos le succès des emplois d’avenir.
-Je souhaite que nous exprimions notre rejet de cette mesure inefficace
+Je souhaite que nous exprimions notre rejet de cette mesure inefficace!
 C’est bien par l’emploi que les Français pourront retrouver un pouvoir d’achat plus important.
 La parole est à Monsieur Arnaud Richard, rapporteur de la commission des affaires sociales.
 Peut-être nous sommes-nous trompés sur la loi TEPA, peut-être n’était-elle pas parfaite.
 Un marqueur existe manifestement, vu la difficulté que nous avons pour nous entendre.
 Nous n’avons donc de leçon à recevoir de personne, monsieur le ministre.
 Ces deux options étaient en débat.
-Vous ne semblez pas très serein
+Vous ne semblez pas très serein!
 J’aimerais conclure avec deux ou trois commentaires.
 La parole est à Monsieur Jean-Louis Borloo.
-Le propre de la démocratie, c’est de pouvoir se parler
-Vous avez dit cela pendant dix ans
+Le propre de la démocratie, c’est de pouvoir se parler!
+Vous avez dit cela pendant dix ans!
 La parole est à Monsieur Lionel Tardy.
 Sans surprise, je suis très favorable à cette proposition de loi de l’UDI.
 à lui donner.
 Cela devrait balayer les réserves de la majorité et l’inciter à voter ce texte.
-Je remarque que le groupe UDI persiste, Et signe
-Pas du tout, elles ne peuvent pas embaucher
-C’est absurde
+Je remarque que le groupe UDI persiste, Et signe!
+Pas du tout, elles ne peuvent pas embaucher!
+C’est absurde!
 On déplace l’équilibre.
 Nous ne partons pas de n’importe quelle situation.
 Comme l’Europe, notre pays connaît depuis six ans une croissance nulle.
-Si
-et c’est bien ce qui vous gêne
+Si!
+et c’est bien ce qui vous gêne!
 Le deuxième objectif était économique.
 Monsieur Muet, nous avons débattu de cette question pendant des heures.
 Une petite minorité de la gauche commence à ouvrir les yeux.
-C’est un rêve
+C’est un rêve!
 En situation de chômage élevé, certains secteurs connaissent une pénurie de main d’œuvre.
-En effet, quatre cent mille emplois ne sont pas pourvus
+En effet, quatre cent mille emplois ne sont pas pourvus!
 Je pourrais vous donner des exemples dans ma propre circonscription.
 Ainsi, le deuxième objectif économique de la mesure était de permettre une meilleure gestion.
 Mais vous ne pouvez pas nier ces deux objectifs.
-Si, nous pouvons les nier
+Si, nous pouvons les nier!
 Le premier objectif a d’ailleurs été atteint.
-Vous avez favorisé la montée du Front national
+Vous avez favorisé la montée du Front national!
 Vous avez amputé le pouvoir d’achat des travailleurs pauvres ou modestes.
 Souvenez-vous, monsieur Muet, même si vous étiez un peu jeune, à l’époque.
 Enfin, monsieur Hamon, vous nous posez la question du financement.
-Nous pouvons vous faire la même réponse, mes chers collègues
+Nous pouvons vous faire la même réponse, mes chers collègues!
 Ce n’est pas moi qui le dis, mais la Cour des comptes.
-Nous sommes donc un peu perplexes quant à votre politique économique
+Nous sommes donc un peu perplexes quant à votre politique économique!
 La parole est à Monsieur Jean-Marc Germain.
-Faites donc quelques heures supplémentaires
+Faites donc quelques heures supplémentaires!
 Je m’adresse à Monsieur Borloo, même s’il est en train de quitter l’hémicycle.
-Non, je suis là
-Ce système est absurde
+Non, je suis là!
+Ce système est absurde!
 Tous les employeurs le savent, les heures supplémentaires, cela se donne.
-C’est L’Assommoir
+C’est L’Assommoir!
 La parole est à Monsieur le rapporteur.
-Cela fait cinq milliards
-Je ne vous reconnais pas, monsieur Hamon
-Bercy, ça change un homme
+Cela fait cinq milliards!
+Je ne vous reconnais pas, monsieur Hamon!
+Bercy, ça change un homme!
 Merci, monsieur le rapporteur.
 Encore quelques mots, madame la présidente.
-Vous avez la parole, mais pas pour huit heures
+Vous avez la parole, mais pas pour huit heures!
 Un dernier point, madame la présidente.
-Ils ont fait exactement le contraire de vous, et cela a fonctionné
+Ils ont fait exactement le contraire de vous, et cela a fonctionné!
 La parole est à Monsieur Francis Vercamer.
-Après les propos de Jean-Marc Germain, Qui démontrent une connaissance fine de l’entreprise
-Rendez-nous Jospin
+Après les propos de Jean-Marc Germain, Qui démontrent une connaissance fine de l’entreprise!
+Rendez-nous Jospin!
 Nous, nous considérons que le travail crée la croissance.
 Si vous supprimez le travail, vous supprimez la croissance, et donc l’emploi.
 Nous en venons à l’examen des amendements.
-Chacun est mis devant ses responsabilités
+Chacun est mis devant ses responsabilités!
 Vous ne voulez pas l’entendre.
-Entendez la voix des travailleurs
+Entendez la voix des travailleurs!
 Par ailleurs, vous tenez un double discours.
 Nous le reconnaissons, cette économie a des conséquences en termes de pouvoir d’achat.
 Mais nous, nous transférons ce pouvoir d’achat à ceux qui n’en ont pas.
 Or sur ce point nous n’avons aucune réponse de  votre part.
-Monsieur Mandon qui est tout de même votre porte-parole, mes chers collègues, Eh oui
+Monsieur Mandon qui est tout de même votre porte-parole, mes chers collègues, Eh oui!
 Vous voilà face à vos propres incohérences et au dogme qui est le vôtre.
 Quoi qu’il en soit, l’avis du Gouvernement est favorable à l’amendement de suppression.
 Nous ne l’avons pas obtenu et nous le déplorons.
-Le choix est si favorable que la courbe du chômage s’inverse
+Le choix est si favorable que la courbe du chômage s’inverse!
 La parole est à Monsieur Gérald Darmanin.
-Chacun ses références, monsieur Robiliard
+Chacun ses références, monsieur Robiliard!
 Vous citez des rapports, vous faites dans la technicité.
-car maintenant ils sont taxés :, C’est la réalité, monsieur Robiliard
+car maintenant ils sont taxés :, C’est la réalité, monsieur Robiliard!
 Nous voterons donc contre la suppression de l’article premier proposée par le groupe socialiste.
 Nous allons procéder au scrutin.
-Monsieur Vigier n’est pas là
+Monsieur Vigier n’est pas là!
 Je mets aux voix l’amendement numéro un.
 Oui, le régime a proportionnellement avantagé les salariés aux revenus les plus élevés.
 C’était avant la loi TEPA.
-Cela n’a rien à voir
+Cela n’a rien à voir!
 Ils n’aiment pas les travailleurs.
-Les classes laborieuses
+Les classes laborieuses!
 À votre place, je ne serai donc pas fier de cet amendement.
 En proportion.
-Lisez le rapport
+Lisez le rapport!
 Quel est l’avis du Gouvernement sur l’amendement numéro deux?
 Avis favorable.
 Ce détricotage n’a rien de surprenant, mais est tout de même décevant.
@@ -544,20 +544,20 @@ Avant de partager le travail, il faut le créer.
 Je mets aux voix l’amendement numéro deux.
 La parole est à Monsieur Denys Robiliard, pour soutenir l’amendement numéro trois.
 Cet amendement propose, ce qui ne surprendra pas, la suppression de l’article trois.
-Hors sujet
-Je ne vais pas citer de mémoire les dates
+Hors sujet!
+Je ne vais pas citer de mémoire les dates!
 Arrêtez donc de dire n’importe quoi pour servir une cause qui est mauvaise.
 Nous assumons, nous, contrairement à vous, la politique qui est la nôtre.
 Nous connaissons ses conséquences en termes de pouvoir d’achat.
-Vous n’avez pas voté en faveur du CICE
+Vous n’avez pas voté en faveur du CICE!
 Quel est l’avis du Gouvernement?
 Favorable.
 Nous considérons, nous, qu’il est urgent de la rétablir.
 Je mets aux voix l’amendement numéro trois.
 La parole est à Monsieur Denys Robiliard, pour soutenir l’amendement numéro quatre.
-Monseigneur est trop bon
+Monseigneur est trop bon!
 La parole est à Monsieur Denys Robiliard, pour soutenir l’amendement numéro cinq.
-Par les temps qui courent, vous auriez au moins pu garder le gage
+Par les temps qui courent, vous auriez au moins pu garder le gage!
 Quel est l’avis de la commission?
 La commission a donné un avis favorable.
 Je comprends donc l’avis de notre collègue Robiliard.
@@ -623,7 +623,7 @@ cent soixante-deux-vingt-deux-quatorze du même code.
 six mille cent vingt-deux-treize du code de la santé publique.
 Elle offre un droit à la liberté de choix.
 Ce fut une expérience très enrichissante pour notre réflexion.
-Bravo, Yannick Favennec
+Bravo, Yannick Favennec!
 La parole est à Madame Bérengère Poletti.
 La plupart des accouchements se passent bien, fort heureusement.
 Les sages-femmes sont compétentes pour suivre des grossesses normales et pratiquer des accouchements normaux.
@@ -633,7 +633,7 @@ En France, la demande d’accoucher à domicile est loin d’être majoritaire c
 Elle ne remet pas en cause la sécurité qu’il est indispensable d’apporter aux parturientes.
 Il aura fallu, c’est vrai, plusieurs débats pour parvenir à cette unité.
 Le groupe UMP soutient et votera ce texte.
-Madame la présidente, madame la ministre, mes chers collègues, enfin
+Madame la présidente, madame la ministre, mes chers collègues, enfin!
 De nombreux pays expérimentent d’ores et déjà ces dispositifs avec une certaine efficacité.
 Ces lieux de naissance seront sécurisés puisqu’ils seront adossés à des maternités.
 Le principe retenu, celui de l’expérimentation, va dans le bon sens.
@@ -642,7 +642,7 @@ Les sages-femmes demeurent le seul et dernier recours pour nombre de femmes.
 La parole est à Madame Catherine Lemorton.
 En termes d’encadrement, elles seront dépendantes des sages-femmes qui y exercent.
 À ce propos, je me félicite, madame la ministre, que vous les ayez reçues.
-Depuis dix ans, peu de gens s’en étaient occupés, il faut bien le dire
+Depuis dix ans, peu de gens s’en étaient occupés, il faut bien le dire!
 C’est vous qui avez fait le premier pas.
 Je souhaite que ce premier pas soit suivi de beaucoup d’autres.
 À titre personnel, je voterai cette proposition de loi.
@@ -676,7 +676,7 @@ La parole est à Monsieur Sylvain Berrios.
 C’est pourquoi nous maintenant notre demande de suppression.
 La parole est à Monsieur Jean-Christophe Fromantin.
 Je partage l’inquiétude de mes collègues face à l’apparition de ce niveau supplémentaire.
-Absolument
+Absolument!
 Je pense qu’elle trahit en réalité la complexité des textes qui nous sont proposés.
 La parole est à Monsieur Jacques Lamblin.
 La parole est à Monsieur Patrick Devedjian, pour soutenir l’amendement numéro trois cent trente-trois.
@@ -685,7 +685,7 @@ C’est la raison pour laquelle ce Haut conseil des territoires est nécessaire.
 Nous savons que, derrière la question des normes, apparaît souvent celle des moyens.
 La Constitution ne prévoit même pas un tel pouvoir d’injonction pour le Parlement.
 La commission des lois a donc émis un avis défavorable à cet amendement.
-Vous créez une hydre à deux têtes
+Vous créez une hydre à deux têtes!
 Nous voyons le paradoxe.
 Je suis saisi d’un amendement rédactionnel, numéro mille cent soixante-trois, présenté par le rapporteur.
 La parole est à Monsieur Jacques Pélissard, pour soutenir l’amendement numéro trois cent un.
@@ -711,16 +711,16 @@ Elle a montré à quel point elle pouvait être efficace et force de proposition
 Je tiens à apporter deux précisions.
 Elle aura peut-être un caractère plus délibératif que la formation plénière.
 Monsieur Berrios, ne me faites pas dire ce que je n’ai pas dit.
-Ce n’est pas la même chose
+Ce n’est pas la même chose!
 C’est un décret en Conseil d’État qui fixera les modalités de désignation.
 La parole est à Monsieur Jacques Pélissard, pour soutenir l’amendement numéro trois cent quatre.
-C’est scandaleux
-Quel mépris à l’égard des maires
-Ce sont eux qui font marcher notre démocratie
-Inscrivez-le dans la loi
+C’est scandaleux!
+Quel mépris à l’égard des maires!
+Ce sont eux qui font marcher notre démocratie!
+Inscrivez-le dans la loi!
 Je reste défavorable à vos amendements.
-Le rapporteur est désavoué
-Un désaveu clair
+Le rapporteur est désavoué!
+Un désaveu clair!
 Les mêmes raisons doivent valoir pour l’ensemble des associations.
 L’ouverture dans la réponse de la ministre permettra d’évoluer en ce sens.
 La parole est à Monsieur Jacques Pélissard, pour soutenir l’amendement numéro trois cent deux.
@@ -728,16 +728,16 @@ C’est un amendement de cohérence avec l’amendement précédent, portant sur
 La parole est à Monsieur Jacques Pélissard, pour soutenir l’amendement numéro deux cent quatre-vingt-dix.
 Quel est l’avis du Gouvernement?
 Je m’en remets à la sagesse de l’Assemblée.
-Cet amendement est discutable, mais que les parlementaires se saisissent de cette question
+Cet amendement est discutable, mais que les parlementaires se saisissent de cette question!
 Amendement de précision.
-Heureusement que Monsieur Carrez essaie de rattraper le texte du Gouvernement
-Les voies du président de la commission des finances sont impénétrables
+Heureusement que Monsieur Carrez essaie de rattraper le texte du Gouvernement!
+Les voies du président de la commission des finances sont impénétrables!
 Sur ces points, nous sommes tous d’accord, une véritable évolution est nécessaire.
 Le fait d’intégrer la commission dans le Haut conseil me paraît une bonne démarche.
 Encore faut-il, en aval, que les avis exprimés par ce Haut conseil soient suivis.
 Il convient en effet de supprimer l’article premier AB, qui introduit un doublon.
-Prévoir qu’il soit remis au Haut Conseil démontre que l’exécutif est schizophrène
-Psychopathe
+Prévoir qu’il soit remis au Haut Conseil démontre que l’exécutif est schizophrène!
+Psychopathe!
 Il s’agit d’une incohérence, d’un doublon, d’un foisonnement administratif.
 L’article premier AB a été étudié de façon extrêmement précise.
 Nous nous porterions mieux si nous suivions l’avis du rapporteur.
@@ -749,12 +749,12 @@ Aujourd’hui, vous créez un lieu d’échanges, le Haut conseil des territoire
 C’est une nouvelle agression scandaleuse à l’encontre des maires.
 Cela revient à maintenir le pouvoir de blocage de telle ou telle collectivité.
 La parole est à Monsieur Jean-Frédéric Poisson.
-Il n’oserait pas
+Il n’oserait pas!
 J’y vois une raison supplémentaire de supprimer cet article.
 La parole est à Monsieur Jean-Christophe Fromantin.
 J’entends la nécessité de cette clause de compétence générale.
 La parole est Monsieur Marc Dolez, pour le soutenir.
-Très juste
+Très juste!
 Cet amendement correspond à l’amendement du Sénat dont est issu l’article premier A.
 Je ne peux être favorable à une rédaction déclarative.
 Le Gouvernement s’en remet à la sagesse de votre assemblée.
@@ -763,49 +763,49 @@ Le groupe UMP votera l’amendement de Monsieur Dolez.
 La commune est la base de notre démocratie.
 L’intercommunalité est une très belle aventure contemporaine, qui monte en puissance.
 L’essence du pouvoir continue d’appartenir aux communes.
-Une fois les bornes franchies, il n’y a plus de limites
+Une fois les bornes franchies, il n’y a plus de limites!
 La parole est à Monsieur Jean-Yves Le Bouillonnec.
 Cet amendement nous gêne.
 L’intercommunalité n’est pas une collectivité, même si les choses évolueront peut-être un jour.
 Le problème, pour nous, c’est que cet amendement ne dit rien en définitive.
-Ça, c’est du costaud
+Ça, c’est du costaud!
 Tel est mon sentiment personnel.
 La parole est à Monsieur Patrick Ollier.
 Au-delà d’une pétition d’intentions, cet amendement réaffirme la vocation de la commune.
-L’unanimité devrait nous porter vers cet amendement
-On fait la loi, pas une pétition
+L’unanimité devrait nous porter vers cet amendement!
+On fait la loi, pas une pétition!
 Je comprends que cet amendement perturbe la majorité et le groupe socialiste.
-Ne vous inquiétez pas pour nous
-Oui, la commune est un point essentiel, fondamental
+Ne vous inquiétez pas pour nous!
+Oui, la commune est un point essentiel, fondamental!
 Vous êtes en train de la piétiner.
-Cela vous embête de voter cet amendement, nous le voterons des deux mains
+Cela vous embête de voter cet amendement, nous le voterons des deux mains!
 La parole est à Monsieur Marc Dolez.
 J’invite donc l’Assemblée à le voter, si possible à l’unanimité.
 J’invite donc vraiment l’Assemblée à voter notre amendement.
 Nous pouvons entendre tous les arguments.
-Appelez à la sagesse de l’Assemblée, alors
+Appelez à la sagesse de l’Assemblée, alors!
 et que le sujet est réel.
-On n’est pas chez le psy
+On n’est pas chez le psy!
 La parole est à Madame Nathalie Appéré.
-Alors votez-le
-Oui, votez-le
+Alors votez-le!
+Oui, votez-le!
 Pour cette raison, nous voterons contre cet amendement.
 Or, avec la métropole, les conseils d’agglomération vont disparaître.
 Nous nous situons là au cœur de la démocratie.
-J’aime les débats rhétoriques, mais encore faut-il qu’ils aient un fondement
-Quelle insulte
-Ce sont bien là deux conceptions différentes
-Aux voix
-Passons au vote, monsieur le président
-Pour paraphraser un précédent pape, je vous dirai ceci, n’ayez pas peur
-Oui, assumez
+J’aime les débats rhétoriques, mais encore faut-il qu’ils aient un fondement!
+Quelle insulte!
+Ce sont bien là deux conceptions différentes!
+Aux voix!
+Passons au vote, monsieur le président!
+Pour paraphraser un précédent pape, je vous dirai ceci, n’ayez pas peur!
+Oui, assumez!
 Revenons au cas de la métropole lyonnaise.
-Le fait que vous ne votiez pas cet amendement est un aveu majeur
+Le fait que vous ne votiez pas cet amendement est un aveu majeur!
 L’intercommunalité n’est donc rien d’autre qu’un instrument, naturellement au service des citoyens.
 Par conséquent, celui qui demande la parole l’obtient.
 Je suis stupéfait des propos que vient de tenir le président du groupe socialiste.
 C’est honteux d’accuser les communes d’être une source d’inefficacité.
-Quel aveu
+Quel aveu!
 En réalité, vous voulez les contourner et c’est exactement ce que contient ce texte.
 Vous voulez mettre les communes à votre botte.
 Je mets aux voix l’amendement numéro mille trente-neuf rectifié.
@@ -816,24 +816,24 @@ Avis défavorable donc.
 La parole est à Monsieur Étienne Blanc, pour soutenir l’amendement numéro sept cent quarante-six.
 Nous pensons que ces conventions doivent être encadrées.
 Cet amendement aura le mérite d’apporter de la clarté et de la lisibilité.
-C’est bien vu
-J’apprécie que Monsieur Poisson reconnaisse ma perspicacité sur cet amendement
+C’est bien vu!
+J’apprécie que Monsieur Poisson reconnaisse ma perspicacité sur cet amendement!
 L’expression, fixent les compétences, est malheureusement assez peu précise.
 La parole est à Monsieur Marc Dolez, pour soutenir l’amendement numéro mille trente-huit.
 Je réaffirme que nous sommes, nous aussi, attachés à l’autonomie des collectivités locales.
-C’est rassurant
+C’est rassurant!
 Les députés du groupe UMP voteront l’amendement de Monsieur Dolez.
 Cela ne règle donc pas du tout le problème des départements de France.
 Pour toutes ces raisons, nous voterons l’amendement de Monsieur Dolez.
 Je trouve cet amendement extrêmement important.
 La parole est à Madame la ministre déléguée.
 Le Gouvernement entend bien vos observations.
-Il y aura de bons départements et de mauvais départements
+Il y aura de bons départements et de mauvais départements!
 Il vous demande de le retirer, sinon il devra émettre un avis défavorable.
-Vous maltraitez votre majorité
+Vous maltraitez votre majorité!
 Le Gouvernement prend ses responsabilités.
 Si j’étais communiste, j’en tirerais des conséquences.
-Mais il est vrai que je ne suis pas communiste
+Mais il est vrai que je ne suis pas communiste!
 Le rappel contenu dans l’amendement de Monsieur Dolez est intéressant, pour plusieurs raisons.
 Aujourd’hui, l’estimation du Gouvernement est de trois milliards, contre dix milliards pour le CEPRI.
 La parole est à Monsieur Alain Chrétien, pour soutenir l’amendement numéro deux cent vingt-deux.
@@ -843,11 +843,11 @@ Il est de suppression, pour les raisons excellemment rappelées par notre collè
 Quel est l’avis de la commission?
 Sans surprise, ce sera un avis défavorable.
 Cela ne s’est pas traduit dans le vote.
-Soyez sérieux, monsieur le rapporteur
+Soyez sérieux, monsieur le rapporteur!
 Je tenais à le rappeler.
 Cet article est central, madame le ministre.
 Il nous met devant la ligne générale du texte que vous proposez.
-Nous applaudissons au choc de simplification
+Nous applaudissons au choc de simplification!
 La cohérence commanderait d’établir une hiérarchie des pouvoirs locaux et d’organiser leur complémentarité.
 Cet article ouvre le débat sur les financements croisés.
 nous retombons dans une autre forme d’incohérence dont nous reparlerons tout à l’heure.
@@ -870,11 +870,11 @@ La parole est à Monsieur Sylvain Berrios, pour soutenir l’amendement numéro 
 La parole est à Monsieur Paul Molac, pour soutenir l’amendement numéro quarante-six.
 Certains conseillers généraux m’ont même dit qu’ils le souhaitaient.
 Murmures.
-Des noms
-Voilà nos nouveaux Chouans
+Des noms!
+Voilà nos nouveaux Chouans!
 L’avis de la commission est donc défavorable sur ces deux amendements.
 Les députés du groupe UMP voteront évidemment contre ces deux amendements.
-C’est un écran de fumée
+C’est un écran de fumée!
 pour moderniser enfin l’organisation de notre pays.
 La parole est à Monsieur Paul Molac.
 Prenons le secteur de l’enseignement.
@@ -882,18 +882,18 @@ Je suis saisi de deux amendements identiques, numéros cent quatre-vingt-six et 
 La parole est à Monsieur Matthias Fekl, pour soutenir l’amendement numéro cent quatre-vingt-six.
 Pourtant, elle pose déjà un certain nombre de difficultés.
 D’une part, les compétences en question ne sont pas totalement exclusives.
-Il faut retirer ces amendements
+Il faut retirer ces amendements!
 Quel est l’avis du Gouvernement?
 Je trouve à ces amendements un intérêt pédagogique.
 C’est ce qui me préoccupe.
 Je rebondis sur un point particulier.
-Cela existe déjà
+Cela existe déjà!
 Avec ces amendements, cela poserait des problèmes juridiques.
-C’est vraiment un embrouillamini
+C’est vraiment un embrouillamini!
 Que l’on parle des métropoles, très bien.
 Que l’on parle des schémas, fort bien.
 Mais tout le reste est, me semble-t-il, hors sujet.
-On préfère, par conséquent, le chaos
+On préfère, par conséquent, le chaos!
 à une clarification que l’on corrigerait ensuite par la loi.
 Je ne crois pas que cet argument soit recevable.
 Par essence, la loi est évolutive.
@@ -901,7 +901,7 @@ Il appartient au Parlement de revenir dessus si nécessaire.
 La parole est à Monsieur Matthias Fekl.
 La parole est à Monsieur Thierry Braillard.
 Nous y reviendrons certainement lorsque nous examinerons les autres textes.
-Je suis d’accord
+Je suis d’accord!
 Reprenons l’argumentation du rapporteur.
 Je retire donc l’amendement numéro sept cent quatre-vingt-quatorze.
 La parole est à Monsieur Paul Molac, pour soutenir l’amendement numéro quarante-sept.
@@ -921,8 +921,8 @@ Je retire l’amendement numéro cent cinquante-cinq.
 La parole est à Monsieur Jean-Luc Laurent, pour soutenir l’amendement numéro mille quatre-vingt-dix-sept rectifié.
 Cette égalité est assurée par la dimension législative de la décentralisation.
 C’est pourquoi je propose la suppression de ces alinéas vingt à vingt-sept.
-Excellent
-Funeste commission
+Excellent!
+Funeste commission!
 Insistons sur le fait qu’il s’agit d’une possibilité et non d’une obligation.
 D’autre part, cela s’appuiera sur un accord des parties concernées.
 D’où cet avis défavorable.
@@ -933,22 +933,22 @@ Il y a plusieurs manières de transférer ou de déléguer une compétence.
 On peut la transférer, et transférer les personnels afférents.
 Tout cela est donc complexe.
 Mais arrêtons-nous pour l’instant à cette possibilité, nous reviendrons à ce sujet plus tard.
-Il faut donc que vous acceptiez cet amendement
+Il faut donc que vous acceptiez cet amendement!
 C’est particulièrement vrai des enjeux soulevés par le présent projet de loi.
 L’amendement défendu par notre collègue Jean-Luc Laurent est tout à fait intéressant.
 Nous touchons là au fond du problème de l’égalité des territoires.
-Les citoyens doivent savoir qui fait quoi
+Les citoyens doivent savoir qui fait quoi!
 Je m’apprête à voter pour l’excellent amendement déposé par Monsieur Laurent.
 En effet, le texte adopté par la commission des lois pose deux problèmes.
 Premièrement, il pose le problème de l’unité de la République et de l’État.
 Deuxièmement, il suscitera un chaos territorial.
-Chaos, c’est un peu fort
+Chaos, c’est un peu fort!
 Le simple fait, madame la ministre, d’aborder ce débat est inquiétant.
 Ce n’est pas aujourd’hui que ce débat doit avoir lieu.
-Ce faisant, vous organisez le chaos
+Ce faisant, vous organisez le chaos!
 Je crois donc que ce texte causera une très forte rupture d’égalité.
 Je ne vois, pour ma part, aucune rupture d’égalité, bien au contraire.
-C’est de la jalousie territoriale
+C’est de la jalousie territoriale!
 Non, il ne faut pas confondre l’égalité et l’équité, qui sont deux choses différentes.
 Le dispositif incriminé prévoit que l’État délègue une de ses compétences.
 Je prendrai un exemple pour montrer comment cela se passe dans les faits.
@@ -958,23 +958,23 @@ Je ne partage donc pas les inquiétudes de Monsieur Ollier et de Monsieur Lauren
 La parole est à Monsieur Patrick Devedjian.
 Je ferai simplement deux observations.
 La première, c’est qu’en effet, une délégation n’est pas une décentralisation.
-Bel exemple
+Bel exemple!
 Cette délégation fonctionne déjà, mais d’une manière inégale.
 En effet, la délégation est généralement assortie d’une convention.
 Or cette dernière n’est pas forcément la même pour toutes les collectivités.
 Dès lors, cela pose un véritable problème.
 Ce principe est fondamental, je pense même qu’il est de rang constitutionnel.
 Le droit est général, sauf à ce qu’il y ait rupture de l’égalité.
-C’est un droit
+C’est un droit!
 J’ai le sentiment que tel n’est pas le chemin inconsciemment emprunté ici.
 La parole est à Monsieur Jean-Louis Gagnaire.
 Il ne faut pas craindre les expérimentations de délégations.
-Évidemment non
+Évidemment non!
 C’est le sens de l’histoire.
-Vous refusez l’expérimentation
-Il n’y a pas d’expérimentation
+Vous refusez l’expérimentation!
+Il n’y a pas d’expérimentation!
 Il faut veiller à ce qu’elles soient généralisables, chaque fois que c’est possible.
-On ne parle pas de la même chose
+On ne parle pas de la même chose!
 Il faut donc évacuer ce type de crainte.
 Vous refusez d’organiser un référendum sur toutes ces questions afin de consulter les populations.
 Les citoyens sont attachés à la commune.
@@ -1002,20 +1002,20 @@ Cela s’appuiera sur une volonté réciproque.
 Je rappelle que la commission a donné un avis défavorable à cet amendement.
 La parole est à Madame la ministre.
 Chaque mot compte a été pesé.
-et dans les domaines prévus par la loi
+et dans les domaines prévus par la loi!
 C’est bien le Parlement qui le précisera.
 Il n’y a donc pas d’inquiétude majeure à avoir, tout est juridiquement bien bordé.
-Monsieur Ollier est rassuré
+Monsieur Ollier est rassuré!
 La parole est à Monsieur Jean-Luc Laurent.
-Il aurait fallu voter la motion de renvoi en commission
+Il aurait fallu voter la motion de renvoi en commission!
 En fait, la suppression des alinéas demandée par Monsieur Laurent n’empêcherait rien.
-Dommage
+Dommage!
 L’action du chef de file s’inscrit dans un cadre librement consenti.
 C’est aussi une question de pédagogie.
 Même si vous le supprimez, cela n’aura en réalité aucun effet.
 Il y a donc là une forme de paradoxe terrible de l’écriture du droit.
 J’avoue donc être un petit peu perdu.
-Monsieur Poisson est lyrique
+Monsieur Poisson est lyrique!
 La parole est à Madame Nathalie Appéré, pour soutenir l’amendement.
 L’avis est donc favorable sous réserve de l’adoption de ce sous-amendement.
 Je maintiens cet amendement.
@@ -1034,7 +1034,7 @@ ce qui n’est pas le cas avec le conseil régional.
 Cette cohérence s’appuie déjà sur des outils.
 Nous y travaillons.
 La parole est à Monsieur Jean-Frédéric Poisson, pour soutenir l’amendement numéro deux cent soixante-quatorze.
-Parfait
+Parfait!
 Qu’est-ce que cela signifie?
 Je suis perclus par cette clarté.
 Je poursuis.
@@ -1045,8 +1045,8 @@ Je ne le répéterai pas, puisque Monsieur Poisson l’a intégré.
 Le chef de file reste cantonné à un rôle d’impulsion.
 J’y reviendrai plus tard.
 Nous vous donnons donc entière satisfaction.
-Si seulement c’était vrai
-Mais ça l’est
+Si seulement c’était vrai!
+Mais ça l’est!
 La parole est à Madame Jacqueline Fraysse, première oratrice inscrite sur l’article.
 Monsieur le président, je serai la seule intervenante sur cet article.
 Nous tenons cependant à souligner combien ces droits sont étroitement plafonnés.
@@ -1063,7 +1063,7 @@ Ce sera un progrès significatif pour ces ouvriers.
 Nous en venons aux amendements.
 La parole est à Monsieur Dolez, pour soutenir l’amendement numéro sept cent soixante-seize.
 C’est donc l’atténuation d’un recul social.
-Non, monsieur Dolez
+Non, monsieur Dolez!
 Cela ne nous paraît pas juste.
 C’est la raison pour laquelle nous proposons cet amendement qui a deux objectifs.
 Dans le cas contraire, le diable se cache dans les détails, comme chacun sait.
@@ -1088,24 +1088,24 @@ Les bases ont été mises en place, et on construit dessus.
 C’est donc que les pierres de base étaient bonnes.
 Peut-être une recomposition ou un repositionnement doivent-ils être effectués.
 Ce que je voudrais, ce sont des précisions sur ce comité scientifique.
-Merci
-Merci de le reconnaître au bout de cinq jours
+Merci!
+Merci de le reconnaître au bout de cinq jours!
 Simplement, vous n’êtes pas allés suffisamment vite, ni suffisamment loin.
 C’est un très grand progrès social.
 La parole est à Madame Isabelle Le Callennec.
 C’est le moment, pour le groupe UMP, de redire sa position.
-Nous avons peut-être parfois été caricaturés par la majorité, Vous avez été caricaturaux, surtout
+Nous avons peut-être parfois été caricaturés par la majorité, Vous avez été caricaturaux, surtout!
 mais nous tenions à remettre les choses au clair.
 Nous voulions donc un peu plus de lisibilité.
 C’est exact.
 Merci, monsieur le président.
-Restez modeste
+Restez modeste!
 J’ai dit qu’une partie du dispositif pénibilité de deux mille dix était abrogée.
 Or j’ai dit le contraire, vous m’en excuserez.
 Ce matin, j’ai eu un problème de démarrage.
-Il faut le temps de l’échauffement
-Je veux donc faire acte d’humilité
-C’est mieux comme ça
+Il faut le temps de l’échauffement!
+Je veux donc faire acte d’humilité!
+C’est mieux comme ça!
 Et j’ai déjà eu la réponse à ces arguments.
 La parole est à Monsieur Arnaud Robinet, pour soutenir l’amendement numéro six.
 Nous voulons, nous aussi, la réussite de ce compte pénibilité.
@@ -1114,14 +1114,14 @@ Il faudra donc du temps.
 La parole est à Monsieur Arnaud Robinet, pour soutenir l’amendement numéro huit.
 Défendu également.
 La parole est à Monsieur Dominique Tian, pour soutenir l’amendement numéro cent onze.
-Vous êtes mal réveillé
+Vous êtes mal réveillé!
 On voit bien que les DRH auront une surcharge de travail.
 À l’évidence, beaucoup de difficultés se poseront.
-Pour vous, ce n’est pas grave de rajouter des normes
+Pour vous, ce n’est pas grave de rajouter des normes!
 C’est normal, on le comprend, vous avez quelques raisons de le faire.
-Mais, à l’évidence, vous ne simplifiez pas, monsieur Terrasse
-Ou alors, vous simplifiez à la socialiste
-Pour l’instant, c’est vous qui voulez complexifier le dispositif
+Mais, à l’évidence, vous ne simplifiez pas, monsieur Terrasse!
+Ou alors, vous simplifiez à la socialiste!
+Pour l’instant, c’est vous qui voulez complexifier le dispositif!
 Cela posera donc quelques soucis.
 De plus, le Gouvernement mettra du temps à faire paraître les décrets d’application nécessaires.
 Il est donc normal que nous demandions un délai supplémentaire.
@@ -1130,12 +1130,12 @@ Repousser l’application de ces dispositifs aux salariés des petites entrepris
 Nous avons essayé de vous l’expliquer clairement.
 Hier soir, les deux ministres ont fait un travail pédagogique important.
 Une grande partie d’entre vous l’ont d’ailleurs reconnu.
-Monsieur Tian, il faut savoir
+Monsieur Tian, il faut savoir!
 Employeurs et salariés doivent faire preuve de bonne volonté.
 Je me réjouis des propos tenus par Monsieur Robinet.
 Cela veut dire qu’au fond, cette grande avancée est très difficile à contester.
-Même si Monsieur Tian a souhaité la limiter, Nous construisons tous ensemble
-L’Assemblée nationale n’est pas une caserne
+Même si Monsieur Tian a souhaité la limiter, Nous construisons tous ensemble!
+L’Assemblée nationale n’est pas une caserne!
 La parole est à Monsieur Arnaud Robinet.
 Ces points posent en effet problème.
 Nous nous posons donc un certain nombre de questions.
@@ -1144,7 +1144,7 @@ Cette obligation qui pèse sur tous les employeurs est donc déjà en vigueur.
 Elle continuera de l’être.
 Il n’y a pas là de lourdeur supplémentaire.
 Vous parlez de complexité.
-Parlons-en, en effet
+Parlons-en, en effet!
 La parole est à Monsieur Dominique Tian.
 Notre pays se signale déjà par la complexité de sa législation.
 Je suis saisi de deux amendements identiques, numéros vingt-neuf et cent dix.
@@ -1183,7 +1183,7 @@ J’ai envie de dire que vous n’êtes pas au bout de vos peines.
 Permettez-moi donc de souhaiter bon courage au Gouvernement.
 Retirez-vous l’amendement, madame Massonneau?
 Oui, monsieur le président.
-Nous ne sommes pas dans une discussion générale
+Nous ne sommes pas dans une discussion générale!
 Cet amendement diffère légèrement de celui de Madame Massonneau.
 Mais il est nécessaire de reprendre la question et d’apporter une réponse.
 Quel est l’avis de la commission?
@@ -1249,7 +1249,7 @@ Nous avons parlé assez souvent, au cours de cette semaine, du seuil de pauvret�
 Ce serait une façon d’améliorer le quotidien des personnes qui sont à l’ASPA.
 La parole est à Madame la présidente de la délégation aux droits des femmes.
 Nous pouvons saluer ce système souple, simple enfin, adaptable, qui, comme le dit Monsieur Jacquat, n’est pas exclusif.
-Pour ceux qui veulent découvrir les secrets des plantes sauvages
+Pour ceux qui veulent découvrir les secrets des plantes sauvages!
 Je pense que c’est une très belle avancée.
 Aujourd’hui, les femmes seniors sont plus au chômage que les hommes seniors.
 Nous devons changer cette mentalité.
@@ -1261,7 +1261,7 @@ C’est un peu le modèle américain, ce n’est pas le nôtre.
 La liberté de chacun s’arrête aussi où commence celle des autres.
 Tout cela doit être pris en compte.
 C’est la raison pour laquelle il me paraît souhaitable de poser certaines limites.
-Elle avait cotisé
+Elle avait cotisé!
 Il y a eu de grandes avancées, et je m’en félicite.
 Je pense sincèrement que c’est un dispositif majeur.
 Il s’agit de la vie des gens tout simplement, et c’est une belle mesure.
@@ -1269,12 +1269,12 @@ L’amendement que je présente est, comme celui de Jean-Marc Germain, un amende
 Cet amendement d’appel est donc assez simple.
 On pourrait imaginer un système plus encadré pour le plafond des ressources.
 L’objectif est de permettre à des jeunes d’accéder un jour à des responsabilités.
-Heureusement que c’est un amendement d’appel
+Heureusement que c’est un amendement d’appel!
 Quel est l’avis de la commission?
 Défavorable, mais pas sur le fond.
 C’est un vrai sujet.
 L’article douze est un bon article.
-le terme est peut-être excessif, Oui
+le terme est peut-être excessif, Oui!
 mais quand même.
 En conclusion, l’avis de la commission est donc défavorable.
 Quel est l’avis du Gouvernement?
@@ -1283,8 +1283,8 @@ L’enjeu de cet article, c’est de mieux encadrer le cumul emploi-retraite.
 Et alors?
 C’est cela qui doit être encadré.
 Cotiser lorsque l’on cumule un emploi et une retraite est un acte de solidarité.
-Madame la ministre a raison
-Je n’ai pas dit le contraire
+Madame la ministre a raison!
+Je n’ai pas dit le contraire!
 Ce n’est évidemment pas acceptable.
 Cela n’est pas acceptable.
 L’article douze permet une avancée significative.
@@ -1294,14 +1294,14 @@ Cela interviendrait alors même que le mandat d’élu local n’est pas une act
 Quel est l’avis de la commission?
 Favorable.
 J’utilise les artifices de la procédure de l’Assemblée pour conclure sur l’amendement précédent.
-C’est l’essentiel
+C’est l’essentiel!
 J’ai bien entendu qu’il s’agissait d’amendements d’appel.
 S’agissant des cotisations, nous pourrions les appeler des cotisations citoyennes.
-Joli nom
+Joli nom!
 La parole est à Monsieur Frédéric Lefebvre.
 J’ai été mis en cause par Monsieur Terrasse.
 Il défendait un amendement, c’est son droit.
-C’est une réalité historique
+C’est une réalité historique!
 est très intéressante.
 Nous avons, l’opposition et nous, une conception différente de la retraite.
 Vous avez, chers collègues, longtemps défendu la retraite par capitalisation.
@@ -1321,67 +1321,67 @@ Défavorable.
 Quel est l’avis du Gouvernement?
 La question du plafonnement s’était alors posée.
 Cela se fera dans les prochaines semaines.
-La question de la rupture conventionnelle peut être débattue, En effet
+La question de la rupture conventionnelle peut être débattue, En effet!
 mais le sujet est sans rapport avec un texte sur la retraite.
 Nous en reparlerons.
 Il s’agit d’un amendement de cohérence du dispositif global.
 Monsieur le président, je demande une suspension de séance de quelques minutes.
 Plusieurs orateurs sont inscrits sur l’article treize.
 La parole est à Monsieur Bruno Nestor Azerot.
-Je veux le rappeler au Gouvernement
+Je veux le rappeler au Gouvernement!
 Si certains agissent dans un sens favorable, d’autres, appliqués de manière injuste, aggravent l’inégalité.
 Qui plus est, elle n’est pas fiscalisée, ce qui favorise les hauts revenus.
 Pour toutes ces raisons, je félicite le Gouvernement d’avoir adopté cette manière de travailler.
 C’est pourquoi nous avons besoin d’approfondir la réflexion sur l’état actuel des droits familiaux.
 Au-delà, ce texte contribue largement à améliorer la retraite des femmes.
 Il s’agit donc d’un ensemble de mesures tout à fait significatives pour les femmes.
-Portée limitée donc, mais utile, C’est très important
+Portée limitée donc, mais utile, C’est très important!
 Je vous en donne lecture.
 La parole est à Monsieur Arnaud Robinet, pour soutenir l’amendement numéro cent quarante-six.
 Je l’ai défendu lors de la discussion de l’article.
 Nos amendements sont retirés, monsieur le président.
 Je souhaite néanmoins poser une question.
 Nous nous étions battus alors, car nous n’avions rien obtenu au départ.
-Très bonne méthode
+Très bonne méthode!
 Quel est l’avis de la commission?
 Satisfait, donc défavorable.
 Ah bon?
-Vous êtes trop bon, monsieur le rapporteur
+Vous êtes trop bon, monsieur le rapporteur!
 D’où l’avis défavorable.
 Un rapport spécifique est bel et bien prévu sur le sujet.
-C’est dans le texte
+C’est dans le texte!
 Maintenez-vous votre amendement, madame Coutelle?
 Je le retire.
 Je suis saisi de deux amendements identiques, numéros trente et cent quatorze.
 La parole est à Monsieur Arnaud Robinet, pour soutenir l’amendement numéro trente.
 Je souhaite répondre à Madame Coutelle.
 Ne caricaturez pas la position de l’opposition, chère collègue.
-Nous n’avons pas besoin de la caricaturer
+Nous n’avons pas besoin de la caricaturer!
 Justement, madame Coutelle, nous allons vous prouver le contraire.
 Il convient au contraire de favoriser leur maintien dans l’emploi.
 Aujourd’hui, la moitié des cotisantes sont couvertes par l’assurance vieillesse des parents au foyer.
 La parole est à Monsieur Gilles Lurton, pour soutenir l’amendement numéro cent quatorze.
-Je tiens à ma liberté d’expression et je m’efforce de travailler pour l’avenir
-Le changement, c’est maintenant
+Je tiens à ma liberté d’expression et je m’efforce de travailler pour l’avenir!
+Le changement, c’est maintenant!
 Et je tiens à continuer à avancer dans ce sens.
 Nous ne sommes pas là pour cela, mais pour construire.
 Mon amendement numéro cent quatorze est défendu.
-C’est encore mieux de l’écrire
-Si c’est comme cela qu’il faut faire
-Voilà le mode d’emploi
+C’est encore mieux de l’écrire!
+Si c’est comme cela qu’il faut faire!
+Voilà le mode d’emploi!
 Il faut pouvoir déterminer de priorité entre les régimes dont relèvent les parents.
 Quel est l’avis du Gouvernement?
 Avis favorable.
 Je souhaite répondre aux propos tenus par Madame Coutelle tout à l’heure.
 Vous nous dites que vous allez améliorer la retraite des femmes.
-Nous ne sommes pas plus éclairés
+Nous ne sommes pas plus éclairés!
 Cependant, aucune mesure concrète n’est prise.
-Pas moins d’un siècle, en tout cas
+Pas moins d’un siècle, en tout cas!
 Je mets aux voix l’amendement numéro deux mille cinq cent soixante-sept.
 Pour garantir effectivement l’égalité salariale, nous proposons deux mesures.
 La seconde mesure que nous proposons réside dans l’obligation de renégocier les classifications.
 Je mets aux voix l’amendement numéro mille deux cent quatre-vingt-treize.
-Cette négociation porte également sur l’application de l’article L
+Cette négociation porte également sur l’application de l’article L!
 Je mets aux voix l’amendement numéro mille quatre cent cinquante-six.
 Quel est l’avis de la commission?
 Avis défavorable.
@@ -1390,24 +1390,24 @@ La parole est à Monsieur Arnaud Robinet, pour un rappel au règlement.
 Monsieur le président, mon rappel au règlement se fonde sur l’article cinquante-huit, alinéa un.
 Or nous n’avons toujours pas la version amendable du texte.
 La suspension de séance est de droit.
-On nous le promet depuis hier
+On nous le promet depuis hier!
 Madame la ministre est arrivée avec quatre autres ministres.
 Aucun document écrit n’a été mis à notre disposition.
-Vous travaillerez le dimanche
+Vous travaillerez le dimanche!
 En revanche, vous n’avez pas répondu à ma question sur les dix millions d’euros.
 Mais nous avons parfois d’assez curieuses manières de travailler.
 La parole est à Madame Jacqueline Fraysse, pour un rappel au règlement.
-Je ne veux pas en rajouter, Mais si
+Je ne veux pas en rajouter, Mais si!
 Déjà mercredi dernier, nous avons déjà dû travailler sans le texte.
 C’est évident.
 La parole est à Madame la présidente de la commission des affaires sociales.
-Je ne peux mettre en cause l’administration, Personne ne l’a fait
+Je ne peux mettre en cause l’administration, Personne ne l’a fait!
 La parole est à Monsieur Christian Paul.
-Au contraire
+Au contraire!
 C’est donc la chronologie du bon sens.
 Autrement dit, le travail a pu commencer.
-Ce n’est pas sérieux
-Monsieur Paul a raison, il faut que cela serve d’exemple
+Ce n’est pas sérieux!
+Monsieur Paul a raison, il faut que cela serve d’exemple!
 Vous pouvez donc y accéder pour préparer vos amendements, chers collègues.
 Je mets aux voix l’amendement numéro deux mille trois cent quatre-vingt-seize.
 La parole est à Madame Véronique Massonneau, pour soutenir l’amendement numéro trois mille cinquante-quatre.
@@ -1432,15 +1432,15 @@ Enfin, le chômage aura le même effet.
 Tel serait l’intérêt du rapport ici demandé.
 Quel est l’avis du Gouvernement?
 L’avis du Gouvernement est défavorable.
-Je vous remercie, madame la ministre
+Je vous remercie, madame la ministre!
 La parole est à Monsieur Denis Jacquat, inscrit sur l’article treize.
 L’article treize bis insère une demande de rapport sur les pensions de réversion.
 Il faut reconnaître que celles-ci touchaient bien souvent de très petites pensions.
 Veuillez conclure, cher collègue.
-Mais c’est très important, monsieur le président
+Mais c’est très important, monsieur le président!
 Le règlement prévoit deux minutes pour les interventions sur les articles.
 Vous parlez depuis deux minutes et trente-neuf secondes.
-En outre, mon intervention concerne les veuves Défenseur de la veuve et de l’orphelin
+En outre, mon intervention concerne les veuves Défenseur de la veuve et de l’orphelin!
 Le plafond fixé pour le cumul doit absolument être étudié.
 Il faut s’adapter à la condition actuelle des veuves.
 La question, effectivement, se pose et doit être traitée comme telle.
@@ -1450,7 +1450,7 @@ C’est une mesure de justice et un progrès pour les salariés à temps partiel
 En parallèle, un plafond spécifique serait instauré afin de limiter les effets d’aubaine.
 Ces deux mesures combinées bénéficieraient en particulier aux jeunes et aux femmes.
 Les personnes concernées n’auront pas à faire cette démarche.
-C’est tout sauf négligeable
+C’est tout sauf négligeable!
 Madame la ministre a raison d’insister, ce sont des mesures très importantes.
 Je salue ces mesures, beaucoup de trimestres, bien que cotisés, étaient perdus.
 Cette injustice est réparée.
@@ -1471,152 +1471,152 @@ Injuste et inefficace, ce budget est aussi irresponsable, j’y reviendrai.
 Un budget plus efficace, c’est aussi plus de stabilité pour les entreprises.
 mais qui s’aggravent, quant à la rétroactivité de la loi fiscale.
 Hélas, telle n’est pas votre stratégie.
-Ça c’est sûr
+Ça c’est sûr!
 Il est faux, tout simplement, je crois que c’est l’adjectif qui convient.
 Celui-ci l’est déjà bien assez, Je parlerai donc d’un budget faux.
 Le déficit de l’État lui-même est passé de soixante-trois à soixante-douze milliards d’euros.
 Les Français ont bien constaté la réalité du matraquage fiscal.
 Vous cherchez ainsi à masquer le déficit structurel.
-Et vous nous parlez d’une amélioration du contexte économique, c’est un peu curieux
+Et vous nous parlez d’une amélioration du contexte économique, c’est un peu curieux!
 Cette manœuvre a un seul objectif, masquer la réalité du déficit structurel.
 Il s’agit bien alors d’un faux, d’une fraude.
 Troisième analyse, monsieur le ministre, vous manquez aux engagements européens de la France.
-Le ministre ne manque pas
+Le ministre ne manque pas!
 Je la préférerais flatteuse, je crains qu’elle soit mortifiante.
 Murmures sur les bancs du groupe SRC.
-Mortifiante, rien que ça
+Mortifiante, rien que ça!
 Michel Barnier, avec diplomatie, parle de chiffres pas toujours stables.
-Vous êtes fort en calcul
-La vérité, c’est que vous en rêviez et que nous l’avons fait
-Vous, vous l’avez même doublé
-Mais si, nous avons réduit l’ONDAM
+Vous êtes fort en calcul!
+La vérité, c’est que vous en rêviez et que nous l’avons fait!
+Vous, vous l’avez même doublé!
+Mais si, nous avons réduit l’ONDAM!
 Cinquième argument, monsieur le ministre, vous n’engagez pas de véritables réformes structurelles.
 Vous dites réaliser neuf milliards d’euros d’économie, mais elles ne sont pas réellement justifiées.
 Madame Batho avait dit à l’époque que je me trompais.
 Aujourd’hui, je crois qu’elle reconnaît que j’ai raison.
-Cela m’étonnerait
+Cela m’étonnerait!
 Oui, il y a des exemples très précis.
-Quel souci du détail
+Quel souci du détail!
 Non, de la précision.
 En réalité, après trois heures de réflexion, le Gouvernement a retiré cette mesure.
 Il recule au bout de quelques heures et retire sa réforme.
 Mais sur le reste, il ne se passe rien.
 Exclamations sur les bancs du groupe SRC.
-Ce n’est pas joli, joli de dire cela
-Respectez le ministre
-Écoutez
-C’est intéressant
+Ce n’est pas joli, joli de dire cela!
+Respectez le ministre!
+Écoutez!
+C’est intéressant!
 Vous trichez, monsieur le ministre, avec la norme de dépenses.
-Des noms
+Des noms!
 Je crains que la plupart de ceux qui ont précédé Monsieur Cazeneuve soient concernés.
-On ne peut pas être plus rigoureux
+On ne peut pas être plus rigoureux!
 Deux exemples, mais il y en aurait d’autres, la défense, d’abord.
-Enfin
-Ils y sont
+Enfin!
+Ils y sont!
 Ils y sont.
 Mais comment?
 En incluant un virgule cinq milliard d’euros d’investissements d’avenir.
 Et alors?
-mais le problème est majeur
-Je croyais avoir compris, chers collègues
-Non, ce n’est pas possible
+mais le problème est majeur!
+Je croyais avoir compris, chers collègues!
+Non, ce n’est pas possible!
 que les investissements d’avenir n’étaient pas là pour se substituer aux crédits budgétaires.
 Le rapporteur général, à juste titre, s’est félicité de cette politique des investissements d’avenir.
 Il y a une grande différence, chers collègues.
-Eh oui, ce n’est pas la même chose
-Prenez des notes
+Eh oui, ce n’est pas la même chose!
+Prenez des notes!
 Deuxième exemple, la formation professionnelle.
-Une paille
+Une paille!
 Je suis lucide et exigeant, chers collègues.
-Je n’en suis pas sûre
-Vous n’avez pas le monopole de l’exigence
+Je n’en suis pas sûre!
+Vous n’avez pas le monopole de l’exigence!
 Aujourd’hui, la dotation de décentralisation s’élève à neuf cents millions d’euros.
 Que propose le Gouvernement?
 De débudgétiser.
-C’est donc une ressource dynamique en moins pour l’État, monsieur le rapporteur général
-Vous ne pouvez pas contester cela
-Mais je n’ai rien dit
+C’est donc une ressource dynamique en moins pour l’État, monsieur le rapporteur général!
+Vous ne pouvez pas contester cela!
+Mais je n’ai rien dit!
 Voila deux manières de contourner la norme de dépense.
-La Gouvernement se félicite donc de stabiliser les dépenses
-Il le fait
+La Gouvernement se félicite donc de stabiliser les dépenses!
+Il le fait!
 Je viens de citer deux exemples, on pourrait en citer d’autres.
 En résumé, pour deux mille treize, ce prélèvement atteint vingt-deux virgule deux milliards d’euros.
 Il y avait un certain nombre de circonstances particulières, dont acte.
-La fiscalisation des droits familiaux pour les retraités ayant eu des familles nombreuses
-Scandaleux
-Chantournées, quel joli mot
-La croissance est revenue
-Vous vous êtes engagé dans un cercle vicieux
+La fiscalisation des droits familiaux pour les retraités ayant eu des familles nombreuses!
+Scandaleux!
+Chantournées, quel joli mot!
+La croissance est revenue!
+Vous vous êtes engagé dans un cercle vicieux!
 La pression fiscale monte.
 À température constante?
 Dixième analyse, vous refusez d’entendre jusqu’au Conseil constitutionnel.
-Trente-huitième analyse
+Trente-huitième analyse!
 Non, c’est la dernière.
-les balades découvertes permettent d’observer
+les balades découvertes permettent d’observer!
 Ah sur les bancs du groupe SRC.
-Patience, votre supplice est bientôt terminé
-Allons, laissez Monsieur Mariton finir
+Patience, votre supplice est bientôt terminé!
+Allons, laissez Monsieur Mariton finir!
 C’est la dernière analyse, mais il me semble que la démonstration est accablante.
 C’est tout le débat sur le plafonnement de l’ISF.
 De surcroît, il est arrivé que d’autres budgets soient critiqués pour leur manque d’intelligibilité.
-L’avenir, vous l’avez gâché
-Et de la pratique
+L’avenir, vous l’avez gâché!
+Et de la pratique!
 Vous avez en effet contribué à les creuser grandement.
 Cela vous autorise donc aujourd’hui à nous expliquer comment il faut les combler.
-Nous attendons vos réponses
+Nous attendons vos réponses!
 Je vais maintenant reprendre les quelques éléments évoqués par Monsieur Mariton.
-Nous y voilà
-En effet, dites-le donc et assumez vos choix
+Nous y voilà!
+En effet, dites-le donc et assumez vos choix!
 Le deuxième point de l’argumentation de Monsieur Mariton portait sur le matraquage fiscal.
-Je n’ai pas dit qu’hier était parfait
-Voilà ce que serait un esprit de précision
-Nous vous parlons du budget pour deux mille quatorze
-Assumez vos choix
+Je n’ai pas dit qu’hier était parfait!
+Voilà ce que serait un esprit de précision!
+Nous vous parlons du budget pour deux mille quatorze!
+Assumez vos choix!
 Veuillez laisser le ministre s’exprimer.
 Je les assume parfaitement.
-Nous assumons
-Oui, nous assumons – et d’ailleurs nous avons perdu
+Nous assumons!
+Oui, nous assumons – et d’ailleurs nous avons perdu!
 Les leçons ne sauraient être à sens unique.
 Vous devez retrouver la mémoire de la responsabilité qui est la vôtre.
-Reconnaissez-le au moins
+Reconnaissez-le au moins!
 La mienne l’est tout autant.
 Protestations sur les bancs du groupe UMP.
 Je le regrette profondément.
-Nous attendons toujours des analyses de votre part
-Quelle piètre défense
-Vous êtes le remplaçant de Monsieur Cahuzac, ne l’oubliez pas
-Monsieur de La Verpillière, laissez parler le ministre
+Nous attendons toujours des analyses de votre part!
+Quelle piètre défense!
+Vous êtes le remplaçant de Monsieur Cahuzac, ne l’oubliez pas!
+Monsieur de La Verpillière, laissez parler le ministre!
 En tout état de cause, nous allons corriger ces injustices fiscales.
-Assumez donc un peu vos choix
+Assumez donc un peu vos choix!
 C’est parce que c’est plus efficace que nous prenons ces mesures.
-Vous aussi, assumez votre part
+Vous aussi, assumez votre part!
 Ces treize milliards, monsieur Mariton, ne vous ont jamais choqué.
 Le premier a trait au programme des investissements d’avenir.
-Excellent
+Excellent!
 Elles étaient à ce point exceptionnelles qu’elles n’avaient pas vocation à être réalisées.
-Les recettes exceptionnelles ont été réalisées
+Les recettes exceptionnelles ont été réalisées!
 Nous en venons aux explications de vote.
 La parole est à Monsieur Pierre-Alain Muet, pour le groupe socialiste, républicain et citoyen.
 Nous avons trouvé un déficit à cinq virgule un pourcent.
-Voilà ce qu’est la responsabilité
+Voilà ce qu’est la responsabilité!
 sur les bancs du groupe UMP, d’avoir une croissance forte.
-Demain, il n’y aura plus d’entreprises
+Demain, il n’y aura plus d’entreprises!
 Vous voyez, monsieur Mariton, ce budget est efficace et responsable.
 Vous avez deux minutes, monsieur le député.
 Vous êtes tombé dans la facilité.
-Vous cherchez à faire oublier cela
-Je ne fais que dire les choses
+Vous cherchez à faire oublier cela!
+Je ne fais que dire les choses!
 Vous dites qu’il faut moins d’impôts, moins de dépenses, moins de déficit.
-Pourtant, vous vous y connaissez en matraquage fiscal
+Pourtant, vous vous y connaissez en matraquage fiscal!
 Mais à gauche, quand on augmente les impôts, c’est pour protéger les plus modestes.
-Voilà comment la droite traite les impôts
+Voilà comment la droite traite les impôts!
 La réalité, c’est que le déficit baisse d’une année sur l’autre.
 Je lui ai dit qu’il avait lui-même rêvé d’atteindre quatre pourcent.
 Ce à quoi il m’a répondu, nous l’avons fait.
 Il y a, de part et d’autre, des gens extrêmement compétents.
 Quand on parle de matraquage fiscal, c’est la réalité.
-C’est laborieux
-Monsieur Galut, s’il vous plaît
+C’est laborieux!
+Monsieur Galut, s’il vous plaît!
 La France détiendra alors le record du monde de l’emprunt en euros.
 Telle est la réalité.
 Je comprends, monsieur le ministre, que vous n’aimiez pas vous entendre dire ces vérités.
@@ -1624,25 +1624,25 @@ Votre attitude était agressive et vous avez été insultant vis-à-vis d’Herv
 Je trouve cela dommage et je le déplore.
 Laissez conclure Madame Dalloz, s’il vous plaît, mes chers collègues.
 Vous faites sans cesse référence au passé.
-Non à l’amnésie
+Non à l’amnésie!
 La confiance, il faudra travailler dur pour la faire revenir.
 Merci de conclure, Madame Dalloz.
-Fini
+Fini!
 Quant à la non-indexation, vous l’avez votée l’année dernière.
 La parole est à Monsieur Olivier Carré, et à lui seul.
-En un sens, Monsieur le rapporteur général leur a rendu hommage
-C’est vrai
+En un sens, Monsieur le rapporteur général leur a rendu hommage!
+C’est vrai!
 Tel est l’objet de la démonstration.
-Elle est limitée
-Pour le moins
+Elle est limitée!
+Pour le moins!
 à cinq milliards d’euros sur l’ensemble des chiffres évoqués.
-C’est court
+C’est court!
 Mais de nouvelles mesures lourdes sont prévues.
 La première, c’est le respect de la parole de la France.
 Rappelons d’abord certains éléments du contexte que nous avons connu.
 La pression sur les pays emprunteurs a baissé.
 Le déficit budgétaire ne faisait pas peur à l’opposition d’alors, devenue majorité depuis.
-Je parlais des déficits structurels
+Je parlais des déficits structurels!
 Dans un tel contexte, la position de la France est singulière.
 Est-ce par le mensonge, l’approximation et l’ambiguïté?
 Rien de tout cela.
@@ -1652,15 +1652,15 @@ Un tel chiffre n’est pas une élucubration de l’UMP.
 En d’autres temps, tant de nouveaux engagements auraient pu être consentis sans difficulté.
 C’est provisoire mais en la matière il est possible que le provisoire dure.
 C’est beaucoup, monsieur le rapporteur général.
-Je serais curieux de savoir comment vous êtes arrivé à ce chiffre
+Je serais curieux de savoir comment vous êtes arrivé à ce chiffre!
 Aujourd’hui, le CICE est particulièrement mal parti, ce qu’on peut regretter.
-Même le rapporteur général est d’accord
+Même le rapporteur général est d’accord!
 Ce qui était notre politique, vous l’avez faite vôtre.
 peut aujourd’hui se trouver remise en cause en catimini.
-Avant de conclure mon intervention
+Avant de conclure mon intervention!
 C’est pourquoi je dis que l’on mange notre pain blanc.
 Je crains que nous ne le payions cher un jour.
-Je veux d’ailleurs vous remercier pour le caractère pondéré Et carré
+Je veux d’ailleurs vous remercier pour le caractère pondéré Et carré!
 de votre intervention et pour la qualité des questions que vous avez posées.
 Je vais essayer d’y répondre précisément.
 Vous évoquez, d’abord, un dérapage de nos déficits de vingt milliards d’euros.
@@ -1672,15 +1672,15 @@ Le CICE n’est pas la seule mesure que nous avons prise.
 Je veux profiter de l’interpellation d’Olivier Carré pour y répondre.
 On avait fait un groupe de travail pendant huit mois.
 Je confirme mon souhait que cela puisse se faire.
-Comme c’est bien présenté
+Comme c’est bien présenté!
 La parole est à Monsieur Dominique Lefebvre, pour le groupe socialiste, radical, citoyen.
-Justement, c’était très bien
-C’est carré
+Justement, c’était très bien!
+C’est carré!
 Elles sont effectivement carrées.
-C’est interdit, d’ailleurs
+C’est interdit, d’ailleurs!
 De grâce, essayons d’avoir un dialogue constructif, apaisé, et posons les choses.
 Arrêtez de tout diriger depuis Bercy.
-Même votre majorité ne s’y retrouve pas, monsieur le ministre
+Même votre majorité ne s’y retrouve pas, monsieur le ministre!
 Il y a aujourd’hui une incompréhension totale sur ce sujet.
 Si tel est le cas, il faudra alors complètement refondre le dispositif.
 Vous avez deux secondes, monsieur le député.
@@ -1688,7 +1688,7 @@ Votre temps de parole est épuisé.
 Je rappelle que vous avez deux minutes pour vous exprimer, cher collègue.
 Cher collègue Olivier Carré, votre intervention invite au dialogue.
 Certaines de mes interrogations sont semblables aux vôtres.
-Voilà
+Voilà!
 La question du déficit structurel revient régulièrement.
 L’union bancaire est également une nécessité.
 Un point doit néanmoins être éclairci.
@@ -1701,18 +1701,18 @@ Par ailleurs, il a soulevé une question absolument fondamentale, celle des taux
 Ces taux augmenteront également chez nous, et c’est déjà un peu le cas.
 Cela ne peut donc pas durer aussi longtemps que les impôts.
 Par conséquent, les taux vont augmenter, et ce de manière terrifiante.
-Je vous laisse calculer ce que cela représente, c’est astronomique
-Il est perdu, le garçon
+Je vous laisse calculer ce que cela représente, c’est astronomique!
+Il est perdu, le garçon!
 Cela étant dit, ce débat, académique et pratique, est d’une importance colossale.
 Si on prend en compte cette question dans l’élaboration du budget, celle-ci devient impossible.
 Exclamations sur les bancs du groupe UMP.
-Vous devez aller au bout de votre démonstration
+Vous devez aller au bout de votre démonstration!
 Nous allons maintenant entendre les orateurs inscrits dans la discussion générale.
 La parole est à Monsieur François Asensi, premier orateur inscrit.
 Nous aimerions que cela soit vrai, mais la réalité est tout autre.
 La crise du capitalisme financier perdure et s’amplifie.
 Les Français la ressentent de plein fouet et sont aujourd’hui dans une grande désespérance.
-Voilà la régression sociale à laquelle conduisent les politiques libérales
+Voilà la régression sociale à laquelle conduisent les politiques libérales!
 Les plans sociaux s’accumulent, facilités par l’accord national interprofessionnel.
 Ce marasme économique, voilà l’héritage d’années d’ultralibéralisme promues par la droite de cet hémicycle.
 Nous payons encore le prix de cette politique au service des plus riches.
@@ -1737,60 +1737,60 @@ En l’état, ce budget est à nos yeux inacceptable.
 Oui, il faut taxer les revenus du capital autant que ceux du travail.
 La taxe Tobin n’est pas excessive, elle est impérative.
 La parole est à Monsieur Thomas Thévenoud.
-Une fine lame
-Vous avez organisé la claque
+Une fine lame!
+Vous avez organisé la claque!
 Voilà en effet les priorités du gouvernement de la France et de cette majorité.
 Je pense en particulier aux cent cinquante mille emplois d’avenir.
-Il faudrait plutôt de vrais emplois
+Il faudrait plutôt de vrais emplois!
 Des moyens supplémentaires sont également octroyés à Pôle emploi.
 Il faut également mentionner les contrats de génération.
 À quoi sert encore un budget?
 À encourager la croissance.
-C’est tout à fait vrai
+C’est tout à fait vrai!
 Monsieur Carrez, dans son contre-budget.
 Il propose de supprimer un certain nombre de minima sociaux.
 Il entend même supprimer des crédits destinés au SAMU social.
 Peut-être ne l’avons-nous pas assez dit.
-Quelle imagination vous avez
+Quelle imagination vous avez!
 La dette est un impôt sur la naissance.
 Ce gouvernement et sa majorité se sont engagés à désendetter le pays.
 J’en viens à l’impôt sur le revenu, dont on parle beaucoup.
 La droite a décidé de remettre en cause sa progressivité.
-Certains trentenaires de l’UMP proposent même
-Vous avez d’excellentes lectures
-J’espère que vous n’en faites pas partie, monsieur Darmanin
-Belle proposition en effet
+Certains trentenaires de l’UMP proposent même!
+Vous avez d’excellentes lectures!
+J’espère que vous n’en faites pas partie, monsieur Darmanin!
+Belle proposition en effet!
 Merci de conclure, monsieur le député.
 Nous avons décidé, au contraire, de renforcer la progressivité de l’impôt sur le revenu.
 Il faut conclure, mon cher collègue.
 Oui, il faut remettre la justice au cœur de notre système fiscal.
-Merci, monsieur le député
-On tombe vraiment de l’armoire quand on entend cela
+Merci, monsieur le député!
+On tombe vraiment de l’armoire quand on entend cela!
 Dieu merci, vous avez donné votre copie au Premier ministre.
 Quoi qu’il en soit, c’est là la preuve d’une improvisation assez perturbante et troublante.
 Ce projet a presque immédiatement avorté.
 Cette année, vous avez sorti l’idée consistant à prendre en compte l’excédent brut d’exploitation.
 Devant le tollé général, c’est finalement l’excédent net d’exploitation qui est retenu.
-Il l’est pour les particuliers
-Et pour les familles
+Il l’est pour les particuliers!
+Et pour les familles!
 Vous bénéficiez de cette évolution, mais vous n’en faites pas grand-chose.
 Votre second joker siège à la Commission de Bruxelles et s’appelle Olli Rehn.
 En matière de coût du travail, vous évoquez le crédit d’impôt compétitivité emploi.
-Et il y en a pour quatre-vingts milliards
+Et il y en a pour quatre-vingts milliards!
 Vous avez manqué l’occasion d’afficher une ambition élevée et d’entreprendre des réformes exigeantes.
 Je vous remercie d’avoir respecté votre temps de parole, mon cher collègue.
 La parole est à Monsieur Philippe Vigier.
 Ce budget est l’acte de décès de cette promesse solennelle de François Hollande.
 Ce projet de loi de finances est également marqué par une série d’échecs.
 Et quelle est l’assiette?
-Carré a parlé de l’assiette, lui
-Promesse enterrée
+Carré a parlé de l’assiette, lui!
+Promesse enterrée!
 Cette mesure va dans le bon sens, mais elle manquera de souffle.
 C’est pourquoi nous vous proposons d’aller plus loin.
-Rien que cela
-À vous de choisir, monsieur le rapporteur général
-Que des victoires aux élections, ensuite
-En tout cas, les résultats sont au rendez-vous
+Rien que cela!
+À vous de choisir, monsieur le rapporteur général!
+Que des victoires aux élections, ensuite!
+En tout cas, les résultats sont au rendez-vous!
 Vous m’accorderez, monsieur Cherki, que ceux de l’Allemagne sont meilleurs que les nôtres.
 Vous nous aviez demandé de vous donner du temps, et nous avions pris date.
 Aujourd’hui, force est de constater que les résultats ne sont pas au rendez-vous.
@@ -1801,14 +1801,14 @@ Celui-ci est réel et immense.
 Il n’y a qu’en France que l’on pense que les taux d’intérêt resteront bas.
 Mais je citerai un seul exemple.
 Monsieur Volcker a pris sa retraite définitive, et nous en restons là.
-Le raisonnement n’est pas faux, c’est exact
+Le raisonnement n’est pas faux, c’est exact!
 Le Gouvernement est bien obligé de faire avec ce qu’il a.
 Ma seconde remarque porte sur la compétitivité.
 L’obligation de compétitivité s’est considérablement accrue avec la crise.
 Je suis très sincère.
 C’est tout de même une évolution fondamentale.
 Le Gouvernement entreprend, dans le même temps, la réindustrialisation du pays.
-Merci de conclure, mon cher collègue
+Merci de conclure, mon cher collègue!
 Je conclus, madame la présidente.
 Par ailleurs, je ne rappellerai pas la tentative de taxer l’EBE.
 Elle a avorté et c’est heureux.
@@ -1820,34 +1820,34 @@ Oui, nous affirmons l’impératif productif pour embaucher, investir, innover, 
 Deux mille agents supplémentaires rejoindront Pôle emploi pour toujours mieux accompagner les demandeurs d’emploi.
 L’opposition prétend que les déficits dérapent, elle confond le présent et son bilan.
 Je constate, au contraire, que les déficits diminuent.
-C’est la mandature sérieuse après la législature dispendieuse
+C’est la mandature sérieuse après la législature dispendieuse!
 Après plusieurs reculades, il est désormais attendu à quatre virgule un pourcent.
 Le pire, c’est que tous ces sacrifices semblent en vain.
-Hier soir, Le Monde titrait, Les Français jugent l’impôt excessif et injuste
-Assumez vos décisions, monsieur le député
+Hier soir, Le Monde titrait, Les Français jugent l’impôt excessif et injuste!
+Assumez vos décisions, monsieur le député!
 Les particuliers sont assommés, mais les entreprises ne sont pas mieux loties.
 Illisible, enfin, car pour financer votre CICE, vous augmentez le mauvais taux de TVA.
-La restauration qui n’a rien produit
+La restauration qui n’a rien produit!
 Vous être désolé que les Français ne vous fassent pas confiance.
 Tout cela est incohérent, quand le même gouvernement affirme entendre les entreprises.
-N’oubliez pas Monsieur le ministre du budget
+N’oubliez pas Monsieur le ministre du budget!
 Plus de vingt mille foyers y sont en attente d’un logement social.
 Les produits de première nécessité coûtent quarante pourcent plus cher.
 Il n’y a pas de continuité territoriale.
 Les dettes sociales et fiscales des entreprises avoisinent le milliard d’euros.
 J’ai également déposé des amendements à l’article treize pour le parfaire.
 La parole est à Monsieur Jacques Bompard.
-J’espérais secrètement me tromper
+J’espérais secrètement me tromper!
 donné raison.
 Cela représente plus de quatre-vingt-dix pourcent de la richesse nationale, presque une année entière.
 Et vous utilisez les vieilles méthodes éculées en recourant massivement aux emplois aidés.
 Vous ne gérez pas la France, vous appliquez votre idéologie.
 Les Français pensent que c’est ce dont vous manquez le plus.
 La parole est à Monsieur Thierry Mandon.
-Nous attendons de voir
+Nous attendons de voir!
 C’est la vérité des chiffres.
 dont il convient de souligner l’intelligence.
-Parlez-en aux entreprises
+Parlez-en aux entreprises!
 La seule difficulté repose dans son préfinancement.
 Il s’applique mécaniquement, jusqu’à deux virgule cinq SMIC.
 On ne peut contester que cet effort soit massif.
@@ -1855,16 +1855,16 @@ Tout d’abord, pour la compétitivité sur laquelle je ne reviens pas.
 Ce choix indispensable est aussi un pari.
 Nous ne le gagnerons pas seuls.
 La parole est à Monsieur Bruno Le Maire.
-C’est le cas
+C’est le cas!
 François Hollande avait proposé une révolution fiscale.
-On réduit leur budget d’un virgule cinq milliard d’euros
+On réduit leur budget d’un virgule cinq milliard d’euros!
 Vous auriez pu alléger les charges qui pèsent sur un certain nombre de familles.
 Vous avez rigoureusement décidé l’inverse.
 Cette mesure vise directement et très concrètement les ménages les plus modestes.
 Cela est désormais terminé.
-Le mal est fait
+Le mal est fait!
 Mais la croissance marche sur deux jambes.
-C’est bien de le dire
+C’est bien de le dire!
 Elle va permettre de favoriser durablement une filière riche en emplois non délocalisables.
 Le soutien au secteur du logement est également l’une de nos priorités.
 Il est indispensable afin de répondre aux besoins des Français.
@@ -1872,40 +1872,40 @@ Elles sont donc l’un des principaux moteurs de l’économie.
 Il faut également saluer l’augmentation des dispositifs de péréquation verticale et horizontale.
 La situation des conseils généraux a également été prise en compte.
 Fénelon écrivait que le vrai courage ne se laisse jamais abattre.
-Même Madame Bettencourt, alors qu’avec vous, elle recevait des chèques
+Même Madame Bettencourt, alors qu’avec vous, elle recevait des chèques!
 Ils avaient raison.
-Quelle spoliation
+Quelle spoliation!
 Ils ont vu leurs impôts augmenter et leurs charges s’accroître.
-C’est vous qui avez menti aux Français en finançant tout cela par la dette
+C’est vous qui avez menti aux Français en finançant tout cela par la dette!
 Un seul avantage a été maintenu, au profit des employeurs.
 Vous êtes en totale contradiction.
-Comme Monsieur Mandon
-C’est de la comptabilité d’épicier
+Comme Monsieur Mandon!
+C’est de la comptabilité d’épicier!
 Là n’est pas le courage, ni la vérité en politique.
 Ce n’est pas la création de la BPI qui va régler le problème.
-Vous payez le prix du mensonge
+Vous payez le prix du mensonge!
 Il faut donc baisser les dépenses.
 Monsieur le ministre, ce n’est certainement pas vous que j’accablerais.
 Je voulais consacrer à ces sujets, disais-je, mes quelques minutes d’intervention.
 La moutarde m’est montée au nez.
 Parlons des jeunes puisque vous en parlez fort peu, chers collègues de l’opposition.
 Qu’avez-vous fait pour leurs parents?
-Rien non plus
+Rien non plus!
 Voilà ce qu’on fait pour les familles et que vous, vous n’avez pas fait.
 Les baisses de dépenses ne sont en effet pas affectées mais globalisées, généralisées.
 C’est considérable.
 Aucune réforme structurelle n’a été engagée qui permettrait de réduire réellement la dépense publique.
 Nous partageons votre détermination.
 Nous vous accompagnerons dans cette lutte.
-Vous avez cité les cinq premiers
-Quatre
-avant les trois derniers
+Vous avez cité les cinq premiers!
+Quatre!
+avant les trois derniers!
 de la deuxième partie.
 Le premier, c’est, Persévérer.
 Eh bien, je vous le dis très sincèrement, errare humanum est, perseverare diabolicum.
-C’est original
+C’est original!
 L’ordre du jour appelle les questions au Gouvernement.
-Eh oui
+Eh oui!
 Les Français rejettent massivement votre politique.
 Ils rejettent le Président des impôts et le Président du chômage.
 Vous êtes impopulaire et en passe de perdre votre majorité.
@@ -1915,19 +1915,19 @@ Vous m’épaterez toujours, Monsieur le Président Jacob.
 Vous avez voulu nous faire la leçon sur tout.
 (Rires et applaudissements sur les bancs des groupes SRC, écologiste et RRDP.
 Exclamations sur les bancs du groupe UMP.
-Un peu de hauteur
+Un peu de hauteur!
 Écoutons la réponse dans le calme, je vous prie.
 Revenons donc aux choses sérieuses.
-Hier et aujourd’hui, une émotion particulière s’est exprimée
-Mêmes mouvements
+Hier et aujourd’hui, une émotion particulière s’est exprimée!
+Mêmes mouvements!
 J’ai entendu et compris l’émotion particulière qu’a suscitée le cas de cette jeune fille.
 Monsieur le Premier Ministre, vous connaissez la souffrance de la Bretagne.
 À situation exceptionnelle, réponses exceptionnelles.
 En même temps, il faut agir dans l’urgence.
 Nous ne laisserons tomber personne, c’est l’engagement que je prends.
-C’est incompréhensible
+C’est incompréhensible!
 Ce chantier a été lancé.
-pour apporter des réponses concrètes à la filière de l’agroalimentaire
+pour apporter des réponses concrètes à la filière de l’agroalimentaire!
 Ces équipes arriveront dans les prochains jours.
 Les forces économiques et sociales y seront associées.
 Ma question s’adresse au Ministre de l’écologie, du développement durable et de l’énergie.
@@ -1940,35 +1940,35 @@ L’ANSES a publié son nouveau rapport hier.
 La défense, fonction régalienne, n’en fait pas partie.
 Aujourd’hui, l’ensemble des forces combattantes du pays tient dans le stade de France.
 En fait, un sentiment d’injustice prédomine parmi les militaires.
-Les anciens militaires, surtout
+Les anciens militaires, surtout!
 La parole est à Monsieur le ministre de la défense.
 Merci de votre question, monsieur le député Folliot.
 Merci d’avoir rendu hommage à l’action de nos forces armées au Mali.
 Votre question appelle une première observation d’ordre volumétrique.
 La parole est à Monsieur Erwann Binet, pour le groupe socialiste, républicain et citoyen.
 Ma question s’adresse à Monsieur le ministre de l’éducation nationale.
-C’est un fantasme
-Vous avez entendu Monsieur Hetzel hier, monsieur le député Binet
+C’est un fantasme!
+Vous avez entendu Monsieur Hetzel hier, monsieur le député Binet!
 Je dis à la majorité qu’elle peut être fière.
 Monsieur Hetzel a parlé d’expérimentation.
 Je vous suggère de vous rasseoir et d’écouter la question de Monsieur Suguenot.
-C’est un scandale
-Il y en a vraiment qui cherchent à se faire casser la gueule
+C’est un scandale!
+Il y en a vraiment qui cherchent à se faire casser la gueule!
 Si vous voulez discuter avec le ministre, vous ferez cela en dehors de l’hémicycle.
 Vous avez la parole, monsieur Suguenot.
-Allons, mes chers collègues, asseyez-vous
+Allons, mes chers collègues, asseyez-vous!
 Ce n’est que l’augmentation des droits de mutation qui est promise aux départements.
 Monsieur le ministre, l’agroalimentaire va mal.
 D’abord, il est vrai que nous appelons les collectivités locales à faire un effort.
 Mêmes mouvements.
-C’est pourtant ce que vous faites en permanence
+C’est pourtant ce que vous faites en permanence!
 En outre, désormais, nous ajustons tous nos budgets par des économies en dépenses.
-Deux minutes
-C’est terminé
+Deux minutes!
+C’est terminé!
 La parole est à Monsieur le ministre de l’économie et des finances.
 Car la croissance, l’emploi, tels sont la philosophie et la finalité de ce budget.
-La France est sortie de la récession, et la reprise est là
-Vous mentez
+La France est sortie de la récession, et la reprise est là!
+Vous mentez!
 Voilà ce qu’est notre budget, monsieur le député.
 La parole est à Madame la ministre déléguée chargée de la décentralisation.
 Vous avez évoqué le non-cumul de mandats.
@@ -1979,12 +1979,12 @@ Enfin, l’établissement d’un régime fiscal particulier va être étudié pa
 Ma question s’adresse au ministre de l’agriculture, de l’agroalimentaire et de la forêt.
 Non, vous ne faites pas le choix de l’équilibre et de la justice.
 À la veille des élections européennes, c’est pour vous un trop grand défi.
-C’est le régime inacceptable de la double peine
+C’est le régime inacceptable de la double peine!
 Déséquilibrée, votre déclinaison nationale de la PAC est aussi injuste.
 C’est d’ailleurs l’occasion de discuter directement avec les agriculteurs.
 Ensuite, je n’ai jamais affirmé que l’aide à l’hectare serait la même partout.
 L’agriculture française de demain a besoin d’agriculteurs.
-Tel est l’enjeu de la surcotation des cinquante-deux premiers hectares
+Tel est l’enjeu de la surcotation des cinquante-deux premiers hectares!
 C’est un sujet important qui sera pris en compte.
 Elle souffre d’un manque d’investissements publics générateurs d’investissements privés.
 Telle est la raison d’être du CICE.
@@ -2002,7 +2002,7 @@ Il faut que les enseignants continuent à les inciter à le faire.
 C’est une manière d’apprendre la citoyenneté qui sera dorénavant importante pour notre pays.
 Dans les priorités dégagées figure bien la ligne POLT.
 Vous prendrez très prochainement une décision concernant les matériels roulants.
-Le POLT, c’est maintenant
+Le POLT, c’est maintenant!
 La ligne POLT est un enjeu majeur pour le désenclavement des territoires.
 Mais cette somme ne sera pas suffisante.
 Le grand plan de modernisation du réseau, demandé à RFF, complétera cette politique.
@@ -2017,19 +2017,19 @@ Or parler de budget, parler de fiscalité, c’est parler de nos choix de socié
 Non, c’est le fond qui compte.
 Ce qui doit nous interpeller, c’est le projet politique qui sous-tend cette démarche.
 Le crédit compétitivité emploi en est l’illustration.
-Ce n’est pas vrai, n’exagérez pas
+Ce n’est pas vrai, n’exagérez pas!
 Monsieur le ministre, c’est ce cancer financier qu’il faut combattre.
-Alors, ne leur donnez pas, ne leur donnons pas cette occasion
+Alors, ne leur donnez pas, ne leur donnons pas cette occasion!
 Oui, le consentement à l’impôt est menacé.
 Il faut réhabiliter l’impôt, la contribution à la charge commune.
 Faire le dos rond ne peut tenir lieu de politique.
-Il faut changer de cap
+Il faut changer de cap!
 C’est dans ces moments de crise qu’il faut inventer, créer, faire preuve d’audace.
 Nous devons également revoir de fond en comble l’impôt sur les sociétés.
 Cette loi de finances est une occasion manquée.
 C’est ainsi que la France restera un grand pays.
 votre responsabilité est écrasante.
-C’est exact
+C’est exact!
 Bien sûr, vous nous accuserez d’étouffer l’économie et nos entreprises.
 Mais, de vous à moi, votre bilan parle pour vous.
 Bref, votre contre-budget, c’est un véritable assommoir économique et social.
@@ -2037,26 +2037,26 @@ Les premiers résultats sont là.
 Ils sont encourageants, mais ils restent fragiles.
 Les ménages, du reste, ne pourraient ni le supporter, ni l’accepter.
 C’est ce que nous ferons au cours des heures de débat qui nous attendent.
-Heureusement que l’UMP est parfois là pour sauver le Gouvernement
-Et l’UDI
-De nombreux députés socialistes aussi
+Heureusement que l’UMP est parfois là pour sauver le Gouvernement!
+Et l’UDI!
+De nombreux députés socialistes aussi!
 Poursuivons le recensement de vos contradictions.
 Voilà une proposition que vous avez faite fin deux mille douze.
 Vous aviez le temps de vous y préparer.
-Eh bien non
+Eh bien non!
 Vous avez un peu d’arithmétique, monsieur le rapporteur général.
 Il manquera donc quatre virgule six milliards d’euros.
-Il y aura aussi des économies
+Il y aura aussi des économies!
 Revenons-en à la croissance.
 Monsieur le rapporteur général, est-ce que la croissance se rétablit un peu?
-Si peu
-Nous aurons zéro virgule deux pourcent, c’est cent pourcent de plus
+Si peu!
+Nous aurons zéro virgule deux pourcent, c’est cent pourcent de plus!
 C’est assurément de la croissance, mais c’est peu pour sauver la France.
 En deux mille quatorze, vous prévoyez zéro virgule neuf pourcent de croissance.
-Avec un déficit de six pourcent
+Avec un déficit de six pourcent!
 Ce fut souvent le cas, notamment avec les gouvernements de gauche.
-Tiens, tiens
-Mais cela se fera de manière si artificielle, si construite
+Tiens, tiens!
+Mais cela se fera de manière si artificielle, si construite!
 Les emplois aidés ont été minorés pendant tout le début de l’année.
 Qu’en est-il de ce critère?
 Le niveau des impôts est excessif.
@@ -2064,57 +2064,57 @@ Voilà une fin de mandat extraordinaire, quarante-huit virgule huit pourcent de 
 Le déficit de l’État sera de quatre-vingt-deux virgule deux milliards.
 C’est une évolution assurément coupable de nos finances.
 Il faut bien sûr les réduire.
-C’est le droit d’inventaire de Monsieur Mariton
+C’est le droit d’inventaire de Monsieur Mariton!
 Or je le reconnais volontiers.
-En dix ans, six cents milliards de dettes supplémentaires
+En dix ans, six cents milliards de dettes supplémentaires!
 Monsieur le ministre, un budget n’est pas un rite.
 Je vous l’ai dit hier, c’est un faux budget que vous nous présentez.
 Il y faut de la volonté et du courage.
 Nous pensons alors pouvoir un jour être dignes de la confiance des Français.
-Jusqu’ici, c’est juste
+Jusqu’ici, c’est juste!
 Pour l’UDI, ce budget est celui des illusions perdues.
-Des preuves
-Ça, c’est une analyse
-C’est vrai, et nous l’assumons
+Des preuves!
+Ça, c’est une analyse!
+C’est vrai, et nous l’assumons!
 Ils perdent, en moyenne, cinq cents euros par an.
 L’augmentation de six euros de la redevance audiovisuelle touche également la quasi-totalité des ménages.
 Ils perdront en moyenne cinq cents euros par an.
 Ça, c’est vrai.
 Votre politique a des effets désastreux pour les ménages modestes.
-Et vous aggravez la situation en deux mille quatorze
+Et vous aggravez la situation en deux mille quatorze!
 Cela est intolérable.
 Deuxième critique, ce budget est économiquement inadapté.
-Ce dispositif est une véritable usine à gaz
-Mensonge
-Mais vous n’y êtes pour rien
+Ce dispositif est une véritable usine à gaz!
+Mensonge!
+Mais vous n’y êtes pour rien!
 Il ne s’agit pas d’économies réalisées par le Gouvernement.
 J’ajoute que vous avez multiplié les fusils à un coup.
 En définitive, nous assistons à la poursuite de la hausse des dépenses publiques.
-Il est donc temps d’agir
+Il est donc temps d’agir!
 Mes chers collègues, je conclurai en disant que tous les voyants sont au rouge.
 Quand allez-vous vous arrêter?
-Vous n’avez que dix minutes
-Mes chers collègues, il faut s’interroger sur cet écart croissant
+Vous n’avez que dix minutes!
+Mes chers collègues, il faut s’interroger sur cet écart croissant!
 Pour nous, il existe deux grandes causes à cette situation.
 La première est que vous avez considérablement surestimé le taux de croissance potentielle.
-Vous parlez déjà depuis plus de onze minutes trente
-Aux douze milliards du programme d’investissements d’avenir
+Vous parlez déjà depuis plus de onze minutes trente!
+Aux douze milliards du programme d’investissements d’avenir!
 Même en tenant compte de ce programme, le déficit est encore en augmentation.
-Vous parlez depuis douze minutes
+Vous parlez depuis douze minutes!
 Merci de conclure, mon cher collègue.
-Le Gouvernement cumule les médailles
-Ce n’est pas là l’essentiel
-Douze minutes trente
+Le Gouvernement cumule les médailles!
+Ce n’est pas là l’essentiel!
+Douze minutes trente!
 Merci, monsieur de Courson.
 Nous avons la semaine pour poursuivre nos débats.
-Il faut diminuer les effectifs de la fonction publique
+Il faut diminuer les effectifs de la fonction publique!
 Merci, mon cher collègue.
-Au revoir, monsieur de Courson
-Vous avez parlé treize minutes, c’est trente pourcent de dépassement
+Au revoir, monsieur de Courson!
+Vous avez parlé treize minutes, c’est trente pourcent de dépassement!
 La parole est à Monsieur Éric Alauzet.
 Le consentement à l’impôt s’affaiblit.
-Il se confirme que le réchauffement climatique
-Le dérèglement climatique, et non le réchauffement
+Il se confirme que le réchauffement climatique!
+Le dérèglement climatique, et non le réchauffement!
 Ce contexte permet de comprendre l’évolution de la trajectoire budgétaire.
 Mais ces mesures sont nécessaires.
 Il faut insister sur la neutralité des prélèvements qui accompagnera cette mesure.
@@ -2145,7 +2145,7 @@ Le président de la commission des finances en est convenu hier soir.
 C’est un effort considérable lorsque l’on connaît l’évolution tendancielle des dépenses publiques.
 On peut bien évidemment discuter sur les chiffres retenus quant à cette évolution tendancielle.
 Mais on ne saurait nier que l’effort est réel, conséquent et peut-être même historique.
-C’est un peu exagéré
+C’est un peu exagéré!
 En contrepartie, certains secteurs non prioritaires ont vu leur budget diminuer.
 la solidarité, le logement.
 Nous aurons l’occasion, mes chers collègues, d’y revenir lors des discussions budgétaires.
@@ -2185,7 +2185,7 @@ Par l’innovation.
 Nous nous préoccupions également de l’utilisation des fonds des investissements d’avenir.
 Le Président de la République a exposé trente-quatre plans d’actions pour dynamiser l’industrie.
 Là aussi, nous en sommes satisfaits.
-Nous aussi
+Nous aussi!
 Par ailleurs, la réforme du marché du travail doit être poursuivie.
 Le coût des emplois précaires a été augmenté.
 C’est une réelle avancée.
@@ -2195,8 +2195,8 @@ Le Gouvernement a mis en place un grand chantier.
 Il légiférera par ordonnance.
 Nous verrons les résultats.
 Enfin, il est certain qu’une réforme des professions réglementées pourrait dynamiser l’économie française.
-Eh bien
-Courage
+Eh bien!
+Courage!
 Toutefois, ne surestimons pas ses effets et prenons garde aux attentes démesurées.
 Mais la question doit être sérieusement soulevée.
 Le budget fixe les lignes directrices du Gouvernement et de sa majorité.
@@ -2205,7 +2205,7 @@ Pour être accepté, ce contrat doit être compris par chaque partie.
 Le discours doit être clair et univoque.
 Ni entre la réduction des dépenses fiscales et la réduction des dépenses budgétaires.
 Si une règle doit primer, c’est la clarté du discours.
-Nous sommes bien d’accord
+Nous sommes bien d’accord!
 Le Parlement n’est pas un cabinet de comptables.
 Il vote sur un projet, une ligne directrice, une vision.
 Nous n’avons pas à rougir.
@@ -2214,11 +2214,11 @@ L’OFCE l’a montré.
 C’était un choix politique.
 plusieurs centaines d’amendements visant à baisser les impôts et augmenter les dépenses.
 De ce point de vue, le sarkozysme a encore de beaux jours devant lui.
-C’est l’inventaire
+C’est l’inventaire!
 Réhabiliter l’impôt, c’est aussi faire en sorte que l’action publique soit efficace.
 L’État – la puissance publique – a structuré la France.
 Nous avons même voté contre.
-Monsieur le ministre, sur ce point, tenez bon
+Monsieur le ministre, sur ce point, tenez bon!
 La parole est à Monsieur Guillaume Chevrollier.
 Il s’agit d’une politique en trompe-l’œil.
 Vous vous gargarisez des économies que vous vous décidez enfin à faire.
@@ -2242,7 +2242,7 @@ Permettez-moi d’exprimer mon scepticisme, en matière d’impôt, le temporair
 Notre pays a besoin d’eux.
 Nous ne pourrons donc pas voter ce budget.
 On ne peut dépenser plus qu’on ne gagne.
-Vous vous êtes assis dessus pendant dix ans
+Vous vous êtes assis dessus pendant dix ans!
 Pour ce faire, des réformes structurelles courageuses sont à mener.
 Il n’a pas la nôtre.
 La parole est à Madame Eva Sas.
@@ -2254,27 +2254,27 @@ Et c’est ce que nous vous proposerons au travers de plusieurs amendements.
 La transition écologique n’est pas un concept.
 Aucune mesure d’envergure n’est prévue sur ces sujets dans ce budget deux mille quatorze.
 Voilà seize mois que nous avons été élus, monsieur le ministre.
-On aimerait une réponse du ministre
-C’est certain
+On aimerait une réponse du ministre!
+C’est certain!
 Mais, mes chers collègues, si l’effort est sensible, le redressement, lui, se fait attendre.
-Continuer comme cela est donc d’une cohérence totale
+Continuer comme cela est donc d’une cohérence totale!
 Cela n’a rien d’étonnant, il en va toujours ainsi en période de récession.
 Et c’est de cette façon qu’une économie redémarre.
 Un mot sur la réforme des retraites.
 Une réforme profonde est nécessaire.
 En conclusion, ce budget poursuit le redressement de nos finances publiques.
-Voilà une leçon d’économie
+Voilà une leçon d’économie!
 La parole est à Monsieur Luc Chatel.
-On n’a pas été déçus
+On n’a pas été déçus!
 Aujourd’hui, le trop-plein fiscal est atteint.
 Mais le problème n’est pas là.
 Le problème, ce n’est pas l’impôt en soi.
-Et la de ces gens sont des sympathisants du parti socialiste
+Et la de ces gens sont des sympathisants du parti socialiste!
 un RSA jeunes ou généraliser le tiers payant.
 Monsieur le ministre, vous avez trahi vos électeurs, vous avez trahi les Français.
 Vous avez réussi à asphyxier l’économie française.
 L’investissement dans l’industrie est en baisse.
-Et vous osez encore nous parler de reprise
+Et vous osez encore nous parler de reprise!
 C’est un acharnement systématique à l’encontre des forces vives de notre pays.
 Votre mesure n’est pas raisonnable.
 C’est un mauvais coup porté à nos entreprises qui vont le payer cher.
@@ -2285,11 +2285,11 @@ Ce déficit public s’accompagnait d’un déficit de confiance en l’action p
 C’est une excellente nouvelle.
 Le soixante-millième contrat a été signé récemment, nous devons tous nous en réjouir.
 Mais ce plan n’est pas réalisé au détriment du redressement des comptes.
-Quel aveuglement
+Quel aveuglement!
 La parole est à Monsieur Jean-Pierre Gorges.
-Cela commence mal
+Cela commence mal!
 La litanie du bilan a été votre seule réponse et le reste encore, d’ailleurs.
-Cela nous intéresse
+Cela nous intéresse!
 Les économies?
 Vous en parliez, mais vous n’en avez jamais fait.
 Pas vous.
@@ -2298,17 +2298,17 @@ Après les acteurs économiques, ce sont les contribuables qui l’ont senti pas
 Pendant ce temps, vous avez prétendu assumer l’impopularité au nom de la justice fiscale.
 Aujourd’hui, nous arrivons à la troisième étape.
 Vous créez quelques ingrats, et des milliers de mécontents.
-Et aussi des aigris
+Et aussi des aigris!
 Personne n’y comprend plus rien.
 Les effets d’annonces contradictoires désorientent tout le monde.
-Les vôtres ne sortent pas davantage
+Les vôtres ne sortent pas davantage!
 Analysez bien les résultats, vous verrez.
 Aujourd’hui, le verdict est sans appel.
 Trop d’impôt tue l’impôt, tout le monde le sait.
 Alors, s’agissant de la justice fiscale, il y a une contradiction.
 Et qu’avec les résultats, la confiance va renaître.
 C’est pourtant quand tout va bien qu’il faut oser réorganiser.
-Et j’ai pris la suite d’un socialiste
+Et j’ai pris la suite d’un socialiste!
 La parole est à Monsieur Jean-Paul Chanteguet.
 C’est cet enchaînement pervers qu’il faut remplacer par un cercle vertueux.
 Ce nouveau modèle de développement existe.
@@ -2326,11 +2326,11 @@ Je suis convaincu que nos concitoyens connaissent parfaitement la situation pré
 Ils savent qu’un effort collectif est nécessaire et ils y sont prêts.
 Mais deux problèmes se posent, monsieur le ministre.
 Certains de nos collègues s’en sont d’ailleurs félicités.
-Évidemment, l’effet économique est désastreux
+Évidemment, l’effet économique est désastreux!
 Il y a deux choses que vous omettez de dire.
 La première, c’est que toute votre stratégie repose sur la faiblesse des taux d’intérêt.
 La Cour des comptes vous l’a dit.
-Mon cher collègue
+Mon cher collègue!
 Je conclus.
 La deuxième, c’est que la baisse du déficit se dégrade.
 C’est signé Didier Migaud.
@@ -2340,8 +2340,8 @@ La parole est à Monsieur Pascal Terrasse.
 J’ai donc l’expérience des années passées, j’en dirai un mot tout à l’heure.
 Nous étions en désaccord sur un certain nombre de points et d’articles.
 Cette croissance, je souhaite vous en dire un mot.
-Précisément, ils se les sont cassées
-C’est à vos électeurs qu’il faut le dire
+Précisément, ils se les sont cassées!
+C’est à vos électeurs qu’il faut le dire!
 Je veux parler de la mise en place du rapport Gallois.
 De ce point de vue-là, regardons les choses assez simplement.
 Avec le Gouvernement, monsieur le ministre, vous avez pris les mesures structurelles qui s’imposaient.
@@ -2349,73 +2349,73 @@ De ce point de vue, le rapport Gallois nous donne un juste horizon.
 Je suis également très satisfait des mesures qui sont prises en matière de logements.
 Faut-il moins d’enseignants?
 Personne ne souhaite qu’ils soient moins nombreux dans les classes.
-Il faudra tout de même vous décider
-C’est pourquoi
+Il faudra tout de même vous décider!
+C’est pourquoi!
 Je vous remercie de bien vouloir conclure, mon cher collègue.
-C’eût été une mesure sociale
-Encore une promesse trahie
+C’eût été une mesure sociale!
+Encore une promesse trahie!
 Nous aurons l’occasion d’en reparler, mon cher collègue.
-mais nous continuerons à travailler avec vous
+mais nous continuerons à travailler avec vous!
 La parole est à Monsieur David Douillet.
 L’impôt doit rester juste et tolérable, or vous avez clairement dépassé les limites.
 Selon la bonne vieille maxime, trop d’impôts tue l’impôt.
 L’exil fiscal est reparti de plus belle.
 Ceux-là, nous ne les reverrons jamais.
-C’est faux et archifaux
+C’est faux et archifaux!
 Tout cela est aléatoire.
 J’en viens désormais à la sécurité.
-Vous annoncez la création de nouvelles zones de sécurité prioritaire, merveilleux
+Vous annoncez la création de nouvelles zones de sécurité prioritaire, merveilleux!
 Les dotations de fonctionnement ne prennent pas la mesure de la réalité.
 Ce budget n’est que la traduction de votre obstination et de votre incompréhension.
-Non au dopage
+Non au dopage!
 La parole est à Monsieur Alain Fauré.
-Ce n’est pas tout à fait faux
+Ce n’est pas tout à fait faux!
 Une consultation pour amnésie avérée s’impose.
 Il doit pourtant bien y avoir une raison pour que vous soyez dans l’opposition.
 Le projet de loi de finances deux mille quatorze s’inscrit dans cette voie.
-Vous, c’est plutôt un microscope que vous utilisez
-Eh oui, les taux baissent
+Vous, c’est plutôt un microscope que vous utilisez!
+Eh oui, les taux baissent!
  parce qu’il est nécessaire pour redonner de l’espoir et surtout de la dignité.
-Il est bon de le rappeler
-Voilà une réalité incontestable
-Horresco referens
-En somme, c’est un budget réaliste et volontariste
-Vous n’y croyez pas
+Il est bon de le rappeler!
+Voilà une réalité incontestable!
+Horresco referens!
+En somme, c’est un budget réaliste et volontariste!
+Vous n’y croyez pas!
  que nous devons défendre avec force et vigueur, ici et à l’extérieur.
-À l’extérieur, c’est plus difficile
+À l’extérieur, c’est plus difficile!
 La confiance ne se décrète pas, elle se gagne.
 Allons à l’essentiel.
-Prenez donc un pot de peinture
-C’est déjà mieux
+Prenez donc un pot de peinture!
+C’est déjà mieux!
 Ils s’interrogent quant à l’efficacité de votre politique.
 Ils sont du même coup agacés par votre frénésie fiscale.
 À l’instar de mes collègues, je souligne l’augmentation de tous les taux de TVA.
-Elle aurait profité au plus grand nombre
+Elle aurait profité au plus grand nombre!
 En vérité, vous avez bâti votre campagne sur la suppression de ce dispositif.
-Et de vos factures
+Et de vos factures!
 Cela vous oblige à augmenter la TVA bien plus que nous ne l’aurions fait.
 A contrario, vous minorez fortement l’indemnité compensatoire de formation destinée aux employeurs d’apprentis.
 Pourtant, ces PME offrent de réelles perspectives à nos jeunes.
-Ce sont là les vrais emplois d’avenir
+Ce sont là les vrais emplois d’avenir!
 Notre voisin allemand l’a bien compris, lui qui incite fortement à l’apprentissage transfrontalier.
 C’est l’instabilité dans vos prises de décision qui renforcent ces craintes.
 Vous êtes dans la contradiction permanente, sans cohérence ni logique économique.
-Nous sommes tous dans l’expectative
+Nous sommes tous dans l’expectative!
 Car nous craignons un épisode tragique du blocage de l’économie.
 La parole est à Monsieur Christophe Castaner.
-Mais parfois sur la comparaison
+Mais parfois sur la comparaison!
 Je comprends qu’au vu de son bilan, la droite préfère oublier ses errements passés.
 L’impôt, s’il est juste, est accepté.
 Pour compenser ses largesses fiscales, la droite a choisi la dette.
 Mais l’impôt ne fait pas une politique.
 Seule, la justice dans l’impôt est politique.
 C’est bien cela, mesdames, messieurs les députés, qui nous différencie de l’UMP.
-Ne dites pas n’importe quoi
-Les dépenses augmentent
+Ne dites pas n’importe quoi!
+Les dépenses augmentent!
 Ce serait trop lent.
-Pis encore, nous mentirions aux Français
-Nous n’avons jamais dit cela
-Cela se voit
+Pis encore, nous mentirions aux Français!
+Nous n’avons jamais dit cela!
+Cela se voit!
 Ce n’est pas un budget d’austérité et il est tout entier tourné vers l’emploi.
 En deux ans, nous aurons réparé cette faute.
 Derrière ces contrats, ce sont des femmes, des hommes, des familles qui retrouvent l’espoir.
@@ -2428,23 +2428,23 @@ Ce gouvernement et cette majorité portent donc seuls la responsabilité de cett
 Première contre-vérité, aucun des engagements sur le redressement des finances publiques n’est tenu.
 Il sera supérieur à quatre pourcent, soit vingt milliards de plus.
 Il serait maintenant à trois virgule six pourcent.
-Fin deux mille quatorze, quarante-cinq milliards d’impôts en plus
-quarante-cinq milliards
-Ça augmente d’heure en heure
-Il faudrait vous acheter un boulier pour faire les comptes
-Oui, on voit bien que vous êtes dans le coma
-Vos chiffres sortent de nulle part
-Rendormez-vous
+Fin deux mille quatorze, quarante-cinq milliards d’impôts en plus!
+quarante-cinq milliards!
+Ça augmente d’heure en heure!
+Il faudrait vous acheter un boulier pour faire les comptes!
+Oui, on voit bien que vous êtes dans le coma!
+Vos chiffres sortent de nulle part!
+Rendormez-vous!
 Et ce n’est pas fini.
-Chers collègues, laissez Monsieur Marcangeli s’exprimer
+Chers collègues, laissez Monsieur Marcangeli s’exprimer!
 Lui seul a la parole.
-Ce n’est pas le cas
-Vous arrivez même à dénaturer le programme d’investissement d’avenir
+Ce n’est pas le cas!
+Vous arrivez même à dénaturer le programme d’investissement d’avenir!
 Les chiffres sont cruels.
 Alors oui, le constat est sévère.
 Pourtant, une autre voie est possible, monsieur le ministre, chers collègues de la majorité.
-Empruntez-la avec courage
-On a déjà donné
+Empruntez-la avec courage!
+On a déjà donné!
 La parole est à Monsieur Olivier Faure.
 C’est un exercice annuel, l’un des rendez-vous majeurs en démocratie.
 C’est pour cela que ce débat ne devrait pas être caricatural.
@@ -2455,21 +2455,21 @@ La droite, c’est la compétitivité des entreprises et la gauche, l’asphyxie
 Parlons d’abord de l’impôt.
 L’opposition dit que nous prélevons treize milliards sur les ménages.
 Pour y parvenir, elle suggère cinq milliards de dépenses en moins.
-Allez comprendre
+Allez comprendre!
 Ceux qui paieraient moins ne sont pas ceux qui recevraient plus.
-Voilà qui est bien
-Tout en finesse
+Voilà qui est bien!
+Tout en finesse!
 La France est un grand pays, nous en sommes convaincus.
-Avec vous, nous croyons en son redressement et ce budget y contribue
+Avec vous, nous croyons en son redressement et ce budget y contribue!
 Boucler un budget est un exercice difficile, monsieur le ministre.
-Surtout parmi vos amis
-Pas seulement
+Surtout parmi vos amis!
+Pas seulement!
 Les employeurs, noyés sous les charges, ne sont pas en mesure de le compenser.
-Rien de tel dans votre budget
-Pas si nombreuses que ça
-Une douzaine tout au plus
+Rien de tel dans votre budget!
+Pas si nombreuses que ça!
+Une douzaine tout au plus!
 Mes collègues de l’UMP et de l’UDI et moi-même leur avons tendu la main.
-L’universalité comprend aussi New York
+L’universalité comprend aussi New York!
 Nous devons réagir avant qu’il ne soit trop tard, monsieur le ministre.
 La parole est à Madame Valérie Rabault.
 Celui-ci, nous le savons, passe par un chemin étroit.
@@ -2477,7 +2477,7 @@ La situation économique est complexe et personne ici ne dira le contraire.
 Tel n’était pas le cas auparavant.
 Je remercie le Gouvernement pour la qualité de la discussion que nous avons eue.
 La vérité, c’est que ce projet de budget est une véritable punition.
-Je sais que mes collègues m’applaudissent intérieurement, monsieur le rapporteur général
+Je sais que mes collègues m’applaudissent intérieurement, monsieur le rapporteur général!
 La parole est à Monsieur Jean-Jacques Cottel.
 Dans certains pays, la taxe générale sur les activités polluantes est dissuasive.
 Tous les metteurs sur le marché doivent contribuer au recyclage des objets.
@@ -2493,39 +2493,39 @@ Les Français trouveraient juste que les dépenses de l’État soient réduites
 Ils trouveraient juste que les missions des collectivités territoriales soient rationalisées.
 Ils trouveraient juste que le nombre de fonctionnaires cesse d’augmenter.
 C’est la raison pour laquelle, bien évidemment, un tel budget est inacceptable.
-L’avenir, c’est-à-dire que c’est maintenant
+L’avenir, c’est-à-dire que c’est maintenant!
 Le pirate regarde votre réseau et s'est où se trouve vos failles de sécurités.
-Avant de nous contacter, regarder notre foire aux questions
-Je souhaite contribuer à votre projet
-La ferme aux cochons élèvent des cochons et sont nourris gracieusement
-La recherche avancée est disponible à partir du bouton suivant
-les sablés légers
-cent quatre vingt cinq grammes de farine
-quatre-vingt dix grammes de beurre ramolli
-quatre-vingt dix grammes de sucre en poudre
-un oeuf moyen
-une pincé de sel
-Bonjour à tous et à toutes
-Roulez, étalez la pâte et découpez-la à l’emporte-pièce
-ou en carrés avec un couteau
-Disposez les biscuits sur une plaque munie d’un papier cuisson
-Cuire au four préchauffé à deux cent degrés, quatre à cinq minutes
+Avant de nous contacter, regarder notre foire aux questions!
+Je souhaite contribuer à votre projet!
+La ferme aux cochons élèvent des cochons et sont nourris gracieusement!
+La recherche avancée est disponible à partir du bouton suivant!
+les sablés légers!
+cent quatre vingt cinq grammes de farine!
+quatre-vingt dix grammes de beurre ramolli!
+quatre-vingt dix grammes de sucre en poudre!
+un oeuf moyen!
+une pincé de sel!
+Bonjour à tous et à toutes!
+Roulez, étalez la pâte et découpez-la à l’emporte-pièce!
+ou en carrés avec un couteau!
+Disposez les biscuits sur une plaque munie d’un papier cuisson!
+Cuire au four préchauffé à deux cent degrés, quatre à cinq minutes!
 Sortez et placez les biscuits sur une grille pour les laisser refroidir.
-Recette spéciale pour les allergiques
-Préchauffez votre four à cent quatre-vingt degré pendant 10 minutes
-Laissez lever la patte environ 30 minutes au frigo puis mettez là au four
-Les légumes sont bons pour votre santé, ils sont variés suivant la saison
-Ajoutez les légumes avec le bouquet garni et couvrez d’eau
-Aujourd'hui, la pluie est arrivée
-Nous pouvons voir les débuts des flaques d'eaux apparaître
-Les délicieuses pommes de terre à l’huile au cumin, légèrement citronnée
-que vous pouvez accompagner d'une viande grillée au barbecue
+Recette spéciale pour les allergiques!
+Préchauffez votre four à cent quatre-vingt degré pendant 10 minutes!
+Laissez lever la patte environ 30 minutes au frigo puis mettez là au four!
+Les légumes sont bons pour votre santé, ils sont variés suivant la saison!
+Ajoutez les légumes avec le bouquet garni et couvrez d’eau!
+Aujourd'hui, la pluie est arrivée!
+Nous pouvons voir les débuts des flaques d'eaux apparaître!
+Les délicieuses pommes de terre à l’huile au cumin, légèrement citronnée!
+que vous pouvez accompagner d'une viande grillée au barbecue!
 couper les carottes en julienne et émincer l’oignon.
-Avant de servir, assaisonner avec sel, poivre et huile d’olive à votre goût
-Bien mélanger
+Avant de servir, assaisonner avec sel, poivre et huile d’olive à votre goût!
+Bien mélanger!
 L’aspect du taboulé doit être brillant, indiquant qu’il y a suffisamment d’huile d’olive.
-Le chou stimule l’amincissement en régulant le métabolisme du sucre et des graisses
-Enculé de ta mere
+Le chou stimule l’amincissement en régulant le métabolisme du sucre et des graisses!
+Enculé de ta mere!
 Lorsque la lune est pleine, les loups garous se transforment.
 Les ornithorynques sont des créatures hors du commun.
 Les abeilles sont malheureusement menacées par l'utilisation excessive de pesticides.
@@ -2544,18 +2544,18 @@ La mer Méditerranée est plus calme que l'océan Pacifique.
 Un hexagone est une figure géométrique à six côtés.
 La civilisation Maya est très ancienne et mérite qu'on y porte plus d'attention.
 Je suis allé faire un marathon contre le cancer du sein le mois dernier.
-Avec la technologie tout devient de plus en plus sans fil
-Même mon aspirateur
+Avec la technologie tout devient de plus en plus sans fil!
+Même mon aspirateur!
 Marie et moi vivons en symbiose, on est vraiment fait l'un pour l'autre.
-Michaël est devenu un expert en pétanque, il touche presque toujours le cochonnet
+Michaël est devenu un expert en pétanque, il touche presque toujours le cochonnet!
 Les jeux olympiques représentent une compétition importante pour les sportifs.
 L'indépendance est une forme de liberté dont je ne voudrais jamais me séparer.
 C'est dans les petits commerces que l'on peut trouver les meilleurs babioles.
 La baguette magique d'Harry est faite d'un bois particulier.
-À la bonne heure
+À la bonne heure!
 Faisons ainsi mon cher ami.
 Julie veut que tu fasses les comptes pour lundi prochain.
-Mon fils est le meilleur joueur de Scrabble qui soit
+Mon fils est le meilleur joueur de Scrabble qui soit!
 C'est quand même bien pratique d'avoir un frigo.
 Albert Einstein est l'un des plus grands physiciens du vingtième siècle.
 Le boson de Higgs est ce qui donne à la matière, sa masse.
@@ -2563,108 +2563,108 @@ L'oncle de Ben a une maladie cardiovasculaire.
 Qu'est-ce qui peut bien schlinguer à ce point?
 Mamie Joseline a perdu son dentier en se levant ce matin.
 Tu pourrais offrir un cadeau à ta soeur pour son anniversaire quand même.
-Arrête de m'embêter ou je vais vraiment m'énerver
+Arrête de m'embêter ou je vais vraiment m'énerver!
 Jeanne et Arthur ont eu un bébé récemment, il s'appelle Théo.
 Conduire en état d'ivresse peut être dangereux pour soi mais aussi pour les autres.
-Le chat noir se promène sur le balcon en plein soleil
-Un chasseur sachant chasser doit connaître la vie des animaux
-La chaussée humide est particulièrement glissante ce matin
-J'ai passé l'après-midi à ne rien faire
-Je commence à travailler tard le soir car la nuit m'inspire
-L'installation du logiciel a été singulièrement compliquée
-Le capitaine largue les amarres au coucher du soleil
-Le train a du retard aujourd'hui
-Le saucisson sec d'Auvergne est le meilleur
-La cuisine est une activité relaxante pour celui qui s'y adonne
-Le serveur de fichier ne répond plus à partir de vingt heure
-La musculation permet de se maintenir en forme sur la durée
-Un petit footing le matin permet de se réveiller rapidement
-L'ordinateur est resté allumé toute la nuit mais l'algorithme n'a pas encore convergé
-L'apprentissage automatique nécessite beaucoup de tâches ingrates en amont
-Heureusement la musique est entrainante et facilite cette tâche
-L'université est fermée tout le mois d'Août
-Je commence à fatiguer mais je m'accroche avec l'énergie du désespoir
-Mon verre de vin est vide, je vais aller le remplir avant de continuer
-Le repas du soir était un peu lourd, la digestion est difficile
-La chaleur du mois de Mai réchauffe mes vieux os
+Le chat noir se promène sur le balcon en plein soleil!
+Un chasseur sachant chasser doit connaître la vie des animaux!
+La chaussée humide est particulièrement glissante ce matin!
+J'ai passé l'après-midi à ne rien faire!
+Je commence à travailler tard le soir car la nuit m'inspire!
+L'installation du logiciel a été singulièrement compliquée!
+Le capitaine largue les amarres au coucher du soleil!
+Le train a du retard aujourd'hui!
+Le saucisson sec d'Auvergne est le meilleur!
+La cuisine est une activité relaxante pour celui qui s'y adonne!
+Le serveur de fichier ne répond plus à partir de vingt heure!
+La musculation permet de se maintenir en forme sur la durée!
+Un petit footing le matin permet de se réveiller rapidement!
+L'ordinateur est resté allumé toute la nuit mais l'algorithme n'a pas encore convergé!
+L'apprentissage automatique nécessite beaucoup de tâches ingrates en amont!
+Heureusement la musique est entrainante et facilite cette tâche!
+L'université est fermée tout le mois d'Août!
+Je commence à fatiguer mais je m'accroche avec l'énergie du désespoir!
+Mon verre de vin est vide, je vais aller le remplir avant de continuer!
+Le repas du soir était un peu lourd, la digestion est difficile!
+La chaleur du mois de Mai réchauffe mes vieux os!
 Qu'est-ce qui est jaune et vert et monte et descend?
 Quelle heure est-il à l'horloge atomique de Toulouse?
-La voiture est mal garée dans la rue adjacente
-Un truc que je n'ai jamais compris, cela ne se peut
-Le ricard à l'apéro c'est ce qui se fait de mieux par grande chaleur
-Le clavier de mon ordinateur s'illumine de mille couleurs
-Le son dans mon salon est au maximum
-Mon voisin n'est pas content car je suis trop bruyant
-Par chance, il finit par accepter de participer à ma fête d'anniversaire
-Le linge sèche sur la véranda inondée de soleil
-Les murs blancs de la maison réfléchissent la luminosité ambiante
-La télévision diffuse un navet ce soir
-La machine à café est tombée en panne ce matin
-Le plancher ciré de la salle à manger est glissant
-La porte vitrée entrouverte laisse deviner ce qui se passe dans l'autre pièce
-La bicyclette est abandonnée dans la rue
-Le camion passe dans une flaque d'eau, éclaboussant les piétons
-L'avion atterrit avec plus d'une heure de retard
-Le sapeur pompier manie la lance d'incendie avec maestria
-Le footballeur professionnel gagne bien sa vie en général
-Un dentiste s'appelait autrefois un arracheur de dent
-L'automobiliste n'a pas respecté le code de la route
-Les freins de la voiture ont lâché dans la descente
-Le passage à niveau s'est fermé avant que le train ne passe
+La voiture est mal garée dans la rue adjacente!
+Un truc que je n'ai jamais compris, cela ne se peut!
+Le ricard à l'apéro c'est ce qui se fait de mieux par grande chaleur!
+Le clavier de mon ordinateur s'illumine de mille couleurs!
+Le son dans mon salon est au maximum!
+Mon voisin n'est pas content car je suis trop bruyant!
+Par chance, il finit par accepter de participer à ma fête d'anniversaire!
+Le linge sèche sur la véranda inondée de soleil!
+Les murs blancs de la maison réfléchissent la luminosité ambiante!
+La télévision diffuse un navet ce soir!
+La machine à café est tombée en panne ce matin!
+Le plancher ciré de la salle à manger est glissant!
+La porte vitrée entrouverte laisse deviner ce qui se passe dans l'autre pièce!
+La bicyclette est abandonnée dans la rue!
+Le camion passe dans une flaque d'eau, éclaboussant les piétons!
+L'avion atterrit avec plus d'une heure de retard!
+Le sapeur pompier manie la lance d'incendie avec maestria!
+Le footballeur professionnel gagne bien sa vie en général!
+Un dentiste s'appelait autrefois un arracheur de dent!
+L'automobiliste n'a pas respecté le code de la route!
+Les freins de la voiture ont lâché dans la descente!
+Le passage à niveau s'est fermé avant que le train ne passe!
 Les chaussettes de l'archiduchesse sont-elles sèches?
-Le travail de préparation est très important et doit absolument être fait
-Le train de nuit vient de quitter la gare de marchandise
-Ecrire sans relâche est une activité salvatrice pour moi
-Lire toute la nuit finit par fatiguer les yeux
-Effectivement, j'arrive au bout de mon labeur
-En espérant avoir apporté ma petite contribution
-Mon imagination commence à s'assécher
-Il ne reste plus qu'à passer à autre chose
-Merci d'être venu, d'avoir participé et au plaisir de vous revoir
-Super, merci pour le lien
+Le travail de préparation est très important et doit absolument être fait!
+Le train de nuit vient de quitter la gare de marchandise!
+Ecrire sans relâche est une activité salvatrice pour moi!
+Lire toute la nuit finit par fatiguer les yeux!
+Effectivement, j'arrive au bout de mon labeur!
+En espérant avoir apporté ma petite contribution!
+Mon imagination commence à s'assécher!
+Il ne reste plus qu'à passer à autre chose!
+Merci d'être venu, d'avoir participé et au plaisir de vous revoir!
+Super, merci pour le lien!
 et voilà.
-Rester sur ces connaissances de base, c'est tout à fait possible
-L'aire numérique peut se comparer à l'aire secondaire que vous avez pu apprendre
-L'aire préhistorique est le début de l'informatique et est considéré comme compliquer
-L'aire secondaire est apparu avec l'internet, appelé de nos jours Web
-Le but est de rappeler leurs missions et les différentes limites rencontrées
+Rester sur ces connaissances de base, c'est tout à fait possible!
+L'aire numérique peut se comparer à l'aire secondaire que vous avez pu apprendre!
+L'aire préhistorique est le début de l'informatique et est considéré comme compliquer!
+L'aire secondaire est apparu avec l'internet, appelé de nos jours Web!
+Le but est de rappeler leurs missions et les différentes limites rencontrées!
 Mais aussi avec une infrastructure solide pour répondre aux différentes attentes.
-L'amélioration des performances a toujours été présente, pour proposer toujours quelques de plus rapides
-L'installation est simple puisqu'il s'agisse d'une extension PHP
+L'amélioration des performances a toujours été présente, pour proposer toujours quelques de plus rapides!
+L'installation est simple puisqu'il s'agisse d'une extension PHP!
 Au niveau de la configuration, celle-ci passe par l'ajout des lignes suivantes.
-Tout est très fluide, même avec des applications complexes comme un Drupal par exemple
-Cette sonde envoie ensuite les données collectées à un agent via un socket local
-Il est ainsi très facile d'obtenir des mesures de performance
-Au niveau des outils d'analyse statique, vous pouvez trouver ceci
-Il suffit alors de sélectionner le projet souhaité pour lancer l’analyse
+Tout est très fluide, même avec des applications complexes comme un Drupal par exemple!
+Cette sonde envoie ensuite les données collectées à un agent via un socket local!
+Il est ainsi très facile d'obtenir des mesures de performance!
+Au niveau des outils d'analyse statique, vous pouvez trouver ceci!
+Il suffit alors de sélectionner le projet souhaité pour lancer l’analyse!
 Enfin, les analyses publiques permettent un suivi de tous les projets OpenSource référencés.
-Ainsi, vous trouverez dans cette boite, les outils suivants :
-Il s'agit d'une application à installer avec PEAR
-Il applique certaines règles pour vérifier la qualité de votre code
-PHP Code Sniffer un autre moteur, qui peut s'utiliser indépendement du Tools
-PHP Coding Standard Fixer
-PHP_CodeBrowser est un outil destiné, à être utilisé en conjointement avec CruiseControl
-Ces zones seront codifiés par couleurs
-Il est compatible avec les autres outils d'assurance qualité  comme PHPUnit ou PHP CodeSniffer
+Ainsi, vous trouverez dans cette boite, les outils suivants :!
+Il s'agit d'une application à installer avec PEAR!
+Il applique certaines règles pour vérifier la qualité de votre code!
+PHP Code Sniffer un autre moteur, qui peut s'utiliser indépendement du Tools!
+PHP Coding Standard Fixer!
+PHP_CodeBrowser est un outil destiné, à être utilisé en conjointement avec CruiseControl!
+Ces zones seront codifiés par couleurs!
+Il est compatible avec les autres outils d'assurance qualité  comme PHPUnit ou PHP CodeSniffer!
 Bien entendu, l'outil évolue régulièrement avec des outils pertinents à posséder.
-L'article a présenté un certain nombres d'outils du moment
-En mille huit cent quinze
-Charles-François-Bienvenu Myriel était évêque de Digne
+L'article a présenté un certain nombres d'outils du moment!
+En mille huit cent quinze!
+Charles-François-Bienvenu Myriel était évêque de Digne!
 C'était un vieillard d'environ soixante-quinze ans, il occupait le siège de Digne depuis mille huit cent six.
-Myriel était fils d'un conseiller au parlement d'Aix, noblesse de robe
-Charles Myriel, nonobstant ce mariage, avait, disait-on, beaucoup fait parler de lui
-Charles Myriel, dès les premiers jours de la révolution, émigra en Italie
-Sa femme y mourut d'une maladie de poitrine dont elle était atteinte depuis longtemps
-Ils n'avaient point d'enfants
-Que se passa-t-il ensuite dans la destinée de M Abbesse
-Abbesse
-La préparation a durée d'Août à Décembre, soit quatre mois et demi
-Ensuite nous avons eut droit au stage commando
-Le combats à main nu est compris dans le tarif
-Une fois arrivé sur Oberhoffen il a fallu que nous retrouvions nos affaires civiles
-Personne ne savait où elles se trouvaient
-Nous les avons dénichées dans une salle d'eau fermée à clef
-Ensuite durant un mois et demi nous avons pu profiter de notre permission
+Myriel était fils d'un conseiller au parlement d'Aix, noblesse de robe!
+Charles Myriel, nonobstant ce mariage, avait, disait-on, beaucoup fait parler de lui!
+Charles Myriel, dès les premiers jours de la révolution, émigra en Italie!
+Sa femme y mourut d'une maladie de poitrine dont elle était atteinte depuis longtemps!
+Ils n'avaient point d'enfants!
+Que se passa-t-il ensuite dans la destinée de M Abbesse!
+Abbesse!
+La préparation a durée d'Août à Décembre, soit quatre mois et demi!
+Ensuite nous avons eut droit au stage commando!
+Le combats à main nu est compris dans le tarif!
+Une fois arrivé sur Oberhoffen il a fallu que nous retrouvions nos affaires civiles!
+Personne ne savait où elles se trouvaient!
+Nous les avons dénichées dans une salle d'eau fermée à clef!
+Ensuite durant un mois et demi nous avons pu profiter de notre permission!
 Je me suis inscrit à l'IUT de Strasbourg-sud.
 Eve promenait parmi les animaux de la création sa beauté flamande.
 Mais c'etaient là des tresors perdus.
@@ -2682,10 +2682,10 @@ La rive opposée m'était mieux connue puisque je l'habitais.
 La rue des Petits-Augustins s'appelle aujourd'hui rue Bonaparte.
 Vous ne me comprenez pas?
 vous ne savez plus ce que je veux dire?
-Hélas
+Hélas!
 Les générations nouvelles ne l'ont point vu subir, captif, les outrages des écoliers.
 Elles ne l'ont point vu couché, l'œil a demi clos, dans une résignation douloureuse.
-À l'occident aussi, j'avais touché les confins de l'univers
+À l'occident aussi, j'avais touché les confins de l'univers!
 Point de fiacres, quelques promeneurs à peine.
 Le coco était dans une carafe coiffée d'un citron.
 La poussière et le silence passaient sur ces choses.
@@ -2723,10 +2723,10 @@ Je jugeais qu'il y en avait beaucoup, et peut-être plus de cent.
 C'était une science trés negligée en ce temps-la.
 La douleur est la grande éducatrice des hommes.
 J'étais en grande familiarité avec ce marchand de lunettes.
-Elle lui demandait avec intérêt: Eh bien
+Elle lui demandait avec intérêt: Eh bien!
 Monsieur Hamoche, comment va?
 Et ils faisaient un bout de causette.
-Eh bien
+Eh bien!
 ça va t'il mieux, les affaires?
 Monsieur Hamoche, les bras croises, morne, le regard a l'horizon, ne répondait pas.
 Son costume, comme son air, était étrange.
@@ -2738,11 +2738,11 @@ Et nous nous en allions, elle et moi, trouble et pensifs, vers les Champs-Elysee
 Et cela surtout me jetait dans des etonnements profonds.
 Car enfin, je voyais bien que M.
 Hamoche etait malheureux.
-Il est malheureux
-Il avait tout pour lui, celui-la
-Grand, fort, beau, malin et jovial
+Il est malheureux!
+Il avait tout pour lui, celui-la!
+Grand, fort, beau, malin et jovial!
 Et toujours bien tenu, toujours une rose a la boutonnière.
-C'était un homme bien agréable
+C'était un homme bien agréable!
 Elle apparaissait dans mon imagination d'enfant comme une maison devorée par un antique incendie.
 Mes parents étaient un peu plus instruits.
 Elle l'avait repris alors, elle l'avait ramené chez elle avec une joie triomphale.
@@ -2752,7 +2752,7 @@ C'est pour vous une delivrance, disait mon pere a Madame Mathias.
 Les pharmacies surtout m'étonnaient par la grandeur et l'éclat de leurs bocaux.
 Quelques-unes de ces boutiques etaient peuplées de grandes statues peintes et dorées.
 En les revoyant, je fus saisi du regret de Nanette perdue.
-J'eus envie de courir en pleurant et en criant: Nanette
+J'eus envie de courir en pleurant et en criant: Nanette!
 Des lettres et des enveloppes étaient collées sur tous les carreaux.
 Du toit de zinc sortait un tuyau de cheminée coiffe d'un grand chapeau.
 Un vieillard, courbe sur une table, leva la tête a notre vue.
@@ -2760,29 +2760,29 @@ Des favoris en fer a cheval bordaient ses joues roses.
 Ses cheveux blancs s'enlévaient sur son front comme dans un coup de vent orageux.
 Sa redingote noire était par endroits blanchie et luisante.
 Il portait un bouquet de violettes a la boutonniere.
-Tiens
-c'est la vieille
+Tiens!
+c'est la vieille!
 dit-il sans se lever.
-Puis me regardant d'un air peu sympathique
+Puis me regardant d'un air peu sympathique!
 C'est ton petit bourgeois, hein?
 demanda-t-il.
 repondit Madame Mathias, il est gentil enfant, quoiqu'il me fasse souvent endever.
 Il est maigrichon et palot.
-Ca ne fera pas un fameux soldat
+Ca ne fera pas un fameux soldat!
 comment vas-tu, Hippolyte?
 dit-il, la santé n'est pas mauvaise.
 Le coffre est bon.
 Mais les affaires ne vont pas.
 Trois ou quatre lettres a cinq sous pièce, le matin.
-Et c'est tout
-A ta santé, la vieille
-A ta santé, Hippolyte
+Et c'est tout!
+A ta santé, la vieille!
+A ta santé, Hippolyte!
 Le vin était piquant.
 En y trempant mes lévres, je fis la grimace.
 C'est une petite demoiselle, dit le vieillard.
 A son age, j'étais deja porte sur le vin et les amours.
 Mais on ne fait plus des hommes comme moi.
-Le moule en est brise
+Le moule en est brise!
 J'étais a Craonne et a Fere-Champenoise.
 Et, le matin d'Athis, Napoleon m'a demande une prise de tabac.
 Je crois le voir encore, l'empereur.

--- a/web/locales/kab/messages.ftl
+++ b/web/locales/kab/messages.ftl
@@ -284,7 +284,7 @@ request-language-success-content = A nennadi aṭas amek ara nernu tulayt-nwen a
 
 language-section-in-progress = Ad d-iteddu
 language-section-in-progress-description = Tutlayin deg usfari ttwabnant i uttekki sɣur tirebbaɛ-nneɣ; asfari-nsent yeskan-d anida llant deg usmel n usidel akked imecwaṛen n ulqaḍ n tifyar.
-language-section-launched = Yendeh
+language-section-launched = Yekker
 language-section-launched-description = Tutlayin-agi yekkren, d tid yesɛan asmel web yettwasuqel akken iwata, tid yesɛan daɣen ddeqs n tifyar i d-yettwaleqḍen, akken ad yebdu uttekki s <italic>{ speak }</italic> akked <italic>{ listen }</italic>.
 languages-show-more = Wali ugar
 languages-show-less = Wali qqel


### PR DESCRIPTION
@mikehenrty This should fix the punctuation characters that went missing due to the script's bug.
I also fixed around 3 other small issues in German, I stumbled upon.
It would be nice, if we could find someone that speaks french to take a short look at this, I'm not 100% sure, if this many exclamation marks are accurate.
For German the exclamation marks have just been restored from @jf99 's file