### PR TITLE
add turkish text from SETimes

### DIFF
--- a/server/data/tr/setimes.txt
+++ b/server/data/tr/setimes.txt
@@ -1,0 +1,5079 @@
+Her iki zanlı da soykırımla suçlandı.
+Yaklaşık %19 ise kararsız.
+Bu, demokrasinin özüdür.
+Ekim ayında bir ilerleme raporu yayınlanacak.
+Bülbüller güneş ışığında şakıyorlardı.
+Gezinin bir sonraki durağı ise Sofya.
+Karadağ, unutulmayacak bir Aralık ayı geçiriyor.
+Hükümetse suçlamayı reddediyor.
+Bölgede yenilenen işbirliği çözüme katkıda bulunaabilir mi?
+Fazlagica Kula.
+Bunun olacağını sanmıyorum.
+Üsküp ise öneriye kuşkuyla yaklaşıyor.
+Tadiç Ahtisaari'nin kararını daha hoş karşıladı.
+Tasarının en çok tartışılan maddesi Madde 7.
+Bence bir insan çok şeyi değiştirebilir.
+Reform süreçlerinin hızından memnun musunuz?
+Şu andaki personel sayısı 2 bin 851.
+Ve bir yıl sonra, bu ay, bu iki kitap basıldı.
+Bu konuda herkes yüzde 100 iyimser değil.
+Sergi Ocak ayı sonuna kadar açık kalacak.
+Hamuru sarın.
+Görüşmelerde Kosova konusuna da değinildi.
+Kosova mutfağı kara iklimiyle son derece uyumlu.
+AB resmi bir açıklamada bulunmadı.
+Proje, altyapı ve ekonomik açıdan önem taşıyor.
+Ödül hayatınızda ne gibi değişiklikler yarattı?
+Bu yüzden de, Cipliç'e göre çözüm yeni seçimler.
+Makedonya'da kadınların yönettiği şirketlerin gelişebilmesi için yeterli koşullar mevcut mu?
+Çalışma gelecek yılın ilk günlerinde başlayacak.
+'Romanya'da böyle bir şey nasıl olur?' diye aylarca öfke içinde düşündüğümü hatırlıyorum.
+Artık kimsenin bizden korkmasına gerek yok.
+Cumhuriyetin temel ilkelerinin tehdit altında olduğu doğru değil mi?
+İyi bir gazeteci her zaman nesnel olabilmelidir.
+Üste görevli başka Sırplar da var mıydı?
+Ancak kuruluşun özelleştirilmesi kolay olmadı.
+Şampiyonaya 20 ülkeden sporcular katılacak.
+Her türlü yatırım için en önemli ön koşul bu.
+İhale için son teklif verme günü 5 Aralık.
+İbar'ın güneyinde yaşayanlar için manzara farklı.
+Sırp pasaportuyla Batı vizesi almanız hâlâ zor.
+Sizlere yatırım yapıyoruz.
+Dört yıl sonra dava gün ışığına çıktı.
+Fikir bir miktar direnişle de karşılaşmadı değil.
+Fakat ilişkiler her zaman bu kadar pembe değil.
+Ancak yasa tam olarak uygulanmıyor.
+Dini muhafazakârlar toplumun %33,5'ini kapsıyor.
+Kitap 30 yabancı dilde basılacak.
+Uzanlar bu kararı 14 Ağustos'ta temyiz etti.
+Bu engelleri aşmada ne gibi bir plan uygulanacak?
+Bu yüzden, meclis çalışmaları durmuş durumda.
+Tabii bu zirveyi devralmak isteyen adaylar var.
+Tartışma Haziran ayında yapılacak.
+Nisan ayında olağan bir seçim yapılmıştı.
+Ekonomik kalkınma önemli bir öncelik.
+Mahhemenin altı ay sürmesi bekleniyor.
+Organize suç, siyaseti ve basını kirletiyor.
+Kokaini taşıyan tır Makedon plakalıydı.
+Eğitim ve danışmanlığa 10 Mart'ta devam ettik.
+Bir koridorla da hastane bölümüne bağlanıyor.
+Her iki sanık da suçsuz olduğunu iddia etti.
+Anlaşma Lefkoşa'da imzalandı.
+Bu, neredeyse her 100 erkekten ikisi demek.
+Fehmiu Kosova'da doğmuştu.
+Buzların çözüldüğüne dair henüz bir işaret yok.
+Mladiç şimdilik hala kaçak durumunda.
+Bu bir ön şart.
+Bu yılan balık ve kurbağa ile besleniyor.
+Tadiç'in çağrısına uyuldu mu?
+Maaşlarımızı kesecekler.
+Toplam 25 milyon avroluk yatırım yapıldı.
+Çok hızlı dil öğrenmiş ve uyuşturucuya alışmış.
+Bugün ise bunun sonuçlarına tanık oluyoruz.
+Makedonya henüz tanınmadı.
+Tarih tekerrür edebilir mi?
+Güvenlik planı 1 Temmuz'da başlatılacak.
+Her ikisi de diyaloga hazır olduğunu söylüyor.
+Yunanistan ise gelecek yıla bakıyor.
+Parti, Türkiye'deki 81 ilin 58'ini ele geçirdi.
+Armagedon küsmüş.
+Seçimler 18 Nisan'da yapılacak.
+Her ikisi de 1996'dan beri saklanıyor.
+Finans sektöründe de ciddi eğilimler görülüyor.
+Burada özgürlüğümüz yok, güvenliğimiz yok.
+Makedonya ise 9. Grupta üçüncü sırada yer alıyor.
+Peki bu popülerlik ne boyuta ulaştı?
+Projenin toplam maliyeti yaklaşık 60 milyon avro.
+Temel haklara saygı gösteriliyor.
+Bu yılki en önemli konu güvenlikti.
+Pek çok tanınmış üye partiden ayrıldı.
+Fakat 1453 fethinin anma törenleri tarihle bağdaşıyor mu?
+Karadağ'da ortalama aylık maaş 475 avro.
+Sibiu'nun kendisi de bir açık hava müzesi.
+Ve bu borçları bile ödemesi zor olacak.
+Fakat bu konuda da çeşitli engeller söz konusu.
+Bu sürecin en az iki yıl sürmesi bekleniyor.
+İşsizlik oranı %43'lerde dolaşıyor.
+Şu ânda bütün yerler tutulmuş durumda.
+Günlük üretim 745'ten 840 üniteye çıkarıldı.
+Miljus daha önce de ölüm tehditleri almıştı.
+Bu Hasan'ın onları canlı son görüşüydü.
+İngiliz heyeti Cuma günü Türkiye'den ayrılacak.
+Traykovski evli ve iki çocuk babasıydı.
+Bunlara asla sırtımızı dönmeyeceğiz.
+Bu yılki etkinliklerde otuz iki şair yarıştı.
+Ancak kıyılardaki yazlık evler buna dahil değil.
+Tesis, Balkanlar'daki en büyük su parkı olacak.
+Toplantıya toplam 140 milletvekili katıldı.
+Hızlı bir ekonomik büyüme neden yeterli değil?
+Üniversite idaresi de aynı bölgede yer alıyordu.
+Sırp liderlerin tepkileri çeşitli oldu.
+Her yaştan takasçı geliyor.
+Bu saldırıyla uğraşacak zamanları olmalı.
+Seçimlerin yapılmasından bu yana beş ay geçti.
+Yaklaşık 100 bin etnik Sırp hâlâ duruyor.
+Fuara 45 ülkeden 780 mucit katıldı.
+Doğrusu benim için hoş bir sürpriz oldu.
+Çin'in tutumu belli değil.
+Kamuoyuna sunulan proje büyük ilgi çekti.
+Yerel basın daha da ihtiyatlı davrandı.
+Sonuç olarak bir de iftirayla suçlandılar.
+Hepimiz bu hatalardan ders almalıyız.
+Ancak rejim çöktükten sonra müze kapatılmıştı.
+Peki ufukta ekonomik bir düzelme görünüyor mu?
+On milletvekili çekimser kaldı.
+Görüşmeler Ocak ayı sonunda tamamlanacak.
+Türkiye yönetim sistemini elden geçiriyor.
+Diğer yetkililer bu tür endişeleri paylaşmadılar.
+Ancak hükümet bu rakamı ödemiş değil.
+Bizim Kosovalılar olarak kendi yasalarımız var.
+Blaga'nın istifası Schengen umutlarına inen bir darbe mi?
+En yüksek profilli dava, sözde Limaj davası.
+Franchini ölmedi.
+Bir de yolsuzluk potansiyeli var.
+Fakat herşey yolunda gidiyor.
+Ancak Gruevski iki öneriyi geri çevirdi.
+Buna nasıl tepki veriyorsunuz?
+Sergide 150 taslak ve kolaj çalışması yer alıyor.
+Karnındaki bebek ise hiçbir zaman doğmamış.
+Muhalefet partileri bu hareketi sorguladılar.
+Brüksel de ilave kaynak sağlıyor.
+Bu yılki rapor serinin 8'inci raporu oldu.
+Seminer 11 Kasım'da İstanbul'da başladı.
+Hepsinin de Sırp uyruklu olduğu belirtiliyor.
+O ülkeden herhangi bir tepki geldi mi?
+Her zaman ve her yerde madalya kazanırdık.
+Ve ne kadar süreyle?
+Sizce diplomatik ilişkiler ne zaman kurulur?
+Bu, bizim her gün yaşadığımız bir realite.
+Simitis de bu ihtiyacı hissettiğini söylüyor.
+Onları yenmek çok önemli olacak.
+Sırbistan-Almanya maçı.
+Bu seçimlerin yeni özelliği budur.
+Sizce yeni gerginlikler ortaya çıkabilir mi?
+Tesisin inşaatı, dört buçuk yılda tamamlanancak.
+Bu, bizi her koşulda birleştiren bir şey.
+Bu kampanya beklenilen başarıya ulaştı mı?
+Son derece uluslararası bir zihniyetteler.
+Neden kuzeye güneyden farklı muamele edilsin?
+Televizyondaki her dört sözcükten birisi kriz.
+Bu, sınırları aşan, uluslar ötesi bir meseledir.
+Sizce yeni bir kriz tehlikesi var mı?
+Bundan cumhurbaşkanı bile etkilendi.
+Anlaşma 1 Ocak'ta yürürlüğe girecek.
+Ancak tutuklama olmadı.
+Aradaki fark önemli.
+Ayrıca güzel manzaralı bir balkonu da var.
+Değişikliklerin bu ay kabul edilmesi bekleniyor.
+Sonrasında ilgili müdür bu listeden atanacak.
+Kimse zahmet edip soruları yanıtlamadı.
+Ara sıra iş buluyorum.
+Bu şekilde bir aşırı görüş diğerini besliyor.
+Hızlı ve doğru şekilde hareket etmek zorundaydık.
+Bunu birçok nedeni var.
+Romanya genel klasmanda 17. sırada bulunuyor.
+Saldırganların hiçbiri tespit edilemedi.
+Bu yıl ödül ilk defa bir Sırp doktora gitti.
+Ancak durumun böyle olmadığını gördük.
+Bir de ünlülerin yazdığı anı kitapları var.
+Onlara komünist sistemi anlattı.
+Ancak komisyon yine de güçlüklerle karşılaştı.
+Hükümet yeni sistem için yakında ihale açacak.
+Operasyon Pazar günü şafak sularında başlatıldı.
+Üretime yıl sonunda başlanması planlanıyor.
+Bazılarına ilgi diğerlerine göre daha büyük.
+Sırbistan'daki bilimsel ilerleme ve başarılara ilişkin değerlendirmeniz ne yönde?
+Maçı İngiltere 2-1 kazandı.
+Daha fazla rekabetin rolü nedir?
+Pasiç sorunun siyasi olduğunu düşünüyor.
+Salıverilme şartları hala belirsizliğini koruyor.
+Ailenin her ferdine birer dilim dağıtılıyor.
+Miktarı ne olursa olsun para kabul edemeyecekler.
+Bunlardan yaklaşık 3 bin 700'ü ise suçlu görüldü.
+Ve bence olaylar da bu yönde gelişecek.
+Büyük yeniden yapım projesi dört aşamaya bölündü.
+Futbol etnik bölünmeleri aşabilir mi?
+Tesise 29 milyon avroluk yatırım yapılacak.
+Bu grupların büyüklükleri nedir, bu gruplar etrafındaki insanların sayısı aşağı yukarı ne kadardır?
+Kampanya Haziran 2010'a kadar devam edecek.
+Bu konudaki görüşünüz nedir?
+Babasının yokluğunda Yusuf konuşmayı bırakıyor.
+Burada tam olarak ne oldu?
+Bu sebeple yasa pek etkili değil.
+Yeni yasa uyarınca bunlar da kaldırıldı.
+Mladiç'le hiçbir zaman iyi anlaşamadı.
+Üsküp yine de vazgeçmiyor.
+Çoğu işveren fazla mesaileri ödemiyor.
+"Mallarınızı düşük fiyata mı satmak daha iyi, yoksa iflas etmek mi?" diye soruyor.
+Festivale 16 ülkeden yaklaşık 200 kişi katılıyor.
+Anlaşma sağlanması yıllar sürdü.
+Her iki ülke de 4,1 puana sahip.
+Anlaşmanın değer 4,7 milyon dolardı.
+Kosova'da en sevdiğim yiyecek mi?
+Bu süre icinde ne gibi başarılar elde edildi?
+Bu da işçi maaşlarına hiçbir şey bırakmıyor.
+Nihayet!
+Sonra da aptalca hatalar.
+Bir çocuğun dikkati bir saatten uzun sürmez.
+Uluslararası toplumun, özellikle çatışmadan yeni çıkılmış bu dönemde, nasıl bir faydası olabilir?
+Tek bir dava bile takip edilmedi.
+Artık tüm bunlar değişti.
+Saati 700 avro olan bu hizmet biraz lüks tabii.
+Anlaşmanın bedeli açıklanmadı.
+Havayolu şirketi haftada dört sefer yapacak.
+Fakat sonuçlar tatsızdı.
+Bunlardan üçü şimdiden kesinleşti.
+Operasyon altı kentte birden yürütüldü.
+Papademos zorlukları kabul ediyor.
+Türk medyasındaki tepkiler karışık oldu.
+İlk dersler Eylül ayında başlayacak.
+Hiçbir soru, "Maçı nerede izleyeceksin?" sorusundan daha önemli değildi.
+Ziyaret 21 Temmuz'da gerçekleşecek.
+Peki devlet kurma sürecinin hangi aşamasına gelindi?
+Ancak hükümet enflasyon konusunda endişeli.
+Yeni sistem 2007 başlarında faaliyete geçecek.
+Öğrenmede ve sınavlarda sıkıntı yaşıyorlar.
+Şehir merkezinde fırıncılık yapıyor.
+Davanın Pazartesi günü açılması gerekiyordu.
+Ancak istisnalar da yok değil.
+Batiç ise herhangi bir dosya gördugunu reddetti.
+Pürüzsüz bir kıvam elde edene kadar karıştırın.
+İktidara geldiğinde tamamen farklı olacak.
+Ön teklifler 25 Eylül'e kadar kabul edilecek.
+Yeni Zadar limanı 2011 yılında hizmete girecek.
+Kamyon durduruldu, mühürlendi ve arandı.
+Her iki sanatçıya da 23 biner avro ödül verildi.
+Projenin toplam maliyeti 247 milyon avro.
+Toplam 250 milyon avroluk yatırım yapılacak.
+Esas yarışma son iki günde yapıldı.
+Durres turizm açısından da önem taşıyor.
+Neden bu tür programa dahil olmayı tercih ettiniz?
+Burada da yaklaşık 125 bin avro toplandı.
+Kosova tam mali özerkliğe sahip olacak.
+Anlaşma üçüncü şahıs gemiler için geçerli değil.
+Bağış önerileri açık rekabetle seçiliyor.
+Iron Maiden kapalı gişe bir konser verdi.
+Bu arada Ddik de önceki sözlerini tekrarladı.
+Tasarı 2004 yılı sonunda meclise sunulacak.
+Belgradlı sinemaseverler için seçenekler azaldı.
+Bunlar da çözülecek, çünkü çözülmek zorundalar.
+Bu, Dabeski'nin aynı ödülü ikinci kazanışı oldu.
+Ekim 2005'te müzakereler başladı.
+Adresimiz info@setimes.com.
+Bununla nasıl başa çıktınız?
+Gençleri Sırbistan'da kalmaya ve gidenleri geri dönmeye nasıl ikna edebiliriz?
+Fiyatlar da arttı.
+Seçmen kaydı da başka bir sorun.
+Belgrad'dan bu konuyla ilgili herhangi bir geri bildirim aldınız mı?
+İnşaat yaklaşık 53 milyon avroya mal olacak.
+Arnavutluk kendisini köprü kurucu rolünde buldu.
+Oylamaya 17 milletvekili katılmadı.
+Romanya'da araba işi patlama yaşıyor.
+Ohri ve Üsküp yaz festivalleri oldukça meşhur.
+Kosova'da herkes buna katılmıyor.
+Fakat bu, dayanakları sağlam bir iddia mıdır?
+Referandum tarihi henüz belirlenmedi.
+Başlıca farklılık noktaları ekonomik.
+Restoran yaklaşık 700 kişilik kapasiteye sahip.
+Sırbistan Kosova ile müzakerelere hazır mı?
+AB de hükümeti destekledi.
+Dimitrova 64 yaşındaydı.
+Ancak bu bakanın hoşuna gitmedi.
+Bu kişilerin banka hesapları donduruldu.
+Astibo'da 4.000 kişi çalışıyordu.
+Macaristan "pasaport politikası" mı oynuyor?
+Sosyal eşitsizliğin ve ekonomik performans düşüklüğünün bunca zamandır devam etmesinin sebebi ne?
+Ciddi bir meslek nasıl böyle aşağılanabilir? 
+Operatör Huawei ile beş yıllık sözleşme imzaladı.
+Örneğin uluslararası güçler ne zamandır Kıbrıs'da bulunuyor?
+Ancak bazı projelerin finansmanı hala beklemede.
+Bu konunun belirgin iki yönü var.
+Yabancı diplomatlar da ekipte yer aldı.
+AB de operasyona olumlu tepki gösterdi.
+Sebeplerden biri uluslararası endişe.
+Sanader de günün anlam ve önemine dikkat çekti.
+Bu olayı bir dizi soruşturma izledi.
+Kitaptaki kişi ben olabilirdim.
+Yabancı dil eğitimi getirilmeli.
+Kosova 17 Şubat'ta bağımsızlık ilan etti.
+Polis reformu en büyük engel olmayı sürdürüyor.
+Bu noktada kültürler arasında bir savaş olduğunu söyleyebilir miyiz?
+Ancak her şey o kadar kolay değil.
+Karadziç 1996 yılında kanundan kaçmaya başladı.
+Fabrika iki merkezde faaliyet gösteriyor.
+Kentas bundan emin değil.
+Bu yasada yeni olanlar nedir?
+Dava 2003 sonlarında başladı.
+Bizi kandırıyor ve bize yalan söylüyorlar.
+Bunun yaklaşık 1000 tonu imha edilecek.
+Yarışmaya 83 ülkeden toplam 258 öğrenci katıldı.
+Fuarın bu yılki ortak ülkesi İsrail'di.
+Nuremberg'de de aynen böyle oldu.
+Bu yasayı yeni bir özel birim uygulayacak.
+İki bölümlük dizinin ilk bölümü.
+Mesajı ileten Hasan'ın gözleri yaşla doldu.
+Moldova toplantıya gözlemci statüsüyle katılıyor.
+Barış müzakereleri hiçbir zaman kolay olmaz.
+Asker de öyle.
+Fonlar, eğitim projelerinde kullanılacak.
+İki ağabeyim ve bir kız kardeşim var.
+Barikatlardan çekilmemiz gerektiğini düşünüyorsa neden bize bu yönde daha önce çağrıda bulunmadı?
+Kimilerine göre bu yeni bir şey değil.
+Şirket bugüne kadar 107,6 milyon avro pompaladı.
+Aile reisinin eğitim durumu da önemli bir faktör.
+Değişmesini istediğiniz şeyler neler?
+Iraklı Kürt liderlerden de kınama geldi.
+Rade de altı yaşındaki oğlunu yanında getirmiş.
+Yolsuzluk ve rüşvet yok kabul ediliyor.
+Fiyatlar çok yüksekti.
+Dava 7 yıl sürüncemede kaldı.
+Herkes aynı duyguyu paylaşmıyor.
+Zamanın hepimizin lehine işlediğine de eminim.
+Fakat bu alanda az bir ilerleme kaydedildi.
+Kıbrıs sorununda herhangi bir değişiklik yoktur.
+Bu durum bu yıl da geçerliydi.
+Görüşmelerde Kosova'nın statü sorunu ele alındı.
+Ayrıca iç kurumsal meselelerle de uğraşıyor.
+Fakat anılarımızda yer almak için burada.
+Bu başvurunun dayanağı nedir?
+Etkinliğin ilki 2006 yılında gerçekleşmişti.
+Peki Balkan sporcuları şanslılar arasında yer alacak mı?
+Rücker göreve resmi olarak 1 Eylül'de başlayacak.
+Çocuk, 1999 yılında satıldığında üç yaşındaydı.
+Grup biraz dil engeliyle karşı karşıya.
+Özlem sonunda muradına eriyor.
+Bu önemsiz bir sorun sayılmaz.
+Sonunda iyi bir haber aldık.
+Torunu, Tito'nun izinden mi gidiyor?
+Bu olay ilk değildi.
+Fakat süreç içinde sorunlar da yaşanmıyor değil.
+Aleksiç'i dipçikleriyle dövmeye başladılar.
+Pazar günü Almanya itirazlarını geri çekti.
+Daha sonradan Lahey'e iade edildi.
+Hayvar kırmızı biberden yapılıyor.
+Projenin toplam bütçesi 1 milyar avro.
+Örneğin domuz eti fiyatları yüzde 10 arttı.
+Oruçtan sonra Sırplar et yemekleri yiyorlar.
+Şu ânda durum nedir?
+Elli köprü yenileniyor.
+Tartışmalar devam ediyor.
+Türkiye ile uzun vadeli bir ortaklık sağlanması konusuna ilişkin beklentileriniz neler?
+Peki bu durumda Kosova'nın ekonomisini düzeltme ihtimali nedir?
+Bu haliyle köy oldukça huzurlu görünüyor.
+Çok sayıda gösterici gözaltına alındı.
+Sürekli ve kararlı bir yasal reform.
+Hırvatlar fuara 13 buluşla katıldılar.
+Organizatörler öneriyi geri çevirdiler.
+Fakat Avrupa kamuoyu buna ikna oldu mu?
+Peki sonuç ne oldu?
+Eğer öyleyse, seçimleri kaç gözlemci izleyecek?
+Avrupa Komisyonu konuyu incelediğini söyledi.
+Pek çok analist de buna katılıyor.
+Buna karşı olan var mı?
+Bu iddialarla ilgili yorumlarınız nelerdir?
+Ama bu olmadı.
+Kosovalı Sırp liderler törene katılmadı.
+Merkez bankasının başlıca amacı düşük enflasyon.
+Savaş suçu davaları hâlâ inceleniyor.
+Yatırımcılar bunu bekliyor.
+Bu da rekabetçiliği ve istihdamı olumsuz etkiler.
+Bu durum hakkındaki düşünceleriniz neler?
+Ülkede 680 Romen askeri bulunuyor.
+Moldova halkı yorgun ve kafası karışmış durumda.
+SC parlamentosunda da durum böyle.
+Ali'nin özel polis timi üyesi olduğu söyleniyor.
+Milan, torunu için geldiğini söylüyor.
+Rajevac ülkesine olan sadakatini bir kenara koyarak vargücüyle maça odaklanabilir mi?
+İttifak üyeliğine muazzam bir halk desteği var.
+Yetenekli genç oyuncuların sizin izinizden geldiğini düşünüyor musunuz?
+Sergi bir ay devam edecek.
+Halk arasındaki tepkiler de şok niteliğinde.
+Bu rakam 2011'in başlarında %57'ye geriledi.
+Pek çoğu da Roman toplumundan geliyor.
+Bunu başkaları da izleyecek.
+Aylık kredi ödemeleri hızla yükselmeye başladı.
+BM, kararı incelemekte olduğunu açıkladı.
+Yunan takımıyla ilgili kavgalar yenilginin önsözü mü?
+Teknenin batması yaklaşık üç dakika sürdü.
+Adam kayırma vakalarına sık sık rastlanıyor.
+Yaşanan gelişmeler pek çok kimseyi şaşırtıyor.
+Görüşmelerde Tadiç planını sundu.
+Yeni meclis ilk oturumunu gerçekleştirdi.
+Sizce bu sorun yakın bir gelecekte çözüme kavuşabilir mi?
+Kaybettik ve eve erken dönmek zorundayız.
+İlk Balkan Schengen'i mi?
+Sırbistan, Kosova tarafından verilen araç plakalarını ve evrakları tanıyacak mı?
+Teklif sunma süresi 1 Nisan 2006'da sona eriyor.
+Görüntüler Ekim ayı sonunda çekilecek.
+Elektriğe bu ay %6,7 oranında zam yapıldı.
+Durum iyi görünmüyor.
+Yine de ordunun değişmekte olduğuna inanıyor.
+Burada kazanan yok.
+Ancak yetkililer Nuh deyip peygamber demiyorlar.
+Dizi harika!
+Ancak Vuciniç'e göre bu suçlamalar asılsız.
+Geri kalan malzemelerle hamuru hazırlayın.
+Bizi karıştırmayın - sadece adlarımız aynı!
+Ancak onlar olmadan film de yapılmaz.
+Risk altındaki tek sektör turizm değil.
+Bakanlar Kosova konusunda da konuştular.
+Artık bulundu.
+Buna harcanan paraya değer, kriz ne kadar büyük olursa olsun!
+Kosova'nın tanınma sürecinde yavaşlama mı yaşanıyor?
+Gözden geçirilmekte olan diğer bir madde ise 87.
+Yolsuzluk ve organize suçla mücadele etmeliler.
+Savaşta çocukları korumayı düşünen pek yoktu.
+Ancak, bunlar Bulgarlar için yeni haber değil.
+Komşu Kosova'da da durum aynı.
+Şimdilik değişen pek bir şey yok.
+Şimdi ise bu oranlar yer değiştirdi.
+Üsküp'e göre Kosova, bu konuda ayak sürüyor.
+Genel durumu iyileştirme yönünde herhangi bir fikriniz var mı?
+Projenin 2010 yılında tamamlanması bekleniyor.
+AB misyonu her taraftan baskı altında.
+Bunların mahkemeye sunulması gerekir.
+Askerler gün boyunca görev yerlerinde kaldılar.
+Kazanana çoğunluk oyuyla karar verilecek.
+Bu arada, gözler yeni anayasanın kabulüne döndü.
+Ancak bu konuda yardım gelebilir.
+Zherka kardeşlerse 15 gün gözaltında tutulacak.
+Herşeyin bir kapasitesi var, değil mi?
+Ortalama fatura 200 avroyu buluyor.
+Sizce eski Yugoslavya topraklarında medya, profesyonel ve ahlaki açıdan yeterli olgunluğa ulaştı mı?
+Fikir yeni değil.
+Böyle bir şeyi dünyanın başka neresinde görebilirsiniz?
+Bunu nasıl değerlendiriyorsunuz?
+Ankete katılan herkese teşekkür ederiz.
+Gül hesabını geçen ay açmıştı.
+Bunun ön koşulları hâlâ var.
+Bu durumun devam edeceği konusunda iyimserim.
+Anayasaya göre Arnavutluk'un resmi bir dini yok.
+Sizce bu durum, çoklu etnik bir yapıya sahip toplumumuzu nasıl etkiler?
+Ancak bu meclisin yetkileri tırpanlanacak.
+Türkiye'de toplam 28 ulusal gazete bulunuyor.
+Bu, pek çok acı ve ölüm getirmiş bir kitap.
+Makedon okulları çevre eğitimine kavuştu.
+Ziyaret, Arnon'un ülkeye ilk gelişi oldu.
+Kurti ve örgütün diğer üyeleri gözaltına alındı.
+Devlet koruması altındaki bir eser haline gelmiş.
+Yunanistan stratejik açıdan önemlidir.
+Örneğin bir konserve fabrikası çöpünü nereye dökecek?
+Yasak önümüzdeki üç ay boyunca geçerli olacak.
+B92 blogcuları açıklama arıyorlar.
+Bir diğeri aynı fikirde değil.
+Mali af akıllıca bir kamu politikası mı, yoksa seçim oyunu mu?
+Sonucu ancak seçim sonuçları belirleyecek.
+SI bu kararıyla iddiayı kaybetmiş göründü.
+Süreç büyük olasılıkla bu ay başlayacak.
+Kosovalı hakim ve savcılar bu gibi davaları görebiliyorlar mı?
+Uluslararası toplum krizi çözmeye çalıştı.
+Bu konuda sizin tutumunuz nedir?
+Ancak bu sorun da çözülüyor.
+Ana menüde balık ve domuz eti var.
+Bu erteleme için bir somut gerekçe gösterilmedi.
+Bu görevi beklenilen şekilde yerine getirebiliyorlar mı?
+Kuruluş ilk defa Sırbistan'a not verdi.
+Vahhabi'ler ülkeye girdiğinde işler değişti.
+Korg .
+Taksiciyle aranız iyi olursa herşey mümkün.
+Yıldız da duyduğu güveni dile getirdi.
+Kararın Kosova'daki yansımaları ne oldu?
+Bunun için geri geleceğiz!
+Ödül için 37 kitap yarışmıştı.
+Türkiye firmayı yedinci girişiminde satabildi.
+Asgari fiyat 6 milyon avro olarak belirlendi.
+Bir köpeğin kariyeri beş yıla kadar sürebiliyor.
+Son Yugo müzeye konuyor.
+Etkinlik 29 Kasım'a kadar sürecek.
+Ancak tek faktör bu değil.
+Bu ürün, tanıtımlarında iddia edilen etkileri yaratıyor mu, yoksa bir aldatmacadan mı ibaret?
+Nerede?
+Bu çatışma çok uzun bir geçmişe dayalı.
+Liste polis ve yargı kurumlarına iletildi.
+Bu kentsel alanlar için sorun değil.
+Kuruluş özelleştirmeye hazır.
+Tabii ki, riskler var.
+Makedonya üyelik başvurusunu 22 Mart'ta sundu.
+Ancak hala bazı engeller var.
+Temel sorumlu onlar.
+Son başvuru tarihi 26 Şubat 2010.
+Fırtınalar bölge genelinde sorunlara yol açtı.
+Sekiz kişi gözaltına alındı.
+Fazilet onun kendi ödülüdür.
+Bu, bağımsız ama mesajı olan bir film.
+Ödül 5 bin avro olarak açıklandı.
+Bu türün en üretken sanatçılarından biriyim.
+Travnik'teki evin içi.
+Valotto görevde bir yıl hizmet verdi.
+Fuara 600 yerli ve yabancı yayınevi katılacak.
+Yunanistan'ın Selanik kenti de ilk ona girdi.
+Her üç Hırvat'tan biri sigara içiyor.
+Peki siz, Sırp toplumunda kadının yerini nasıl değerlendiriyorsunuz?
+Sırbistan'ın tek yolcu otomobili üreticisini daha parlak günler mi bekliyor?
+Her iki ülke de listede 24'er sıra yükseldi.
+Lisanslar 15 yıl süreli olacak.
+Bu arada da kendi hayatını sürdürmeye çalıştı.
+Projenin iki yıl içinde tamamlanması bekleniyor.
+Bu değişim, aslında bir çeşit yeni Osmanlıcılık akımının bir sonucu mu?
+Hükümete göre program sonuç veriyor.
+Şimdilik.
+Şok halindeyim.
+Ulaşması zor ama benzersiz.
+Kendim için protesto ediyorum.
+Bu durum, ülkeyi aşırılık yanlılarının hedefi haline getirebilir mi?
+Bu yorumlar Lahey tarafından hoş karşılanmadı.
+Bence bu tarz şeylere açık olmanız gerekiyor.
+Sırbistan bunun gibi bir şeyi yıllardır yapıyor, bize gelince neden sorun yaratsın ki?
+Diğer spor dalları neredeyse yok gibi.
+Kolaylık, Karadağ'ın değerlerinden biri.
+Seçimlerde önemli bir olay bildirilmedi.
+Tuzla, çeşitli ödüller almış bir şehir.
+Bulgartabac yorum yapmayı reddetti.
+Daha sonra bu kişi yemek masasını hazırlar.
+Ancak sürecin tamamlanmasına daha çok var.
+Belgrad Kosova'yı hala eyaleti sayıyor.
+Bunu akıldan çıkarmamalı.
+Yeni lidere eşi ve 18 yaşındaki kızı eşlik etti.
+Sektördeki resmi ortamala aylık 211 avro.
+Olduktan sonra tepki gösterebilirsiniz ama olmasını nasıl engelleyebilirsiniz?
+Haradinay iddiaları reddetti.
+Bu tavrım hepsini şaşırttı.
+Bu sefer başaracaklarını sanıyorum.
+Bu Perşembe tekrar biraraya gelecekler.
+Festival 26 Kasım'a kadar devam edecek.
+Festivalde 53 ülkeden toplam 232 film gösterildi.
+Yarışın ilk yedisi Kenya'dan geldi.
+Geri kalan yufkalarla da bu işlemi tekrarlayın.
+Yeni sınır kapısı Limnitis kasabasında olacak.
+Ancak proje bir engele takıldı.
+Hırvat tarımı ayakta kalabilecek mi?
+Ancak sonuçlar ölümcül olabiliyor.
+Ancak artık çok geçti.
+Projeler turizm açısından da önem taşıyor.
+Ancak Lefkoşe öneriyi kesin bir dille reddetti.
+Bugün artık tüm siyaset küresel.
+Ne yapabilirim ki?
+Uluslararası toplum seçimleri yakından izliyor.
+Bute maçı onuncu rauntta nakavtla kazandı.
+İşten çıkarmaların devam edeceğine dair işaretler var mı?
+Ancak belirli bir çözüm seçilmedi.
+Herhangi bir şeyi kanıtlamak mümkün mü?
+İnşaatın dört yıl sürmesi bekleniyor.
+Bölgede istikrar artacak mı, yoksa önümüzde yeni krizler mi var?
+Peki bunu yapabilirler mi?
+Ancak küçük partiler isyanlarda.
+Azınlıklara özel bir saygı gösterecektir.
+Fuara 45 ülkeden yaklaşık 700 icat katıldı.
+Bu çok tehlikeli bir şey.
+Olaylarda yaralanma bildirilmedi.
+Fiyatın 66 milyon avro olduğu bildirildi.
+Demokratlar buna tepki verdiler.
+Neden hayat bu gittikçe daha pahalı hale geliyor?
+Veriler 2008 yılının ilk üç ayını kapsıyor.
+Festivale tüm dünyadan 50 film katılıyor.
+Bu arada yerli malları da yok oluyor.
+Fakat Ivica farklı düşünüyor.
+Projenin 200 milyon avroya mal olması bekleniyor.
+Etrafımda bir sürü yerli insan var.
+Sorun, kamuoyunda tartışmalara yol açtı.
+Merwin, festivale üçüncü kez katılıyor.
+Şu anda bölgede yaklaşık 90 bin Sırp yaşıyor.
+Sırp Cumhuriyeti eşit temsil hakkını ihlal etti mi?
+Güneydoğu Avrupa hükümetleri, kayıtdışı ekonominin boyutları konusunda endişe duymalı mı?
+Üyelik için hedef tarih verilmiyor.
+Popov "Neden?" diye soruyor.
+Romen leyi 1 Temmuz'da 10 bin kat değerlendi.
+Kırk sekiz parti aday listelerini sundu.
+Bölge yeni ve tarihi bir fırsatla karşı karşıya.
+Ancak isimler açıklanmadı.
+İşyerleri durumdan kötü zarar gördü.
+Hâlâ görüştükleriniz var mı?
+Nüfus arttıkça, Ankara'daki hükümet de büyüdü.
+Bunda, soğuk havanın da etkisi olmuş olabilir.
+Sizi Bondsteel hakkında yazmaya sevkeden özel bir neden var mı?
+Bu işbirliği diğer taşımacılık biçimlerine de yayılacak mı - örneğin hava taşımacılığı?
+Bu soruşturmalar hangi safhada ve bulgular ne zaman beklenebilir?
+Aynı gün de başkanlığın başkanı seçildi.
+Kosova'da, insanlarda Facebook çılgınlığı var.
+Yanmamasını sağlayın.
+Bu anlamda sizce hangi genç Sırp oyuncu öne çıkıyor?
+Bu misyonlarda yer almak Makedonya'ya nasıl bir deneyim ve kazanım sağladı?
+Endeksin dünya ortalaması ise 4.11 puan.
+Toplantı dokuz saat sürdü.
+Sonra da bekliyorlar.
+Bu günlerdeyse değişim rüzgarları hissediliyor.
+Bu oran daha hızlı bir şekilde aşağı çekilmeli.
+Gelecekte ne tür adımların atılması bekleniyor?
+Hırsızlar, hazır olmayacak bir fidye yolu arıyor.
+Durum kötüleşirse ne yapacaksınız?
+Ancak tarihi kent bugünlerde tehdit altında.
+Yeni lider 18 Şubat'ta ant içecek.
+Gecikmenin kaynağı ise hala belirsiz.
+Reuters'e göre, teklif için iki grup yarışıyor.
+Çiftlikteki bahçe.
+Gazprom da bu projeye dahil mi?
+Grup üyesi birçok kişi tutuklandı.
+Etkinlik 6 Haziran'a kadar devam edecek.
+Deniz güvenliğini sağlayıcı önlemler de alındı.
+Kurgu da çok etkileyici değil.
+İkili, Kosova'nın statü sürecini değerlendirdi.
+Limaj'a bir ay ev hapsi verildi.
+Ne yazık ki ben gidemedim.
+Bunun değişeceğini umuyorum.
+Makedonya bağımsızlığının 18. yılını kutladı.
+Karar yerel turizmi hızlandırdı.
+Sonunda taşınmak zorunda kaldılar.
+Kuşların ikisi de karantinada öldüler.
+Devletten 2 bin 700 avro tazminat almışlar.
+Karadağ yeni bir Monako olabilir mi?
+Kosova'da Kasım ayında seçimler yapılacak.
+Kahvelerimizi bitirdik ve arabaya geri yürüdük.
+Aksi takdirde gerileme kaçınılmaz olacak.
+Bu yılki etkinliğin onur konuğu Mısır idi.
+Tesisin 100-120 yeni iş yaratması bekleniyor.
+Küçük bir Bulgar belediyesi İnternet'e geçti.
+Hırvatistan yeni bir rüzgar santraline kavuştu.
+Hükümet sorunla baş etmek için adımlar atıyor.
+Bu, rekabet kültürünü artıracaktır.
+Yine de riskler var.
+Türkiye, Ortadoğu'daki kargaşanın dışında kalabilecek mi?
+Yangında yaralanan olmadı.
+Sistemi çok partili bir sisteme değiştiriyoruz.
+İçerideki bölünmeler ülkenin uluslararası arenadaki görevine gölge düşürecek mi?
+Bu katı bilişsel uyumsuzluğun arkasında yatan etmenler nedir?
+Ancak yeni askerlere sürekli ihtiyaç duyuluyor.
+Yalandan inanma olamaz.
+Bu alandaki Avrupa ortalaması ise %97.
+Amaçsa, kötü ruhları korkutup kaçırmak.
+Bu onların hayatta kalma stratejisi.
+Sizce sanat ve pazarlama arasında nasıl bir bağ var?
+Sırbistan benzin ithal etmiyor.
+Fakat artık çok geçti.
+Bir diğer sorun da Kıbrıs.
+Erkeklerse Brezilya'yı 2-1 yendiler.
+Paktın önerisi basitti.
+Mesele uluslararası hakemliğe götürülebilir.
+Bu yüzden de, bu açıdan önemlidirler.
+Her ikisi de 47 puan aldılar.
+Aralarında pek çok mülteci var.
+Devletin inşası işte o zaman başladı.
+Partinin hükümet desteğinin yarısı kesildi.
+Baiç altı yıldır Fransa'da yaşıyor.
+Etkinliğe 21 ülkenin temsilcileri katılıyor.
+Sanader bu yaz umut verici bir başlangıç yaptı.
+Büyük ödül 15 bin avro.
+İlk kemoterapi küründen sonra kanser yok olmadı.
+Ancak hükümet ücret ödenmemesine karar verdi.
+Ülkenin başlıca rakibi Hırvatistan 34 oy aldı.
+Şimdi de kuralları değiştiriyorlar.
+Şeşel'in yokluğunda Sırbistan siyasetinde neler olacak?
+Genelde, yolcular gelişmelerden heyecan duruyor.
+Üst yönetim seviyesinde fark daha da büyük.
+Hafta sonu ülkeye 50 santimetre daha kar yağdı.
+Kosova'da çok az bir otoritesi kaldı.
+Eylemci grupları daha az ihtiyatlı davrandılar.
+Sırbistan memur ve emekli aylıklarına zam yapacak mı?
+Moldovan-Tilea ciriti 53,04 metreye attı.
+Şimdi aynı denklemi düşünme sırası Pekin'de.
+Bayram üç gün sürüyor.
+Bundan sonra ise Viyana'ya dönecek.
+Bu doğru mu sizce?
+Sana yardım edebiliyorsam, ederim.
+Açık bir siyasi açısı olmayan bir film.
+İki taraf, taban tabana zıt tutumlar benimsiyor.
+Bunların sayısı kaçtır ve bu kişiler gelecekte ne yapacak?
+Klasik müzik etkinliği 30 Ağustos'ta sona erecek.
+Veles, Makedonya.
+Öfke ve çaresizliğin arkasında ne var?
+Ayrıca uluslararası şirketlere de engel oluyor.
+Şu anda ikisi de işsiz durumda.
+Genel anlamda proje büyük başarı yakaladı.
+Kurbanların çoğunu çocuklar oluşturuyor.
+Her iki ülkede de 2007'de seçimler düzenlenecek.
+Sizce 2009 şirket açısından başarılı bir yıl mıydı?
+Şu anda trenler günde iki defa hizmet veriyor.
+Reform süreci bir kenara bırakıldı.
+Miro on oy alarak adaylığı kazandı.
+Antik bina arkeolojik kazılar sırasında bulundu.
+AB temsilcileri haberi memnuniyetle karşıladılar.
+Karadağ'da meyve üretiminde maliyetler yüksek.
+Bu yeni bir baskı biçimi midir?
+İnşaata Aralık ayında başlanacak.
+Ülke, ırklararası büyük çatışmalara sahne oldu.
+Oysa İslam Konferansı'nda 57 üye ülke bulunuyor.
+Festival Pazar günü sona eriyor.
+Sizce Dink neden öldürüldü?
+Bizim politikamız açık.
+Projenin değeri yaklaşık 650 bin avro.
+Bu da özelleştirme gelirlerinden karşılanacak.
+Tüm partiler erken seçim yapılmasını istiyor.
+Ordunun bu konudaki tavrı nedir?
+Şanslı para kimin olacak?
+Kentin mali esnekliğinin düşük olduğu bildirildi.
+Etkinlikte toplam 11 performans sergilendi.
+Diğer bölgelerde katılım göstermeye hazır mısınız?
+Liderler Kosova konusunda anlaşamadılar.
+Karadağ da Maine ile ortak oldu.
+Genel görünüm istikrarlı olarak kaldı.
+Ancak sokakta görüşler farklı.
+Yerel basın haberi müjdeledi.
+İmamın konuşması sonrasında saygı duruşu yapıldı.
+Bu konuda elinizde net rakamlar var mı?
+Fakat Sırp devleti henüz devreye girmiş değil.
+Mahkemeler görevlerini yapacaklar mı?
+Hareketi Makedon hükümeti de destekledi.
+Futbolda neler olacağını ise kestirmek zor.
+Nerede yaşadığımızın artık bir önemi yok.
+Örneğin maaşlar artıyor.
+Karadağ'da emlak büyük bir pazar.
+Şu anda özelleştirme sözleşmesini hazırlanıyor.
+Bir söylenti ortamına giriyoruz.
+Yapı Osmanlı temaları da taşıyor.
+Uluslararası toplum da saldırıları kınadı.
+Bu mümkün olsaydı, bütün süreç daha kısa sürerdi.
+Ne tür araçlar, yapılar ve işbirliğiyle?
+Devlet birliğinden önünde hâlâ pek çok engel var.
+Türkiye başkanlığı Haziran ayında devraldı.
+İndirim herkes için geçerli olmayacak.
+Mekanlardan birinde polis uyuşturucu da buldu.
+Burada önemli pek çok faktör var.
+Müziği eski bir Bosna halk şarkısından geliyor.
+Fakat liberal demokrasiler bile tek parça değil.
+Etkinliği kültür bakanlığı düzenledi.
+Bölgede ve ötesinde çok iyi bir işbirliğimiz var.
+Fakat bu yaz, bunların bir kısmı adadan ayrıldı.
+Skor 3-0 oldu.
+Evlerde bile insanlar maskeler takıyorlar.
+İş örgütleri konuyla ilgili oldukça hevesli.
+En parlak zaferse İsveç'e karşı kazanıldı.
+Kocası ise daha sonra yine Yunanistan'a dönmüş.
+Bulgaristan %73 ile ortalarda bir yerde yer aldı.
+Sergi 28 Şubat'a kadar açık kalacak.
+Ülke belgeyi hazırlamaya başladı bile.
+İddianameden sonra, Gotovina ortadan kayboldu.
+Turnuvaya 41 ülkeden toplam 208 boksör katıldı.
+Yerleşim yerlerinin manzarası harika. 1.
+İnşaat çalışmalarının dört ay sürmesi bekleniyor.
+Aslında, pek çok istatistiki gösterge olumlu.
+Bu malların kaynağını kontrol etme amaçlı tedbirler alacak mısınız?
+Proje yaklaşık 200 bin avroya mal olacak.
+Ordu ve poliste izinler kaldırılacak.
+Konseyin 120 üyesi iki hafta içinde belirlenecek.
+Fakat bu sürecin bir de kabullenme kısmı var.
+Bir diğer eşsiz yerel ürün de koyun peyniri.
+Her iki lider de farklı çalışma tarzlarına sahip.
+Bunlar nerede iş bulacaklar?
+Drescher'in kendisi de rahim kanserini yenmişti.
+Yemek alanı sokak lambalarıyla aydınlatıldı.
+Mali bilgi verilmedi.
+Bir amacımız yok.
+Etkinlik 4 Eylül'de sona eriyor.
+Ancak diğer analistler durumdan daha umutlu.
+Birlikte yine harika vakit geçirdik.
+Yoksa sadece bir mutlak iyimser miyim?
+Muhabbet etmek için yanımıza geliyorlar.
+Özetle Makedonya'yı başarılı bir yıl bekliyor.
+Mara ile çalışıyor.
+Sofralarıysa çok lezzetli yemeklerle dolu.
+Gül'ün bu gelişme üzerine gitmesi bekleniyor.
+Fakat projenin savunucuları isyan ediyorlar.
+Bu da tehlikeli olabilir.
+Krizin etkileri döviz arzında da görülüyor.
+Çeşitli börekler de sofrada hazır bulunur.
+Kosova'da altı hafta önce nüfus sayımı yapıldı.
+Herkes bunun iyi bir fikir olduğunu düşünmüyor.
+Proje yaklaşık 800 milyon euroya mal olacak.
+Kaybedecek hiçbir şeyim yok.
+Konser tarihi 15 Aralık'ta belirlenecek.
+Yapabileceklerine inanıyorum.
+Kosovalı liderleri yoğun bir süreç bekliyor.
+Bugüne kadar bir albüm kaydetti.
+Denetçiler kişisel banka hesaplarını açabilecek.
+Boskovski bağımsız aday olarak yarışıyor.
+Daha sonra bu rakamın da çok üzerine çıkıldı.
+Eğitime elbette daha fazla yatırım yapılmalı.
+Kendimizi bu sanat türüne adamamızı sağlayan şey ne?
+İki tane vardı.
+Blöf yapmıyoruz.
+Uzmanlar sistemin değişmesi gerektiği görüşünde.
+Benim için de aynısı geçerliydi.
+Yarışmayı Çinli bir öğrenci kazandı.
+Rusya'nın bu adaylığa karşı çıktığı bildiriliyor.
+Araç çarpışmanın etkisiyle dümdüz olmuştu.
+Kanal bu talebi reddetmiş.
+Gönüllüler aynı zamanda islamci misyonerlerdi.
+Turnuvayı en az 80 ülke canlı olarak yayınlıyor.
+Ankara ziyaretin devamını bekliyor.
+Ancak bazı uzmanlar sorular soruyor.
+Bu vatandaşlar vizeleri için para ödemiyorlar.
+Bize bir Amerikan birliğiymişiz gibi davranıyorlar!
+Bugüne kadar varılan anlaşmaların uygulanabilirliği nedir?
+Ekonomik ya da daha farklı engellemeler olmasını bekliyor musunuz?
+U2 hayranları 63 bin biletin tümünü kapıştılar.
+Sanatçı ilkinde solo çalmıştı.
+Fakat Vahabiler, korku salan tek grup değil.
+Belgrad'ın bu konudaki görüşü ise tamamen farklı.
+İlk sırada, faturalarını ödemeyen müşteriler var.
+Elçi daha sonra Priştine'ye dönecek.
+Adaylık Ocak ayı sonunda sunulacak.
+Esasen ülkede şu anda herşeyin fazlası var.
+Morrisey "Sonunda birileri şarkılarımın sözlerini biliyor!" diye bağırdı.
+Nikoliç'in açlık grevinin etkileri ne oldu?
+Sergide 35 ülkeden 160 fotoğraf yer alıyor.
+Bunlar yatırım fonları sektörüne nasıl yansır?
+Halk tasarıya ateş püskürüyor.
+Ancak giderek huzursuzlaşan halkı buna ikna edebilecekler mi?
+Gücü nasıl tanımlıyorsunuz?
+Ancak madalyona diğer yüzünden bakanlar da var.
+Albtelecom'un özelleştirme süreci uzun sürdü.
+Ordu kente girerse kaçabilirler.
+Kıbrıs Türklerinin çoğunluğu planı onayladı.
+Arnavutluk sıralamaya sokulmadı.
+Yüz binlerce insan tasarruflarını kaybetti.
+Yarışmaya 35 genç sanatçı katıldı.
+Tebrikler!
+Balkanlar'ın yükselen küresel kültüre bağlanma olasılığı nedir?
+Fakat iş arayanların hepsi ikna olmuş değil.
+Japon hükümeti tesise maddi yardımda bulundu.
+Bu itirazlar dışında, hükümet başarısından emin.
+Karadağ bir kültür başkenti mi olacak?
+Kesinlikle harikadır.
+Gasiç ailesi kalmaya karar verenlerden.
+Anlaşma hala onaylanmayı bekliyor.
+Sergi üç hafta süreyle açık kalacak.
+Çok sıfırlı rakamlar kafa karıştırıcı olabiliyor.
+Polis bu olayla ilgili ki şüpheliyi tutukladı.
+Makedonya'da isim meselesi kızışıyor.
+Ayrıca tanıkların kimlikleri de gizli tutulacak.
+Ancak hükümet bunu reddediyor.
+Çok yönlü Kraounakis konserde.
+Aynı rakam 2002 yılında yüzde 9,6 idi.
+Bu, bazı sorunlar yaşanmadığı anlamına gelmez.
+Bunun nedenlerinden birisi siyaset olabilir.
+Roman çocuklar bu durumdan özellikle etkileniyor.
+Kaynakların çoğu hâlâ devlet sektörüne gidiyor.
+Proje üç ila dört yıl sürecek.
+Onun sadece işini yaptığını biliyorlardı.
+Buna kimsenin hakkı yoktur.
+Bunlar ekonomiye çok fazla girmiş durumdalar.
+Günümüzde siyasetçiler hiçbir şey yapmıyor.
+Ancak buna yasal bir engel olabilir.
+Güvenlik tedbirleri.
+Ancak Makedonya'nın yapması gereken işler var.
+Eğitim, sürekli bir çaba ve reform gerektirir.
+Selimaj yaklaşık 30 avro harcıyor.
+Asıl geri ödeme tarihi 2021 idi.
+Yerli halk binayı Vijecnica olarak adlandırıyor.
+Uzun metrajlı bölümünde dokuz film gösterilecek.
+Tadiç tüm erken seçim çağrılarını reddetti.
+Neredeyse 400 kişi aleyhinde dava açıldı.
+Beni dövüyorlar, çünkü bana 'Sen yasal değilsin.
+Projenin değeri 2,77 milyon avro.
+Bu konu üzerinde iyi düşünmemiz gerekir.
+Şampiyona önümüzdeki yıl Zagreb'de yapılacak.
+Ve de gerçekten küçük.
+Louka Katseli ekonomi bakanı olacak.
+Hayvanlar kimsenin iyi niyetine bağlı değil.
+Sonuçların 5 Aralık'ta belli olması bekleniyor.
+İspanya karar konusunda inat ediyor.
+Bu söz konusu yazarın ikinci kitabı.
+Kaldırım ve asfaltlar yenileniyor.
+Dahası, her yaştan insan bisiklete binebilir.
+Maaşımız mı artacak, daha fazla mı iş olacak?
+Kimsenin maaşlardan haber verdiği yok.
+Rapor Kasım ayında sunulacak.
+İkinci turda da bir takım olaylar bildirildi.
+Sertifikalar dairemiz tarafından verilmektedir.
+Bu noktada rekabetçilik konusuna geri dönüyoruz.
+Bu işleri mahkemelere bırakalım.
+Hizmet Mart ayında başlayacak.
+Bu yıl bir 30'uncu yıldönümüne de sahne olacak.
+Beşli 30 gün gözaltında tutuldu.
+Romanya takım halinde de gümüş madalya kazandı.
+Bunu söylemek zor.
+Tasarı yüksek mahkeme tarafından da reddedildi.
+Karadağ geçen yılki 84. sıradan 90'a düştü.
+Üzerimde düz bir gömlek ve kep vardı.
+Moldova ise gözlemci statüsünde.
+Fakat diğer yandan üretilen sütün kalitesi düşük.
+Köyümdeki camiler depoya dönüştürüldü.
+İki aday ikinci turda karşı karşıya gelecek.
+Hepimiz bu doğrultuda çalışabiliriz.
+Birçok blogcu adaylığın olumlu olduğuna inanıyor.
+Ona göre, bu durum seçim sonuçlarını etkileyecek.
+Ancak programın kendi sorunları da yok değil.
+Cumhurbaşkanlığı seçimleri 6 Nisan'da yapılacak.
+Gayet iddialıyız.
+Kosova Şubat ayında bağımsızlık ilan etti.
+Yurtdışında da 1.806 seçmen bulunuyor.
+Dimitrov, isim önerisi getirilmediğini doğruladı.
+Başında olduğunuz kurum da bu tür bir baskı ile karşı karşıya kaldı mı?
+Kentin kalburüstü semti olan Sandton'a gittik.
+Durres turizm sektörü için de önemli.
+Her iki olayda da yaralanan olmadı.
+Ancak mahkeme başkanı bu fikri hoş karşılamadı.
+Daha küçük bir gösteri de Sofya'da düzenlendi.
+Bu tip sorular karşısında üzülen konuklar oluyor mu?
+Herşeyimiz vardı.
+Fakat Belgrad'da herkes durumu böyle görmüyor.
+Washington yardım sözü verdi.
+Siz bu konuda ne düşünüyorsunuz?
+Fakat söz konusu aktarımın kısa dönemde gerçekleşmesi olası bir durum mu acaba?
+Ada üzerinde her iki ülkenin de çıkarı bulunuyor.
+Seçim sonuçlarına gölge düştü.
+Bu, pek çok Balkan ülkesinin yaşadığı br sorun.
+Munter'in görev süresi gelecek yaz sona erecekti.
+Sonra Radonciç'in teklifi geldi.
+Başvuran sayısının 10 bine ulaşması bekleniyor.
+Hırvatistan'ın da bunu izlemesi bekleniyordu.
+Vatandaşın yasağa uyduğu görülüyor.
+Lajiç bu görüşteki tek Sırp değil.
+Kişisel veriler artık daha iyi korunuyor.
+Ancak bundan daha iyisini yapmamız gerekiyor.
+O muhteşem kişilikli Marietta.
+Ohri'de gece hayatı da oldukça canlı.
+Peki anlatılanlar yalnızca bir öyküden mi ibaret?
+Benim kabul edilemez gördüğüm statüko buydu.
+Görüşmeler başarılı oldu ...
+Gelişmeye ve yeni şeyler sunmaya yetmiyor.
+En az ise 55 yaş üstü işçiler etkileniyor.
+Bugüne dek herkes hizmetlerimizden memnun kaldı.
+Cortiç buna katılıyor.
+Bunun Sırbistan açısından anlamı yüzde 10 daha yüksek bir enflasyon mu?
+Sorun uzun vadede turizme tehdit oluşturabilir.
+Bir diğer sorun ise İnternet.
+Ordu 1960'tan bu yana dört hükümet devirdi.
+Bu, papanın 100'ncu dış dini gezisi oldu.
+Ancak bu iş kolay olmayacak.
+Belge 18 Haziran'da sunulacak.
+Bu haftalık bu kadar.
+Biz bir dizi çözümlenmemiş meseleyi devraldık.
+Görüşmede bölgesel meselelere de değinildi.
+Makedonya turnuvayı 11. sırada tamamladı.
+Çeşitli çıkarımlar yapmak mümkün.
+Ancak kişi başına düşen gelir ne yazık ki düşük.
+Fakat Stojarova'nın başka bir önerisi var.
+Buna karşı Yunanistan tam ters yönde ilerliyor.
+Bu üyeler parti kongresinde oy kullanamayacak.
+Fakat daha farklı açıklamalar da mevcut.
+Bu konudaki izlenimleriniz ne yönde?
+Bu kuşak, toplumu ileri taşıyabilecek mi?
+Etkinlik 28 Ekim'de sona erecek.
+Hırvatlar, bu yazın turizm sezonundan endişeli.
+Ancak Gavran bu konuda iyimser.
+Yine de, önümüzde koca bir yıl var.
+Şimdi Budapeşte de konuya müdahale etti.
+Kosova organize suçla mücadelede ne gibi sorunlarla karşılaşıyor?
+Romanya'da mazot, benzinden daha pahalı.
+Ama yapamam.
+Bu biraz etkili oldu, ama sona erdi.
+Proje 2007 başlarında başlayacak.
+Sağnak yağmur altında soğuk bir hava hakimdi.
+Şu andaki asker sayısı ise 13 bin.
+Bu sorun Balkanlar'a özgü de değil.
+Hareketleri ve operasyon çok iyi hesaplanmış.
+Bu terimle kastedilen şey ve Kosova'nın bu kavram içindeki yeri nedir?
+Fakat Geoana kendinden emin görünüyor.
+Kosor henüz bu meydan okumaya yanıt vermiş değil.
+Parça karışık tepkiler aldı.
+Görüşmeler 18 Eylül'de devam edecek.
+Bu yüzden de kimse ateşle oynamamalıdır.
+Emekli aylığımızla ne satın alabiliriz?
+Ancak reform bazı güçlüklere de yol açmadı değil.
+Sırbistan, en iyi atletlerini en iyi antrenman koşullarına nasıl kavuşturacak?
+Nikoliç, cumhurbaşkanının istifasına şaşırmamış.
+İkinci çeyrekte, ülke sekizinci sıradaydı.
+Ancak herkes aynı görüşte değil.
+Sergi 12 Haziran'da kapanıyor.
+Bu tamamen Kosova yönetimine bağlı ...
+Kesinti en çok inşaat sektörünü etkileyecek.
+Bu yılın sonuna kadar ülke ekonomisinin statüsü değiştirilebilir mi?
+Fakat bütün siyasiler bu kadar şanslı değildi.
+Parti seçimlerden sadece yüzde 18 oyla çıktı.
+Avrupa ise gırtlağına kadar borca batmış durumda.
+Bir önceki yönetimde durum böyle değildi.
+İyi günler dilemenin çok güzel bir yoluydu.
+Belgrad zor bir görevle karşı karşıya.
+Sırbistan'da bu hâlâ yapılamıyor.
+Romen hükümeti de projeye katkıda bulunuyor.
+Bunu başarmak için de yeterli eğitim gerekiyor.
+Türkiye geçen yıl turizmde rekorlar kırdı.
+Bunu kim ister?
+İhtilaf, bugüne dek 40 binden fazla can aldı.
+Mahkeme ise bu iddiaları reddetti.
+Kız çocukları oğlanlardan daha romantikler.
+Sivil örgütler de şaşırmış durumda.
+Toprak kaymaları da oldukça sık yaşanıyor.
+Gerekli yasalar da mevcut değil.
+Yargı reformu özellikle endişe yaratan bir konu.
+Kosova'daki özel üniversiteler eğitimdeki boşluğu dolduruyor mu?
+Dizi, 10 Aralık'ta sona erdi.
+Yaklaşık 3 bin kişi işinden olabilir.
+Ancak hareket hiç de eleştirilmiyor değil.
+Hırvat medyası da bize destek ve yer veriyor.
+Roman olmadığımı söylesem bir şey farkeder mi?
+Görev için 19 aday yarıştı.
+Edi Rama da aynı fikirde.
+Bunun başarıp başaramamak ise onlara kalmış.
+Konsere Makedonya'dan binlerce kişi katıldı.
+Jüri ön eleme sonrasında 24 şarkıcı seçecek.
+Evler kiralığa çıkarılıyor.
+Fehmiu 74 yaşındaydı.
+BH 101. oldu.
+Bu yıl ise ayrılan bu rakam yeterli olmayabilir.
+Artık hapis cezasını biliyor.
+Proje dört yıl sürecek.
+Bunda başarı sağlandı gibi de görünüyor.
+Kaderimizi elimize almalıyız.
+Ancak geçmişe değil geleceğe bakma zamanı.
+Polis olayı bir suikast girişimi olarak niteledi.
+Benim kuşağım kayıp bir kuşak oldu.
+Adi suçlarda bunun mümkün olduğunu duydum.
+Adamlardan biri helikopterin dışına fırlamıştı.
+Tüketici kredisi de bu konuda rol oynadı.
+Ekipmanın Mayıs ayında ulaşması bekleniyor.
+Kosova başkentinswki yolcu sayısı arttı.
+Yine de hakem kararları bir felaketti.
+Sibiu'nun kendine has bir ortaçağ havası var.
+Kostümler, kuklalar ve sahneleri oluştururken ne gibi özel güçlüklerle karşılaşıyorsunuz?
+Belgrad ve Lahey arasındaki işbirliği konusunda ne düşünüyorsunuz?
+Madenciler de talep düşüşü yaşıyorlar.
+Peki Sosyalistlerin en son önerisi çıkmaza son verebilecek mi?
+Bu işbirliğine Gotovina'nın iadesi de dahil.
+İnsanlar daha iyi yaşam fırsatları arıyorlar.
+Bu devrimci mesajlara benziyor.
+Her ikisi de Sofya'daki cinayetlere karışmıştı.
+Açılış töreni Eylül ayı sonlarında gerçekleşti.
+Fakat bu, masada hâlâ duran bir bahis.
+Atina'da dilenen bir kadın.
+Bugünlerde, Sighisoara popüler bir tatil beldesi.
+Her 3 bin Arnavut'tan yalnızca biri suç işlemiş.
+AB fonlarının büyük kısmını tarım sektörü alacak.
+Merkezin toplam bütçesi ise 1.25 milyon avro.
+Türkiye bölgeye yardım gönderme sözü verdi.
+Haydar Pnişi İsviçre'de yaşıyor ve çalışıyor.
+Karadağ parlamentosu da büyük bir destek verdi.
+Belge 1 Ocak 2008'de yürürlüğe girecek.
+Birçok yorumcu da aynı görüşü dile getirdi.
+Bu yöndeki haberler asılsızdır.
+Proje, açıklanmayan nedenlerden ötürü durduruldu.
+Örgüt çok sayıda şiddet olayı da bildirdi.
+Dink'in ölümünün etkisi ne oldu?
+Günlük yevmiye ise 25-30 avro civarında.
+Filmin bir kuruş bile kazanmadığını duydum.
+Bu arada meşru sektörler de zarara uğruyor.
+Tablolarda ülke ve Arnavut halkı resmediliyor.
+Kimse yalnız yaşamaz.
+Kosova'nın Balkanlardaki siyaset hedefi nedir?
+Rinor bu argümana yanıt veriyor.
+Bu da kısa ve orta vadeli bir süreç alacaktır.
+Hepimiz bunun bir bahane olmadığını düşünüyoruz.
+Oysa gerçekte durum bundan daha karmaşık.
+Bu da, siyasi açmazın bir sonucu.
+Etkinliğe dünyadan 30'dan fazla sanatçı katıldı.
+Roddick maçı 6-1 ve 6-4'lük setlerle kazandı.
+Turnuva 11 Ekim'de sona eriyor.
+Kosova hükümetinin tepkisi net oldu.
+Anketlerden bir sonuç çıkmadı.
+Merwin'e verildi.
+Terim sıralamada yedinci oldu.
+En yakın arkadaşlarım Arnavutluk'ta.
+Birlikte iki çocukları olmuş.
+Sizce barışın sağlanması mümkün mü?
+Toplam 14 gösteri planlanıyor.
+Onlara güvenmememiz gerektiğini gösterdiler.
+Eski kent Dubrovniğin etrafındaki duvar.
+Bu, her ikimiz için de tuhaf bir deneyim oldu.
+Bundan iki hafta sonra da vefat etti.
+Bu anlattıklarınızın ne kadarı gerçeklere dayanıyor?
+Babanızın kariyerinin bunda bir etkisi oldu mu?
+Peki çözüm ne?
+Şimdiyse bu rakam %40'a düştü.
+Aleksandra 15 yaşında ve çok eğlenceli biri.
+Burada olay, hastanın etrafında gelişiyor.
+Konsey çok sayıda somut tavsiyede de bulundu.
+Tek bir grev bile olmadı.
+Erdoğan karara şüpheci yaklaştı.
+O günden beri çok şey değişti.
+İki ülke bloğa 26 ve 27. üyeler olarak katıldı.
+Bu kesime yapılan indirim %99'u bulabilecek.
+Parlamento bu yasal çarkı destekliyor.
+İki güvenlik kontrolünden geçtik.
+Etkinliğe dokuz ülkeden 49 ressam katıldı.
+Yeni tutuklamalar gelebilir.
+Projeler altı bilimsel alanı kapsıyorlar.
+Şimdi ben muayene olmaya gitsem ve doktor beni kabul etmese ne olacak?
+Ankara tedbiri elden bırakmıyor.
+Tadiç sporcuya bir tebrik notu gönderdi.
+Bu yatırımlarla yeni iş sahaları da doğuyor.
+Orada bizi hiç iyi bir şey beklemiyor.
+Bu kararın nasıl bir etki yaratmasını bekliyorsunuz?
+Bu zıt güçleri dengelemekse hiç de kolaylaşmıyor.
+Hakemler bir dolu hata, acemi hataları yaptılar.
+Sanatçı 26 bin avro tazminat aldı.
+Siyasi krizin sona ermesine daha çok var.
+SC hükümeti üç günlük yas ilan etti.
+Sahneye çıktığınızda hâlâ aynı enerji ve coşkuyu hissediyor musunuz?
+Bulgaristan'ın en büyük sinema etkinliği olan 12.
+Bu tanıklar sanığı fail olarak teşhis etmedi.
+Sivil kesimde gelişmeler devam ediyor.
+Ancak bu sporcular Sırbistan adına yarışacaklar.
+Bölge zamanla değişti.
+Bunlar içinde en çok göz çarpanı ise flija .
+Ancak süreçte daha fazla ilerleme kaydedilmedi.
+Dört milletvekili oylamaya katılmadı.
+Fakat hikaye bununla bitmiyor.
+Gerçekler olmadan barış olmaz.
+Sizce bu durum bir sorun olarak adlandırılabilir mi?
+Kosova ilk film festivalini başlattı.
+Ancak balıkçılar bu rakamı gerçekçi bulmuyor.
+Ancak bu olmadı.
+İleriye gideceğimize geriye gidiyoruz.
+Bosna-Hersek daha da bölünecek mi?
+Kalanlar ise farklı yollar izliyor.
+Ancak Karamanlis bu olasılığı dışladı.
+Tartışmanın merkezinde hukuk sorunu yer alıyor.
+Kampanya süresi de 30 günden 20 güne indirildi.
+Kosova'da çocuklara yönelik televizyon programları nasıl geliştirilebilir?
+Sizin de ilerde birgün teknik direktör olma planlarınız var mı?
+Bunun için yaratıcı bir çözüm bulmak gerekti.
+Ancak ilk sonuçlar telafi edildi.
+Olimpiyatlara hazır olmadığımı söyleyemem.
+Bunda mesafelerin yakın olmasının da payı büyük.
+Sizce bu yükümlülüğün yerine getirilme tarzı tatmin edici düzeyde mi?
+Ancak bütçe sorunları engel teşkil edebilir.
+Panelistler, "Geriye yapılacak ne kaldı?" sorusunu sordular.
+Söz konusu taslağı inceleme fırsatı bulabildiniz mi?
+Projenin tahmini maliyeti 4,6 milyar avro.
+Proje Haziran ayına kadar tamamlanacak.
+Fünikülerin yatay uzunluğu 4.182 metre.
+Çoğu zaten gülümsüyordu.
+Pek çok dükkan sahibi için işler berbat.
+Türkiye kukla festivaline ev sahipliği yapıyor.
+Bu konuyu nasıl yorumluyorsunuz?
+Sevgiyi hisset.
+Schengen'e geçiş hazırlıkları sürüyor.
+Bunlar hala da çözüm bekliyor.
+Fuara toplam 175 yayınevi katıldı.
+Müzakereler bir yıl önce başlatıldı.
+Belgrad'ın tepkisi öncesinden daha da güçlü oldu.
+Mevki iki yıldır boş bulunuyor.
+Bu düşünceler bugün bile tepki alıyor.
+Her gün yeni binalar ve bulvarlar yapılıyor.
+SC parayı üç ila dört ay içinde almayı umuyor.
+Romanya Nokia aksesuar fabrikasına kavuştu.
+Kıbrıs Rum takımı bu yıl turnuvaya katılmayacak.
+Bütün vakalarda ölüm nedeni boğulma.
+Ortaya çıkan bu trendi herkes hoş karşılamıyor.
+Kararın Ekim ayı başlarında verilmesi bekleniyor.
+Tartışmalara gelen tepkiler karışık oldu.
+Makedonya'nın puanı değişmedi.
+Pensioners also lambasted the measures.
+Burada bir lokantamiz vardı.
+Atılan 500 oyla, kazanan üç eseri sunuyoruz.
+Sanık, Mladiç'i medyadan tanıdığını da doğruladı.
+Romen analistler ise satır aralarını okuyorlar.
+Kariyerinizin bu alanı için ne gibi planlarınız var?
+Çatışmada bir asker de yaralandı.
+Bu yüzden moralleri bozuldu.
+Öte yandan Washington da sahneye çıktı.
+Değişiklik her yerde göze çarpıyor.
+Sunnyside Park dışarıdan oldukça iyi görünüyor.
+Dava boyunca ağırbaşlı bir biçimde duruşmalara katılabilecek mi?
+Bu sorun diğer bölge ülkelerinde de aynı.
+Nokia Cluj'da ticari bir şirket de kuracak.
+Ancak sorunlar devam ediyor.
+Yine de iyimser olmak için neden yok değil.
+Bunları başlatıp sürdürmek zor olacak.
+Aynı durum ihtiyacı olanlar için de geçerli.
+Türkiye Libya'yı şiddetten kaçınmaya çağırıyor.
+Öte yandan Türkiye oldukça iyi gidiyor.
+Hükümet o tarihte talebini kabul etmişti.
+Uka'nın ilk kurbanı otobüsün dışında öldürüldü.
+Diğer bir seçenek de bölgesel bir akademi kurmak.
+Benzer bir çağrı Ankara'dan da geldi.
+Askerler en fazla şiddeti sınırlayabilirler.
+Bu ailenin uymadığı bazı gelenekler de var.
+Üç yıl önce, hayatında ilk defa bir uçağa bindi.
+Sizce bu boykotlar bir sonuç veriyor mu?
+Mevcut olumlu eğilimler, etkin bir sermaye oluşum süreci ile desteklenmeksizin sürdürülebilir mi?
+Görüşmede ekonomik ilişkiler de ele alındı.
+Bu kişilerin çoğu, yaşlılar ve çocuklardı.
+Kısmi bir çözüm ayakta kalamaz.
+Fakat hikayenin hepsi bu değil.
+İşten çıkarma sürecini de kolaylaştırdık.
+Ancak satış pürüzsüz gerçekleşmedi.
+Kosova'yı vizesiz bir rejime yakınlaştırmalıyız.
+Çok kötüydü.
+Balkanlar yaşanan bu felakete anında yanıt verdi.
+Romanya, 5 milyar avroluk ilk dilimi hemen aldı.
+Şikayet 2006 yılında sunulmuştu.
+Dürüst olmak gerekirse, biz de emin değiliz.
+Peki ama, neden?
+Vetevendosje kararı imzalamayı reddetti.
+Kardeşi Muhamed liseye gidiyordu.
+Milletvekili dokunulmazlığı, adaletten muaf olmak mı?
+Portekiz Salı günü bunu yapan 48. ülke oldu.
+Kimse öfkelenmiyor mu?
+Bize arkadan ateş de ettiler.
+Hata yapma potansiyelini tahmin edebilirsiniz!
+Onları savaş suçu davalarına nasıl hazırlıyorsunuz?
+Cuma günkü oylamaya karışık tepkiler geldi.
+Bu hafta için yeni grevler planlanıyor.
+Lajiç'in eşi de iş ihtiyacını vurguluyor.
+Durum oldukça vahim.
+Alıcının adı Kasım ayında duyurulacak.
+Fonlar İller Bankası aracılığıyla dağıtılacak.
+Ziyaretin amacı neydi?
+Bosna Hersek'te pek çok dini mekan bulunuyor.
+Bu örgüt Makedonya'yı istikrarsızlığa sürükleyebilir mi?
+Ülkenin şu anki nüfusu 72 milyon.
+Peki bu jeolojik hareketliliğin sebebi ne?
+Açıklamaya rağmen, kavganın durulduğu pek yok.
+Sizin buna tepkiniz ne olacak?
+Ancak uluslararası toplum somut adımlar bekliyor.
+Mayıs 2005'te başkanlığı Hırvatistan devralacak.
+Gösterimler ücretsiz olacak.
+Bu, hala uzak bir umut olarak görünüyor.
+Teşkilata yığınla başvuru var.
+Etkinlik 7 Haziran'da sona erecek.
+İhaleyi verme süreci aylardır sürüncemedeydi.
+Çekimlere Zagreb'de devam edilecek.
+Davaların çoğunda iddianameler hala bekliyor.
+Gençliğin uzatılması fenomeni ise hala yaşıyor.
+Kimileri ise koşulları kabullenmekle yetiniyor.
+Bu rakamlar geçen yılki rakamların iki katı.
+Benedikt ile yaptığı görüşme sonrasında geldi.
+Şebeke bağlantılarının %20'ye yakını kaçak.
+Daha da yüksek hedeflere ulaşmayı düşünmeyeceğim.
+Halk bize destek verdi ve bize güvenebilirler.
+Bu da sonunda mali krize yol açabilir.
+Eskiden insanlar daha neşeliydi.
+Priştine Belgrad'ın savlarını kabul etmedi.
+Acaba buna yol açan etken Kosova'daki durum olabilir mi?
+Görev bu yılın bitimine kadar sürecek.
+Boskovski'nin savunma ekibi henüz teyid edilmedi.
+Rugova geçen Ekim ayında tekrar seçildi.
+Bu, Hırvatistan'da bir ilk olacak.
+Pek çoğu tekbir getirdi.
+Ancak Nikoliç devam etmekte kararlı.
+Martins, olumlu bir noktaya da işaret etti.
+Ancak projeye karşı olanlar da var.
+Petrol sektöründe başka dış yatırımcılar da var.
+Bakanın istifa kararı pek çok kişiyi şaşırttı.
+Fakat Türkiye'de siyasi koşullar değişiyor.
+O yüzden de bazen keşke o olabilseydim diyorum.
+Bu konuda gelinen aşama nedir?
+Jolie kalabalığı Boşnakça selamladı.
+Bölümün sinyalizasyonu tekrar yapıldı.
+Türkiye, kadın hakları konusunda zor durumda.
+Olayla ilgili bir tutuklama yapılmadı.
+Toplamda %68,6'nız erkek, %31,4'ünüz ise kadın.
+Boskovski tüm suçlamaları reddetti.
+AB fonlarına erişim kolay bir iş değil.
+Kasedin etkisi büyük oldu.
+Parçalardan birindeyse bir şans parası bulunuyor.
+Mevcut enflasyon trendi cesaret verici.
+İşin asıl zor kısmı şimdi başlıyor.
+Sırp hükümeti 15 Mayıs'tan beri görevde.
+Sırbistan'daki Karadağlılar buna katılıyorlar.
+Bu kitap bir kurguya dayanıyor.
+Bu bakımdan Kosova ile kıyaslanamaz.
+Etkinlikte dokuz ülkeden 30 ekip biraraya geldi.
+Port Elizabeth'e gittik.
+Xhema ise Mabetex'in yönetim kurulu uyesi.
+Geçen yıl ülkeye yaklaşık 15 milyon turist geldi.
+Şarkı bütün Yunan halkını büyülemedi.
+Çıkartma takasında kadınlar da yer alıyor.
+Emir Kusturica'nın filmlerini arkamıza aldık.
+Sonuçta da kurbanların çoğu Türkler oldu.
+Hükümet bu konuda adımlar atıyor.
+Bu tamamen doğru değil.
+Bundan sonra ise halk oylamasıyla seçilecekler.
+O zamandan beri ara sıra seyyar satıcılık yapmış.
+Ancak bu durum son yıllarda değişiyor.
+Mustafaj dışişleri bakanlığını yürütecek.
+Priştineli bir esnaf dükkan açmaya hazırlanıyor.
+Burası azgın su slalom olanaklarıyla tanınıyor.
+Ancak bu çok zor bir görev.
+Ovcara davası 9 Mart 2004'te başladı.
+Roman liderler karışıklık yüzünden ayaklandı.
+Tivat ise bu rotanın tam ortasında kalıyor.
+Sırbistan ve Karadağ'ın puanları değişmedi.
+Organ kaçakçılığı sorunu sizin gündeminizde de yer alacak mı?
+Fakat bu kurumda görev savcılar bulmak zor.
+Bana göre bu dikkate değer bir başarıdır.
+Ancak faillerin kimlikleri belirlenemedi.
+Kon'un kendisi de zaferine şaşırdı.
+Savaş, yaklaşık 20 bin cana mal oldu.
+Önemli ekonomik faktörler de söz konusu.
+Saldırının nedeni ise hâlâ bilinmiyor.
+Bence bu hiç de azımsanacak bir şey değil.
+Olaylarda üç kişi yaralandı.
+Dört gün süren festivale binlerce kişi katıldı.
+Antrenör yoktur, bir spora bile benzemez.
+Polancec'in mesleki geleceği şu anda belirsiz.
+Bunların şu anki fiyatları 7,70 ve 22,20 avro.
+Elbette ki her duyduğunuza inanamazsınız.
+Onaylanan adaylardan 32'si Sırp azınlık mensubu.
+Bu konuda neler söyleyeceksiniz?
+Bu karar da çalışmaları hızlandırdı.
+Fakat mevcut realiteyi değiştirebilecekler mi?
+Belediye sınırları dahilinde 16 köy var.
+Üyelik ufukta göründü, ancakHırvat halkı buna hazır mı?
+Ancak bazıları hâlâ iyimserliğini koruyor.
+Müfredatta değişiklik yapılmamasından da mutlu.
+Etkinlik 25 Ekim'e kadar sürecek.
+Listenin sonunda yer alan ülke Angola oldu.
+Çok gerçekçi.
+Ne onlara ne de bize yetecektir.
+Enflasyon yüzde 14.1'e indi.
+Bunların 30'u hayatını kaybetti.
+Görünüm durağan.
+İnşaat 2009 yılında başlayacak.
+Bilgim yoktu.
+Umarız boğa olmayız.
+Umarım Hırvat siyaseti bu doğrultuda devam eder.
+İki lider Kıbrıs konusunu da görüştü.
+Halkın büyük bölümü de aynı görüşte.
+İki madende 2 bin 500'den fazla kişi çalışıyor.
+Bundan sonra bir şeylerin değişmesi gerekecek.
+Parlamento paketi Mayıs ayı ortasında oylayacak.
+Arnavutluk'un üyelik daveti alması ülkede yankı uyandırdı mı?
+Festivalde on adet film gösterilecek.
+Blogculardan da bir çok yorum geldi.
+Vesiç, birkaç örnek daha veriyor.
+Ülke bu sayıyı artırmaya çalışıyor.
+Cuma günü oylama yapılması bekleniyor.
+Bu ikisi yarı finallerde yanlışlıkla elenmişti.
+Limana gitmek bile eğlenceli.
+Tüm bunlar çok olumlu gelişmeler.
+Balkanlar'da hukuk devleti ilkesi nihayet pekişiyor mu?
+Temyiz süreci şu anda devam ediyor.
+Protestoculara göre evet.
+Uygulanmaları konusunda da sıkıntılar var.
+Üzerini örtün ve kabarmaya bırakın.
+Kendimi kötü hissediyorum, ama ne yapabilirsiniz ki?
+Çok uzun bir zamandır.
+Bu oldukça zor bir iş.
+Kararı belirleyen en önemli etken ise fiyat.
+Etkinliğin ileriye dönük bir yönü de var.
+Tesiste yaklaşık 600 kişi çalışacak.
+Paşa için bir sonraki durak Oslo.
+Resimler Mart ayı sonuna kadar sergide kalacak.
+Sergi 28 Şubat'a kadar devam edecek.
+Konsere 10 binden fazla insan katıldı.
+Açıkça görülüyor ki halkın bilgiye ihtiyacı var.
+Fakat hükümeti hakir görenler de var.
+Görünüm dengeli olarak belirtildi.
+Artık çok kaliteli gazeteciler var.
+Görüşmelere yaklaşık 130 uzman katılacak.
+Teklif sunma süresi Pazartesi günü sona eriyor.
+Bu yüzden hep birlikte çalışmamız gerekiyor.
+Uyulmadığı takdirde ülke cezalandırılacak.
+Napolyon 1808'de buradaymış.
+Yeni anayasanın onaylamasına çalışılacak.
+Peki bu kayıtsızlığın sebebi ne?
+Bugüne kadar 250 milyon ton cevher kullanıldı.
+Bu oldukça pis bir iş, ama neticede iş.
+Bu sorunu çözmenin en iyi yolu nedir?
+Bir dönüm noktası oldu.
+Günümüzde avukat olmak zor.
+Ayrı bir kapta şekerli suyu kaynatın.
+Bu Aralık 2010'da oldu.
+Peki Amerikan halkının filme tepkisi nasıldı?
+Bu ülkede her şey her geçen gün pahalılanıyor.
+Yasa henüz gözden geçirilmedi.
+Ekim itibarıyla gerçekleştirecekleriniz arasından iki-üç madde sayabilir misiniz?
+Sevgili gözlerini kapatan ve seni gözyaşlarıma kör eden ne?
+Fuara yaklaşık on beş Sırp şirketi katıldı.
+Oyunla ilgili son gelişmeler nedir?
+Parti konseydeki 35 sandalyenin 17'sini aldı.
+Kamuoyu Denktaş'a karşı.
+Fona başvuru için son tarih 30 Mart 2003.
+Resmi adım Haziran ayı sonunda atılacak.
+DP oyların yüzde 23'ünü almıştı.
+Halka her şeyi açıklayacağız.
+Diğer uzmanlar da benzer kaygılar taşıyor.
+Muhalefet de yeni vergi konusunda ayağa kalktı.
+Çok güzel.
+Projenin toplam maliyeti 31,9 milyon avro.
+Belgede yargıya da değinildi.
+Drago çok iyi Arnavutça konuşuyor.
+Kalkınma yok bölgede.
+Hükümet sürece çok önem verdi.
+Yaşamım zordu, çok gezdim, çok öğrendim.
+Son bir buçuk iki yıldır açıkça yalan söyledik.
+Ama yapamaz.
+Biz iki tarafı da desteklemiyoruz.
+İlki ise Polonya'daydı.
+Etkinliğin ana konusu kategori teorisiydi.
+Gençler arasındaki işsizlik oranı şu anda %27,9.
+Üsküp karar tepki göstemekte gecikmedi.
+Elbette bazı kaynaklar boşa harcandı.
+Bu tarihsel doku insanları sürekli kente çekiyor.
+Sanatta herşey kendi yerine düşer.
+Aday listeleriyle ilgili sorun kalmadı.
+Gerisiyse satışa çıkarılacak.
+Bir diğer 16 bin 662 kişi ise halen kayıp.
+Ama her zaman değil.
+Sergi 1 Nisan'a kadar açık kalacak.
+Etkinliğe yaklaşık 300 bilim insanı katıldı.
+Sergide 17 heykel ve 51 eser yer alıyor.
+İşleri halka hizmet etmek.
+Dezenflasyon sürüyor.
+Konferans 8 Nisan Çarşamba günü sona erdi.
+Pag'ı genelde onbinlerce turist ziyaret ediyor.
+Pek çok alanda da değişiklik yapılması gerekiyor.
+Bunlardan biri de yolsuzlukla mücadele.
+Sergide 54 ülkeden 6000 fotoğraf yer alıyor.
+Kazanan, önümüzdeki yılın başında açıklanacak.
+Katılım oranı %70 olarak gerçekleşti.
+Her ikisi de mahkemede ifade verdi.
+Türk liderleri saldırıyı kınadılar.
+İskelet iyi korunmuş durumda.
+Bu yorumunuzla neyi kastettiniz?
+Biz umudumuzu bu mücadeleden almaktayız.
+Projeye 58 milyon avro değer biçiliyor.
+Ancak bu kural pratikte uygulanmıyor.
+Sırada diğer kamu işletmeleri var.
+Yıl sonuna kadar Kıbrıs'ta çözüm mümkün mü?
+Medya da ikiye bölünmüş durumda.
+Her iki taraf da önceden öneriyi reddetmişti.
+Bunun olmasını istemiyoruz.
+Muhtemelen hayır.
+Ceku da benzer bir tonda konuştu.
+Annelerin gözyaşlarının durmasını istiyor.
+Etkinliğe bölgeden tiyatro grupları katılıyor.
+Ancak gerçek oran kuskusuz daha yüksek.
+Bu da büyük bir masraf ve zaman kaybı.
+Romanya küresel ekonomik krizden ağır etkilendi.
+Tepkiler beklenilenden farklı olmadı.
+Muhalefet partileri de şikayetteler.
+Bunlardan ilki, zorunlu orta öğretim getirilmesi.
+Grupta Arnavutluk takımı beşinci sırayı aldı. 2.
+Kesin karar zirvede alınacak.
+Bulgar hükümeti projede %51 hisseye sahip.
+Bazı analistler iyimser görüşte.
+Tutumların Avrupalı bir unsura rastlamadım.
+Makedonya'nın da bu konuda umudu büyük.
+Bu deneyimlerinizle ilgili neler söyleyeceksiniz?
+Ancak bayrak Pekin'de biraz karışıklığa yol açtı.
+Refah dönemi hemen yarım başlamayacak.
+Bu bombaların %20 kadarı patlamadı.
+Mecliste en fazla 736 sandalye bulunabilecek.
+Beara'nın tutuklanması ortama taze kan getirdi.
+Yoksa tek gerçekçi ihtimal, huzursuz bir şekilde birarada yaşamak mı?
+Erdoğan eleştirileri reddetti.
+Ayrıca festival nerelerde yapılacak?
+Çalışmalarınızın sonuçlarını tatmin edici buluyor musunuz?
+Steiner, Kosova'ya 17 ay önce geldi.
+Anlaşmanın değeri 64 milyon avro.
+Ayrıca %4,54'ü de kadınlardan meydana geliyor.
+Artık İtalya da herkesin hedefi konumunda.
+Turnuvada dünyadan 57 oyuncu biraraya gelecek..
+Bunlar savaş suçluları.
+Kafede Mripa'nın telefonu çalıyor.
+Ayin, 15 dile tercüme edildi.
+Çatışmalar ülkeye 36.500 cana mal olmuştu.
+Bulgar yetkililer kararları hemen kınadılar.
+Halkın tepkisi genelde olumlu oldu.
+Sonunda ise bir çözüm yolu bulunmuş.
+Muhalif basın ve muhalefet partileri var.
+Bandiç oyların %48,54'ünü topladı.
+Durum her kış kötüye gidiyor.
+Hedef büyük, engeller de öyle.
+Bütçe 500 milyon avro olarak belirlendi.
+Abonelere üç farklı ödeme planı sunuluyor.
+Okul en başından beri zararına çalışıyor.
+Buna, bir dolu avantaj ve ikramiye de ekleniyor.
+Şirket haftada dört sefer yapacak.
+Kanyon ve etrafındaki dağlar çok güzel.
+Fakat ülke bu pazar konumundan sonuna kadar yararlanabiliyor mu?
+Zarar 134 milyon avro kadar tahmin ediliyor.
+Bojaxhi'ye göre çeşitli yöntemler izlenmeli.
+Ancak yerel medyanın durumu çok ciddi.
+Şimdilik tek somut kararı dört küçük örgüt aldı.
+Onlar da beş alp disiplininde yarışacaklar.
+Ancak yine de işler kolay olmamış.
+Daha ayrıntılı bilgi verebilir misiniz?
+Romanya, 61,5 puanla 68. sırada yer alıyor.
+AB, bu tarihî durumla baş edebilir mi?
+Sırp sineması sunar ...
+Festival 22 Eylül'e kadar devam edecek.
+Evlerini bile kaybedebiliyorlar.
+Her şey çok kaotik.
+Zagreb bunu değiştirmek istiyor.
+Takım nihayet havasını bulmuş gibi görünüyordu.
+Yeni parlamento 26 Temmuz'da kurulacak.
+Peki bu yeni gibi görünen uzlaşma nereden geliyor?
+Dürüst olmak gerekirse, bu acı veriyor.
+Diğerleri daha şüpheci bir tavır takınıyorlar.
+Teklifler 14 Aralık'a kadar kabul edilecek.
+Hata payı %3 ila %5'tir.
+Un, su ve tuzu karıştırın.
+SC hükümeti büyük zorluklar çekilmeden kuruldu.
+Bu ay yeni ve kapsamlı kazılar başlatılacak.
+Böyle bir durumda çok fazla seçeneğiniz olmuyor.
+Bu kadar basit.
+Görüşülen kişilerin hepsi öğrenciydi.
+Sanık hakkındaki suçlamaları reddetti.
+Fakat bu başarı Tasovac'ı memnun etmeye yetmiyor.
+Üçüncü şüpheli ise henüz yakalanamadı.
+Teklif süresi 26 Şubat'ta sona erdi.
+Grupta üçüncü sırada. Sırbistan 7.
+Su sistemi üç aşamada tamamlanacak.
+Yazar, "Bir hükümet istediğimizden emin miyiz?" diye soruyor.
+Ülke bu sektörde köklü bir geleneğe sahip.
+Bunun da gelecek ay gerçekleşmesi bekleniyor.
+Gelecekteki gelişmeleri Arnavut dış politikasının bakış açısından nasıl görüyorsunuz?
+Eylül ayı sonunda söz konusu oran yüzde 62'ydi.
+Ahtisaari bu görüşte değil.
+Ancak, bu olumlu durum kısa sürede tersine dondu.
+Üçte ikisini kadınlar oluşturuyor.
+Projenin değeri 223 milyon euro.
+Bir çok şey yapılabilir.
+Antikitera Mekanizmasının bir kopyası.
+Ne ki, üyelik imkansız bir hayal değil.
+Korsancılık, bir yerde ucuza eğlence demek.
+Ancak herkes aynı fikirde değil.
+Belgrad bu son hayal kırıklığını hafife alıyor.
+Asıl soru bu.
+Bu yıl farklı.
+İlkinde gereken üçte ikilik çoğunluk sağlanamadı.
+Ledra Caddesi'ndeki barikat 40 yıldır duruyordu.
+Fıçı biranın fiyatı iki veya üç avro.
+Reformlar Türkiye'deki siyasi bölünmeden sağ kurtulabilir mi?
+Onlar arasında annesi ve babası da vardı.
+Siyasette temiz insanlara ihtiyacımız var.
+Avusturya, Rodos'tan sonra ikinci geldi.
+Ancak bu yıl sürprizler olabilir.
+İyi vakit geçirdik.
+Ucuz diş bakımı bu konuda yalnız değil.
+Diğerlerineyse sadece şifa umut etmek kalıyor.
+İlk önce kriterleri karşılaması gerekiyor.
+Küçük kentler oldukça başarılılar.
+Kayakçı süper dev slalomda da gümüş madalya aldı.
+Bu iddianın asılsız olduğu daha sonra kanıtlandı.
+Gruevski boykottan endişe duymadığını söyledi.
+Bu dönüş öyle topluca değil, ev ev oldu.
+Opa!
+Bugüne kadar gelen tepkiler karışık oldu.
+Fakat bu sorun uzun zamandır devam ediyor.
+Stamatis Kraounakis.
+Gündemdeki bir diğer konu da Kosova idi.
+Yaralanma veya tutuklanma bildirilmedi.
+Anlaşmanın şartları açıklanmadı.
+Yine de Avrupa kamuoyu ikna olmuşa benzemiyor.
+Arnavutluk'ta 3,6 milyon kişi yaşıyor.
+Brady tahvilleri de bu dönemden kalma bir miras.
+Gıda fiyatları yüksek.
+Tirlea 23.24'lük bir derece yaptı.
+Bu ortamdan faydalanılmalı.
+Balkanlar'da düşük yoğunluklu fakat dolaylı olarak çok büyük sonuçlar doğuran çatışmalar mı yaşandı?
+Proje Mart ayında başlatıldı.
+Paylaşma ve yoksullara yardım etme zamanıdır.
+Fakat bu söylendiği kadar basit birşey değil.
+Yemekler, bayramın dini önemini yansıtıyor.
+İşte fark burda.
+Festivalde 35 ülkeden 120 film gösterilecek.
+Olayla ilgili iki kişi daha suçlandı.
+Azınlık temsilcileri değişiklik talep ediyor.
+Programdan on beş belediye yararlanacak.
+Son olarak da Yunanistan bir dünya markasıdır.
+Başbakan, bu girişimi bizzat destekliyor.
+Kaset şu anda savcılığa teslim edilmiş durumda.
+Karşılaşma 93-70 sona erdi.
+Bu arada boykot edenler yalnızca Sırplar değildi.
+Dersler İngilizce işlenecek.
+Arnavutluk planı ise planı onaylıyor.
+Ama önce, partinin seçimleri kazanması gerekiyor.
+Ancak siyasi rakipleri aynı fikirde değil.
+Misyonun bir parçası olmaktan gurur duyuyorum.
+Bu çok fazla.
+Artık yığılmalar ortadan kalktı.
+Pek çok şiddet olayını ifşa ettik.
+Yunanistan örgütün dönem başkanlığını yürütüyor.
+İktidar partileri bu talebi reddediyorlar.
+Hatta bazılarına göre bir efsanesiniz.
+Üsküp'te yeni bir kültür merkezi açıldı.
+Yerel ekonomi de bu gerçeğin darbesini hissetti.
+Bu iş artık kalıplaşmış durumda.
+B92 bu açıdan hangi noktada duruyor?
+Önceki net asgari ücret 167,79 euro idi.
+Sergide beş Hırvat yeniliği sergilendi.
+Fakat ülkede yeni yıl için pek heves duyulmuyor.
+Arnavutluk sektörde kronik borç sorunu yaşıyor.
+Sırbistan'ın bunu başarmak için neler yapması gerekiyor?
+Yerli ilaçlar yoksa, yerli ilaç firmaları çalışmıyorsa, neden bu ilaçları ithal etmiyorlar?
+Binada restorasyon çalışmaları sürüyor.
+Ülke 2004'te 67. sıradaydı.
+Nuremberg, Frankenstadion.
+Bu yılki foruma Makedonya başkanlık ediyor.
+Ancak güzel günler yakın olabilir.
+Sergi 4 Mart'a kadar devam edecek.
+Mediu Pazartesi günü bunu gerçekleştirdi.
+Bu kesinlikle çözüm değildir.
+Bir hayal kırıklığı daha.
+Bu seviyede işbirliğinin güçlenmesini bekliyorum.
+Bu, şirketin belirleyeceği bir durumdur.
+Ankete katılan başka Balkan ülkesi yok.
+Barış süreci için yararlı mıdır yoksa bunları göz ardı etmek mümkün müdür?
+Atina hareketi memnuniyetle karşıladı.
+Oyun, Balkanlarda yaşanan ihtilafi konu aliyor.
+Festivale sekiz Slav ülkesi katıldı.
+Filmi büyük bir samimiyetle yaptık.
+Oktar'ın karara itiraz hakkı bulunuyor.
+Bu, teröre destek vermektir.
+Bu da son derece gurur duyduğum bir şey.
+Petkim Türkiye'nin en büyük petrokimya fabrikası.
+Odun olmasa şimdiye dek ölmüştük.
+Dokunulmazlık günleri nihayet sona ermişti.
+Bu, Sırplar arasında oldukça yaygın bir durum.
+Reform, finansal açıdan da faydalı.
+Kuzeyde durumun şiddetlenmesini bekliyor musunuz?
+İşler kızıştıkça daha iyi hale geliyor.
+Ardından emlak vergisi adını aldı.
+Malezya ve Bangladeş de aday önerisinde bulundu.
+Kısıtlamaların kesin içeriği gizli tutuluyor.
+Bir ülke için otoyol, insanın damarları gibidir.
+Konserin tarihi Ocak ayı ortasında açıklanacak.
+Polis 5 binden fazla sahte avroya el koydu.
+Withers Haziran 2007'de büyükelçi olmuştu.
+Yine de bazı sorular henüz cevap bekliyor. Örneğin silah, daktilo ve kaşe nerede?
+Ertesi gün de mahkeme suçlamaları geri çekti.
+"Süper valiler" geri mi geliyor?
+Fakat bu durumun etkileri halen devam ediyor.
+İlaç ve tarım firmaları başı çekiyor.
+Kuzeyde yaşanan çatışmalarda en az 15 kişi öldü.
+Bu programlardaki durumlar sahte.
+Yangında bir itfayecinin yaralandığı bildirildi.
+Turnuva Pazar günü sona eriyor.
+Şimdiye kadar bir teklif sunulmuş değil.
+Bunların toplam değeri 100 milyon avroyu buluyor.
+Peki bu seçim Türkiye'nin parçalanmış solunda yeni bir dönemi başlatacak mı?
+Hasta 25 yaşındaki bir kadındı.
+Projenin 2007 yılında tamamlanması bekleniyor.
+Anlaşmanın değeri 150 bin euro olarak belirlendi.
+Çok çalıştım ve babamdan da büyük destek gördüm.
+Pack ise açık konuştu.
+Hırvat hentbol takımı ülkenin en sevilen takımı.
+Yeni bir girişimin yararı olacak mı?
+Kalbi bir kez olsun kırılmamış insan var mıdır?
+Ancak ilgili aileler için sonuçlar acı verici.
+Ancak Yunanlılar aynı fikirde değil.
+Bir diğer sevilen kış yemeği de tuzlu balık.
+Ancak bu seçimlerin ikinci turu olmayacak.
+Bu eski sistemin maliyeti de yüksekti.
+Makedonya başbakanı Dublin'i ziyaret etti.
+Katılımcıların çoğu girişimcilerden oluşuyordu.
+Makedonya'nın isim müzakerelerinde yeni bir momentum mu?
+Bence, önemli görünüyor.
+Cesur olun.
+Yasaların Ağustos ayında onaylanması bekleniyor.
+Genelde ağırlık bağımsız filmlere veriliyor.
+Bu yaz oyunlara yaklaşık 35 bin kişi katıldı.
+Paris'in kulesi, Çin'in de seddi var.
+Bu ne anlama gelmektedir?
+İş dünyasında geçerli ahlak kuralları var.
+Diğer altı adayın her biri %1'in altında oy aldı.
+Şirketler maliyetleri kısıp işçi çıkarıyorlar.
+Sekiz yıldır iktidardaydı.
+Sergi 15 gün süreyle açık kalacak.
+Fakat pek çok kadın kuralları görmezden geliyor.
+İki zanlı da 48 saat süreyle gözaltına alındı.
+Bu kitabı yazma fikri nerden aklınıza geldi?
+Ancak seçimlerden net bir galip çıkmadı.
+Diğerleri hemfikir.
+Fakat bu tamamen doğru değil.
+Diğer üçü ise Sofya'da ele geçirildi.
+Fakat hala bariz bir ırk ayrımcılığı mevcut.
+Podgorica'da neden bu kadar çok ayakkabı mağazası var?
+Bunları sonsuza dek hoş görmeyeceğimiz kesin.
+Bu noktalar yerel yönetimlerce sağlanacak.
+Her aileye 500 avro kadar yardım yapılabilecek.
+Etkinlik Çarşamba günü sona erdi.
+Ancak, başbakanın beklediği şekilde değil.
+Janiç Cumartesi günü madalya için yarışacak.
+Sizce bu durumu değiştirmek için neler yapılabilir?
+Herkes bu görüşü paylaşmıyor.
+Şimdiden en az üç yeni belediye kurulmuş durumda.
+Bir kişi serbest bırakıldı.
+Gidilecekse seçim tarihi ne zaman olacak?
+Tarhan sürekli tutuklanma korkusuyla yaşıyor.
+Zaman içinde ikilinin arasında bir aşk doğuyor.
+Arnavutluk terörle mücadele çabalarını artırıyor.
+Sizce bunlar yerinde endişeler mi?
+Birer birer pişirin.
+Ücret yılın başında yürürlüğe konmuştu.
+Bakanı koalisyon ortakları bile eleştirdi.
+Kadare'nin eserleri 40'tan fazla ülkede çevrildi.
+Bize bu koşulların neler olduğundan ve hangilerinin henüz yerine getirilmediğinden bahseder misiniz?
+Hoş değildi.
+Vlasiç 203 cm'lik atlayışıyla birinci oldu.
+Prosedür üçüncü keredir erteleniyor.
+Bosna ya normal bir ülke olacak ya da dağılacak.
+Ancak firmaların da elleri boş durmuyor.
+Makedonya 1997 yılından beri bankaya üye.
+Raporda bir çok olumlu eğilime işaret ediliyor.
+Çok ilginç bir film olabilir.
+Türkiye'nin Birliğe katılım şansını nasıl değerlendiriyorsunuz?
+Bunun hiçbir anlamı yok.
+Karadağ ile olan ilişkilerimiz de güçleniyor.
+Yunan yetkililer anlaşmayı benimsediler.
+Ancak yeni seçim yapılmadı.
+Bana iş teklif ettiler.
+Sizin deyiminizle, signomi .
+Biz size yardım etmeye hazırız.
+Sergide 27 sanatçının toplam 73 eseri yer alıyor.
+Sorunun tüm bölgede yaşanmakta olduğu görülüyor.
+Bir sinema ve televizyon ünlüsü bile oldu.
+Ebeveynler, derneğin var olmasından memnunlar.
+Çani, bu yılın daha da zor geçeceğini öngörüyor.
+Şu anda yüksek ölçüde bir destek söz konusu.
+Bu miktar daha sonra 200 milyon avroya düştü.
+Bir davada beş ay hapis cezası verilmiş.
+Uluslararası toplumun bu bağlamda yeni stratejileri var mı?
+Gövdede bir çok çatlak vardı.
+Seçim kampanyasında her şey mümkün görünüyor.
+Fakat bu durum kısa bir süre sonra değişecek.
+Piperovic suçlamaları reddetti.
+Yine de reform çığlıkları giderek büyüdü.
+Kosova hükümeti de sert tepki verdi.
+Tek istisna ise vize serbestliği konusu oldu.
+Şimdi ise bu zorunluluk ortadan kalktı.
+Bu konu açık değildir.
+İlgilenen herkes bunlara katılabilir.
+Tesla, 10 Temmuz 1856'da doğdu.
+Bugün Sırbistan'da 30 kadar ulusal banka var.
+İki taraf da diplomatik gerileme istemiyor.
+Lise aşkını bulmayı başardı.
+Polis varlığı barizdi.
+Artık işler hızla değişiyor.
+Mağdurların hiçbir hakkı olmaması çok saçma.
+Bunlara daha beslenme çantası dahil değil.
+Harizaj mahkemede hiçbir açıklamada bulunmadı.
+Bu temel bir hak.
+Bir köy, bu konuda ortalamanın üstünde.
+Para, bütün bölgesel yönetmenlerin ortak sorunu.
+Biz görevimizi yaptık.
+Hırvat heyetinin gezisi bir hafta sürecek.
+Buraya kadar tamam da, bu acenteler kimlerden oluşuyor?
+Bunların bir çoğu yerel kadınlarla evlenmişti.
+Bir çok ülkeden bir sürü çocukla tanışıyoruz.
+Öte yandan hükümet sabırlı olunmasını istiyor.
+Belgrad şehir merkezindeki bir sokak kafeteryası.
+Aile kilisedeki Noel ayinine de katılıyor.
+Bulgaristan bu turnuvada dördüncü olmuştu.
+Neden partiden ayrılarak Demos'u kurmaya karar verdiniz?
+Ortak bölgesel çıkarlarımız da bunu gerektiriyor.
+Seçmenler bu inancı oy pusulasına da yansıtıyor.
+Başvuru süresi 1 Mart'ta sona erecek.
+Kampanya 15 Eylül'e kadar devam edecek.
+Merkezin 2008 sonuna kadar açılması bekleniyor.
+Satarsak zarar mı ederiz?
+Katılanların yaklaşık %40'ı 35 yaş altında.
+Üç maç da 1-0 skorla sona erdi.
+Cumhurbaşkanı erken seçim kararını destekliyor.
+Görev süresi on iki ay olacak.
+Gerçekteyse sadece 25 milyon avro ödendi.
+Uluslararası toplum fikre karşı çıktı.
+Türkiye şu anda vicdani redde izin vermiyor.
+Pek çok kaynak olduğu söylenebilir.
+Savcılık adalet bakanlığına rapor veriyor.
+Yapılanlar her açıdan çok başarılıydı.
+Savaştan sonra komünist hükümet mülke el koydu.
+Ayrıca seminerler de düzenlendi.
+İkinci en yeni yerleşim de yine çok önemli.
+Polis en az altı kişiyi daha sorguya çekiyor.
+Artymata dördüncü oldu.
+Festival 28 Nisan'a kadar devam edecek.
+Bu ne derece zor oldu ve Kosova makamlarının bu davalardaki işbirliği nasıldı?
+Parti Gül ile görüşmeyi reddetti.
+Sizce çözüm için umut var mı?
+Başbakan istifayı kabul etti.
+Bunun kabul edilemez olduğu açık.
+Pek çok kişi buna katılmıyor.
+Peki nasıl öğretmenlik yapıyor?
+Koridor 8 ve Koridor 10
+Programın üçüncü sezonu Mart ayında başladı.
+Pek çoğu uzman profesyonel ve akademisyenler.
+Geliştirme süreci zaten başlamış durumda.
+Terör, fazla önem vermediğimiz bir sorun.
+Bu bir meclis kararı mı yoksa bağlayıcı bir referandum sonucunda mı olacak?
+Ancak büyük bir saldırıyla karşı karşıya kaldık.
+Ancak temelde bir iş sorundur.
+Bu senaryo henüz gerçekleşmedi.
+Uçuş güvenlik tedbirleri derhal artırıldı.
+Önümüzde hiçbir yükselme veya iyi haber yok.
+Şirket Cosmote'nin yüzde 66,54'üne sahip oldu.
+Avro bölgesi krizi Kosova'yı teğet geçebilir mi?
+Ancak hükümet bu kaygıları dağıtmaya çalıştı.
+Bugünse Pobjeda'nın üretimi zayıf.
+Fon, modernizasyonun finansmanında kullanılacak.
+Bu açıdan, sağlık alanında belirsiz bir fark var.
+Bu da oldukça cesaret verici.
+Boskovski ise mahkemeye 24 Mart'ta gitti.
+Yüksek lisans eğitimini burada tamamladı.
+Sunulan 80 makaleden yaklaşık 25 tane seçildi.
+Douka ödülü kazanan dokuzuncu kişi oldu.
+Paniğe gerek yok.
+Husumetin azalması yönünde çağrılar da var.
+Ancak o günü bütün ülkeler kutlamadı.
+Kosova, Avrupa'nın en genç nüfusuna sahip.
+Okul yılı boyunca başka sınav olmuyordu.
+Daha çalışmaya bile başlamadan zarar ettim.
+Ancak bunu uygulamak daha büyük bir sorun olacak.
+Fakat sadece orduyu eleştirmek de yanlış olur.
+Bakanlık da buna katılıyor.
+Belgradlılar bu konuda farklı görüşlere sahip.
+Tasarıyı ayrıntılı şekilde inceleyeceğiz.
+Öldürmek onlar için hiçbir şey ifade etmiyordu.
+Fakat kararda soykırım sözcüğü yer almıyor.
+Reisi olmayan bir ev gibiydi.
+İnsanların huzur ve mutluluğu için dua ederim.
+Bu da generalin yakalanmasını güçleştiriyor.
+Herşeyi barışçıl yollardan çözerdi.
+Hemşirelerden ikisi tecavüze uğradığını söyledi.
+Bugün Kosova'da olanlar bizim için pek net değil.
+Ne yapabilirsiniz ki, dilini mi keseceksiniz?
+Fuar Pazar günü sona eriyor.
+Fakat suç yalnızca siyasi farklılıkların değil.
+Makedonya bu konuda tam olarak ne denli katkıda bulundu?
+Gelenekleri ve kültürleri de kendilerine özgü.
+Beşinci sırayı ise Kıbrıs aldı.
+Öte yandan Sönmez'e göre, kurul tarafsız değil.
+Etkinlik Avrupa sinemasını tanıtıyor.
+Bilgi, önyargıyı çökertir.
+Tarihi binalar, köprüler ve kaleler var.
+Tihomir Staniç.
+Bir siyasi kargaşa dönemi yakın görünüyor.
+Macaristan bu açıdan başarılı bir model sunuyor.
+Sadece bir kişi kurtulmayı başarmıştı.
+Rusya suçlamaları reddediyor.
+Yine aynısı olabilir mi?
+Fakat sokakta herkes iyimser bir havada değil.
+Ancak yaşam standartları hala düşük.
+Aralık 1993'e kadar da bu mevkide kaldı.
+Bir diğer engel de, tasfiye sürecinin yavaşlığı.
+Bu ifade, manşetlerde öne sürüldüğü gibi sadece bir "diplomatik hediye" mi?
+Bosnalılar da var.
+Arnavutluk adeta bir inşaat sahasına döndü.
+Mahkeme duruşmayı 19 Aralık'a erteledi.
+Üçü gala olmak üzere 20 oyun sahnelenecek.
+Favori kim?
+Çözüme ulaşmanın yolu bu değildir.
+Duyuru karışık tepkiler doğurdu.
+Sırplar Pekin'de neden daha iyisini yapamadılar?
+Fakat bu yıl Türkiye'ye gideceğim.
+Ne gibi zorluklarla karşılaşıyorsunuz?
+Bir tarafta alıyor, diğerinde satıyoruz.
+Bu yıl, iki pilot ders verilecek.
+Bu bizim için bir meydan okumaydı.
+Makedonya'daki tepkiler karışık oldu.
+Ancak süreç Ekim ayında iptal edildi.
+Rusya ülkeye dünya örgütünde destek vermişti.
+Bu değerlendirmelerle ilgili yorumlarınızı alabilir miyiz?
+Ben savaştan çıkmış bir ülkede büyüdüm.
+Fabrikanın 1500 işçiye iş sağlaması bekleniyor.
+Kendime yalan söylemem.
+Doğrulanmış 12 vakadan dördü ölümle sonuçlandı.
+Eski bakan suç işlemediğini iddia ediyor.
+Bakarciev daha sonra olaydaki rolünü itiraf etti.
+Kostunica'nın Seydiu ile görüşmesi beklenmiyor.
+Yurtdışına çıkmamışsınız.
+Bu programlar da onlara bu şansı verecek.
+Bu kişiler de üçer yıl hapis cezası aldılar.
+Pek çok kimse için banka kredisi tek seçenek.
+Cumhurbaşkanını seçme yönteminde yapılacak değişiklikler Moldova'daki siyasi krize son verecek mi?
+Çok sayıda blogcu da duruma ağırlığını koydu.
+Mimosa Hasanramaj ise daha ihtiyatlı.
+Diğerleri de başıboş araçların üstüne sığındılar.
+Ancak Öcalan'ın tecrit günleri sona erdi.
+Belgenin bir ay içinde imzalanması bekleniyor.
+Benim için bu kabul edilemez bir durum.
+Angela Merkel'in sert sözleri anlaşma sağlanmasında katalizör görevi görecek mi?
+Esat Berişa buna bir örnek.
+Kazadan kurtulan olmadı.
+Kosova zengin turta çeşitleriyle de tanınıyor.
+Planlanan filtreleme sistemi sansür anlamına mı geliyor?
+Park alanları çoğunlukla ücretsiz.
+Vukasin Batiniç de bu mültecilerden biri.
+Ancak yakında bu durum değişebilir.
+Katliam her yıl yıldönümünde anılıyor.
+Bana sorarsanız onlar İslamcı bir hareket.
+Geçiş her zaman sorunsuz olmadı.
+Beş yıllık proje 35 milyon avroya mal olacak.
+Mayıs 2006'da söz konusu rakam 34 bin 789 idi.
+Etkinliğe yaklaşık 250 bin kişi katıldı.
+Komşu ülkeler de izleyecek modeller oluşturdular.
+Türkiye turnuvada üçüncü oldu.
+İki kişi sorgulanmak üzere gözaltına alındı.
+Boksör şu anda Kanada için dövüşüyor.
+Bu reform ne kadar sürecek?
+Ancak bir miktar ilerleme de kaydedildi.
+Sırbistan'ın yatırım avantajı işçilikte yatıyor.
+Pek çok kişi Pekin'de ondan altın bekliyor.
+Bu onların hakkıdır.
+Bunun etkileri ise şüphesiz oldukça çarpıcı oldu.
+Partinizin hedef ve öncelikleri ne olacak?
+Fakat bu rahatlama ve coşku uzun ömürlü olmadı.
+Tutuklananlardan biri Çeçen uyruklu.
+Bizde ise halen böyle bir merkez yok.
+Programda on ülkeden toplam 11 film yarıştı.
+Bu yılki fuarın onur konuğu Küba.
+Büronun 6 milyon avro zarara uğradığı sanılıyor.
+Bu konuda bir ikilem yok.
+İşveren dernekleriyse girişimi destekliyor.
+Planı yalnızca 14 vekil destekledi.
+Kuzeyde de durum daha iyi değil.
+Erken seçimlerin mayısta yapılması bekleniyor.
+Polis Kovaçki'ye ait 17 mülkte arama yaptı.
+Böl. 1001 ve 1030 uyarınca cezalandırılabilir.
+Arnavutluk medyası halen geçiş döneminde.
+Zaman değişiyor ve insanlar da değişiyor.
+İlgili tüm partilerin resmi sonuçları kabul etmesini nasıl sağlayacaksınız?
+Geleceği tahmin etmek zor.
+Brüksel tekrar açılmalarına karşı çıkıyor.
+Ancak olay asla çözüme kavuşmamıştı.
+Fakat herkes aynı fikirde değil.
+Ancak istihdam oranı sabit kalıyor.
+Yaşları 14, 15 ve 16 idi.
+Şimdi ise 2008'e ertelenmiş durumda.
+Din asla sorun olmadı.
+Analistlere göre atılabilecek bazı adımlar var.
+Güneydoğu Avrupa ülkeleri biyoyakıt konusunu değerlendiriyor?
+Ayrıca gerçek etnik köklerimizin arkasında saklanırsak önyargıyla nasıl savaşırız?
+Anlaşmanın ekonomik faydaları büyük olacak.
+Bu, halkın istemediği bir şeydir.
+Kent sakinleri de aynı derecede heyecanlılar.
+Ancak cumhurbaşkanını seçmeye yetecek kadar sandalye kazanacak mı?
+Sizce takım şampiyonada hangi aşamaya kadar ilerleyebilir?
+Bakan ayrıntılı bilgi vermedi.
+Bu ülkede hiç kimse o çağa dönmek istemiyor.
+Yerli firmalar önümüzdeki dönemde yollarına nasıl devam edecekler?
+İşi tamamlamak için daha fazla para gerekiyor.
+Davaya 9 Mart'ta devam edilmesine karar verildi.
+Söz konusu süre altı ay.
+Ve gizlemeye çalışmıyor.
+Her iki tarafı da kastediyorum.
+Herşey adıyla bilinmeli.
+Aydar ve Kartal daha sonra serbest bırakıldı.
+Güreşçiler 60 kilo kategorisinde güreştiler.
+Tüm bu yemekler için para gerekiyor.
+Programın toplam değeri 101 milyon euro.
+Kosova'da sizin için özel önemi olan bir yer, yemek veya hikaye var mı?
+Festival 20 Ağustos'a kadar devam edecek.
+Sizce tüm bu takdirin arkasında ne yatıyor?
+Ancak avantajlar bunlarla da kalmıyor.
+Sizin bir tarihiniz, bir geleneğiniz var.
+Onların arzularını dikkate almak gerekir.
+Kosova başka bir şey.
+Genişleme planları bununla da bitmiyor.
+İnşaatın 2014 yılında tamamlanması planlanıyor.
+Bu durumu neye bağlıyorsunuz?
+Sizce bu nasıl durdurulabilir?
+Kyriakou görev için tek adaydı.
+Etkinlikte Arnavut yayınevleri çoğunluktaydı.
+Bazı konularda ise belirsizlik söz konusu.
+Petrol fiyatı arttı.
+Otopark şirketleri karara ateş püskürüyorlar.
+Paylaşılan değerlerin ifadesidir.
+Teklif verme süresi 14 Haziran'da sona eriyor.
+Şarkıcı sadece 26 yaşındaydı.
+Türkiye nükleer santral kurulmasını onayladı.
+Fonların 8 milyon euroluk bölümü hemen verilecek.
+Bu ilgi bir çeşit beklenti yarattı.
+Yalnızca büyükler ayakta kalacak.
+Ayrıca, cumhurbaşkanlığı yarışının da eklenmesi, diğer seçimlerin görünümünü nasıl değiştirecek?
+Seçmen katılımı yüzde 57 olarak gerçekleşti.
+Görüşme ir saat sürdü.
+Ancak bu bilgiler kamuoyuna açıklanmayacak.
+Nasıl Küreselleşmeli?
+Diğer partiler de kendi adaylarını ön sürdüler.
+Yeni son başvuru tarihi 15 Nisan.
+Değişimin temelleri şimdiden atılmaya başlanmalı.
+Öyleyse neden bekleyelim?
+Bazı şeyleri değiştirmeye başlayan insanlar var.
+Bu mesele çok fazla uzadı.
+İki diğer ünitenin yapımı sürüyor.
+Anlaşmanın 31 Ekim'de kesinleşmesi bekleniyor.
+Kadınlar cuma namazına katılabilir mi?
+Libya'ya siyasi çözüm, Kaddafi tarzında mı?
+Nadir bir sikke koleksiyonu da sergileniyor.
+Yardımın varış noktası sorun yaratıyor.
+Etkinlik 20 Aralık'ta sona eriyor.
+Ardından her şey ters gitti.
+İlk olarak sorunun boyutları belirlenmeli.
+Fakat yasayı değiştirmekle herşey hallolmuyor.
+Birinci bölüm için tıklayın.
+Yeni arkadaşlar ediniyoruz.
+Snezana Pajkiç'in bugün nerede olduğunu biliyor musunuz?
+Bu yıl da istisna olmadı.
+Sizce ne zaman yapılmalılar?
+Bizim tutumumuz son derece yapıcıdır.
+Sonuç olarak kriz şimdilik önlendi.
+Hükümet olmayan yerde devlet bütçesi de olamıyor.
+Bu görevlerin çoğu tehlikeli kabul edilmiyor.
+Saldırının sorumluluğunu henüz üstlenen olmadı.
+En son teknolojiler sunulmalı.
+Hakkari'de oy verme oranı yüzde 6'da kaldı.
+Daha bir çok turnuva ve maç kazanmak istiyorum...
+Jezero'nun yeniden inşası 2003 yılında başladı.
+Sami Neza olasılıkları inceliyor.
+Başsavcı bir süredir çekişmelere konu oluyor.
+Teklif sunma süresi 30 Eylül'de sona eriyor.
+Vergi mevzuatı da bu alanlardan biri.
+Tenisçi geçen yıl hiçbir turnuva kazanamadı.
+Fakat aynı zamanda da tehdit altında.
+Sıcaklar dayanılmaz hale geldiğinde onlar nereye gidiyor?
+Konut ve eğitim en önemli alanlar.
+Ayrıca planda anaokulları da bulunuyor.
+Hırvatistan dijital televizyona geçti.
+Bunların karşılanmaları zorunludur.
+Peki siz kariyeriniz boyunca bunu yapmayı başarabildiniz mi?
+Jokiç ise iddiayı yalanladı.
+Yaklaşık 40 milyon seçmen sandık başına gitti.
+Küçülmenin bu yıl da devam etmesini bekliyoruz.
+Sahada 773 milyon metreküp doğal gaz bulunuyor.
+Şirket ruhsat için 71,5 milyon euro ödeyecek.
+Basescu da benzer sözler sözledi.
+Fikirler bol olsa da, kaynaklar kısıtlı.
+Gösterge faiz oranı %6'dan %5,75'e düşürüldü.
+Ülke, yerinde politikalar uyguluyor.
+Kosova'da bu duruma karışık tepkiler geldi.
+Önerilen çözümlerden herkes memnun değil.
+Bu, son altı yılın en yüksek oranı.
+Bunların hiçbiri bizi etkilemez.
+Ameliyata İtalyan uzmanlar yardım ettiler.
+Ancak bu oldukça engebeli bir yol.
+Maç 31-29 skorla sona erdi.
+Bölgede geleceğe yönelik özelleştirme çalışmaları açısından daha neler yapılması gerekiyor?
+Bunların arasında üç de kadın polis bulunuyor.
+Cenazesi Salı günü kaldırılacak.
+İkinci tur 13 Aralık'ta gerçekleşecek.
+Tehlike geçince çete Viyana'ya geri taşındı.
+Peki bu sorunlarla başa çıkma şansımız nedir?
+Sizin bu konudaki tutumunuz nedir?
+İki ayın sonunda ise Kaliforniya'ya geri dönmüş.
+Sizce bu zamanlama gerçekçi mi?
+Arnavutluk ile Sırbistan arasındaki ilişkileri nasıl görüyorsunuz?
+Hükümet de bu tavsiyeye uyuyor gibi görünüyor.
+Kazı çalışmaları yaklaşık altı ay sürecek.
+Dokunan desen oldukça zor ve karışık.
+Haber Üsküp'te coşkuyla karşılandı.
+Kapitalist dünyada rekabet yeni bir kavram değil.
+Kazanan teklifin değeri 6,55 milyar dolar oldu.
+Fonlar 2010-2013 yılları arasında sağlanacak.
+Zagrep Lego'ları sevdi!
+Dostluğunuza müteşekkirim.
+Failler hala yakalanamadı.
+Şimdi Ankara yeniden denemeye hazır.
+Gece hayatı büyüleyiciydi.
+Bu durumun sebebi ne?
+Blog yazarları ise konuya şüpheyle yaklaşıyor.
+Durumdan sendikalar da hoşnut değiller.
+Bazı planlar üzerinde çalışılıyor.
+Merwin oldu.
+Savunma reformu, Makedonya için güçlü bir koz.
+Sırplar İtalya'yı 3-0 mağlup ettiler.
+Dahası, petrol risk altındaki tek kaynak değil.
+Son birkaç yılda nasıl bir değişim oldu?
+Bu yılki fuarda çocuk edebiyatı vurgulanıyor.
+Ödül töreni 16 Mayıs'ta gerçekleşecek.
+Ya yaşasaydı?
+Sırbistan ve bölge açısından herhangi bir güvenlik riski mevcut mu?
+Bu süre bitiminde tesisler devlete devredilecek.
+Festival 20 Ağustos'ta sona erecek.
+Bosna'ya dört yıl önce gittim ve çok sevdim.
+Hareketle ilgili tartışmalar da çıkmadı değil.
+Bizim ülkemizdeyse tam tersi şekilde başladı.
+Eyalet senatosuna da bir ziyaret düzenlendi.
+Ailem için hayat çok zor.
+Sahte bir seyahat belgesi yaklaşık 500 euro.
+Raportörün çağrısı ilk değil.
+Ertelemenin nedeni belirtilmedi.
+Makroekonomik durum tekin kabul ediliyor.
+Türkiye ve İtalya geçiş anlaşması imzaladılar.
+Makedonya ise Arjantin ile birlikte 100. oldu.
+İzlenmesi gereken yol bu.
+Tiran'da bayram havası vardı.
+Peki hedefi ne?
+Sadece kaybedenler var.
+Başka bir kanaldan da adli işlemler başlatıldı.
+İşsizlik %20'ye varıyor.
+Takım üç sezondur şampiyonluğu elden bırakmıyor.
+Tünel, seyahat süresini birkaç saat kısaltacak.
+Reformcular bir aday dahi göstermediler.
+Dev farklar yaratabilirsiniz.
+Ne var ki Erdoğan davaya destek vermedi.
+Görüşmelerde kadastro kayıtlarına da yer verildi.
+Etkinlik 22 Ekim'de sona erecek.
+Karadağ bunda 672,8 milyon euroluk paya sahipti.
+Krizin tam etkisi hala ölçülemedi.
+Makedon hükümeti Pazar günü ulusal yas ilan etti.
+Bir hafta süren yarışma 16 Kasım'da sona erdi.
+Sonuçlar şaşırtıcı değil.
+Yatırımcılar projeyi 14 Ocak'ta sundular.
+Başbakan İvo Sanader sorunu kabul ediyor.
+Blogcu, "Generallerin istifasından sonra, bunların olmasını önleme umudu kaldı mı?" diye soruyor.
+Tesis Atina şehir merkezinde bulunuyor.
+Tabii bu her zaman kolay olmuyor.
+Bu konudaki liste hayli uzun.
+Kaynattıktan sonra suyu atın.
+Bu noktada iki çıkarım yapmak mümkün.
+Eski alan adı 21 Nisan'a kadar etkin kalacak.
+Peki kampanyanın içeriği tam olarak neydi?
+Ayrımcılık hassas bir konu.
+Anket tahminleri sunulamayacak kadar yakınlar.
+Yaklaşık 154 Rad taraftarı tutuklandı.
+O ve iki hakem 23 Nisan'da tutuklandı.
+Şu anda bu girişimi değerlendiriyoruz.
+Girişim bir halk hareketine de yol açtı.
+Bunlar en büyükleri.
+Bu konudaki görüşleriniz neler?
+Bu girişiminde mahkemenin karşılaştığı en büyük güçlük ne oldu?
+Her türlü şiddete karşıyız.
+Yazarın ülkesinde karışık tepkiler geldi.
+Duruşma 11 Ekim'de yapılacak.
+Ancak Hırvat hükümeti vazgeçmiyor.
+Filmin ilham kaynağı da işte bu günlük oldu.
+Gümrük idaresi 572,2 milyon avro topladı.
+Bunu sağlayacak irade mevcut.
+Bu temel görevler büyük oranda yerine getirildi.
+Fakat en alt tabakada sualtı yaşamı yok.
+Sonucu çok az kişi tahmin etmişti.
+Karar ayrıntılı bir analiz sonrasında alındı.
+Profesör Özeren bu değerlendirmeye katılıyor.
+Seyircinin %40'ı yabancılardan oluşuyordu.
+Anlaşmanın sağlanabileceğini düşünüyorum.
+Karışıklık özellikle kırsal bölgelerde belirgin.
+Yunanistan etkinliğin konuk ülkesi olacak.
+Bu kıta büyük özverilerin bir ürünüdür.
+Polis de olayı araştırıyor.
+Hırvat liderler de bunu kabul ettiler.
+Ancak bu işbirliğinin kolay olmadığı görüldü.
+Bunların arasında dövülerek öldürülenler de var.
+Kamuoyunda da güçlü bir destek söz konusu.
+Yine de girişimlerinden ötürü kutluyoruz!
+Librescu geride eşi Marlena ve iki oğul bıraktı.
+Bu yılki festival de istisna olmadı.
+Ancak bu bile mümkün olmadı.
+Bence bu yeni ortaya çıkmış bir şey değil.
+Bu, yokuş yukarı bir tırmanış olacak.
+Askerlerin hizmetleri Ekim ayında sona erecek.
+Ülke halkı çok misafirsever ve dışa dönük.
+Komisyon tamamen hukuk uzmanlarından oluşsa daha mı iyi olurdu?
+Bölge, Kosova ihtilafından da etkilenmişti.
+Şimdilik yalnızca yolcu hizmeti veriliyor.
+Bunlardan 60'ı şüpheli bulundu.
+İkinci tur müzakereler Eylül ayında başlayacak.
+Allahverdi, örgütün ilk Türk üyesi oldu.
+Ayrıntılara girmek istemiyorum.
+Varsa, bunu kim kolaylaştıracak?
+Bölgede yıllardır süren husumet artık sona mı eriyor?
+Ancak satış bazı tartışmalara yol açtı.
+Sırp yetkililer statüyü memnuniyetle karşıladı.
+Fakat zaman ilerliyor.
+Fakat bu da uymuyor.
+Bunun dışındaki her şey spekülasyondur.
+Sırplar ve Arnavutlar ulusal bir barış sağlayabilir mi?
+Yordanova 1500 metre yarışında koşacaktı.
+Peki nerede hata yaptılar?
+AP milletvekilleri beş yılda bir seçiliyorlar.
+Kredilerin büyük bölümü özel şirketlere verildi.
+Taçi, dışarıya olumlu bir görünüm yansıttı.
+Gösterilerde eski giysiler konu ediliyor.
+Bu konuda hükümetlere büyük rol düşüyor.
+Kanalı en çok Arnavutlar kullanıyordu.
+Yeniden inşa çalışmaları yeni başladı.
+Son olaylar endişe seviyesini yükseltti.
+Tüm bunlar ilgimizi çekse de, uzun kalamazdık.
+Bundan sonra bu miktar yarıya iniyor.
+Gazeteler için de aynı durum söz konusu.
+Mobi 63 çalışanları da mutsuz.
+Bunun ilk adı dayanışma vergisiydi.
+Kabinede 19 bakan bulunuyor.
+Grigor, "Gerçekten biliyorum!" diyor.
+Projenin dört yıl içinde tamamlanması bekleniyor.
+Hepsi de dumandan zehirlenerek öldü.
+Film yapımcıları da bu noktadan hareket ediyor.
+Her zaman olduğu gibi, en iyi çocuklarımız gitti.
+Sergi 17 Şubat'a kadar devam edecek.
+Fakat iyi haber uyarısız olarak gelmiyor.
+Bu bir başlangıç olacak.
+Olayla ilgili soruşturma sürüyor.
+Fakat halk sadece barış istediğini söylüyor.
+Ama halk artık bunlara kanmıyor.
+Bu açıdan bu yıl da bir farklılık gözlenmedi.
+B1 olan döviz kuru notu ise değişmedi.
+Aynı gün şüpheli 30 gün süreyle gözaltına alındı.
+İki ülkedeki suç profilleri oldukça farklı.
+Bu dili nerden öğrendiğini soruyoruz.
+En önemli haberse yeni işletmeler için geliyor.
+Rugova istifa etmeyi planlamadığını da belirtti.
+Acelem yok, bunu biliyorsunuz.
+Avrupa bunun en açık örneğidir.
+Bu durum Kosova'yı ne şekilde etkileyecek?
+Temas Grubu Çarşamba günü toplanacak.
+İşlem hacmi 162,3 milyon euroya çıktı.
+Şampiyonada 12 Mayıs'a kadar 12 maç yapılacak.
+İşte sanatçının yaptığı şey budur.
+Bu yılki fuar ortağı İsrail oldu.
+Tek amacımız var olmak ve çalışmaya devam etmek.
+Sizin için bu ödül ne ifade ediyor?
+Her an tehdit edilebiliyorlar.
+Bunları hatırlamak ve unutmamak.
+Etkinlikte toplam 64 okul yarıştı.
+Avusturyalı memur ise evde tedavi ediliyor.
+Parlamento nasıl olsa yaz tatiline girecek.
+Fakat bu çabalar boşa çıktı.
+Devlet sübvansiyonları da azaltılacak.
+Bunun da fiyatı bir kuruş bile değildir.
+Projenin ilk safhası 31 okulu kapsayacak.
+Silajdziç ve Dodik'i, bu tavırlarını değiştirmeleri yönünde ikna etmek için neler yapılabilir?
+Google bu ay Romanya'da bir ofis açıyor.
+Peki sizin partinizin bu konudaki görüşü nedir?
+Bu sefer beklentiler geçen seferlerden yüksek.
+Beklendiği gibi, sevilen taraf Afrikalı takımdı.
+Maç olaysız geçti.
+Dünyada da 43 ortak üyesi var.
+Kurbanların çoğu kadın ve yaşlılardı.
+Turnuvaya 41 ülkeden toplam 370 sporcu katıldı.
+Vaat etmiyoruz.
+Ancak yerel şoförler sabırsızlanıyorlar.
+Merkezin 2012 yılında açılması planlanıyor.
+Para biriminin sayısal kodu ise 941.
+Hidroelektrik üretiminde gerileme yaşanıyor.
+Bu durumun gelecekte değişeceğini düşünüyor musunuz?
+Fakat yine de bu işe bir şans vermiş.
+Bu, Avrupa'ya uzanan bir yol.
+Uzlaşmak istemiyorlar.
+Bugünse bu rakam 5 bin civarında.
+Paranın onda biri hibe olarak verilecek.
+Onun için bu, sürdüreceği bir gelenek.
+Takımın yaş ortalaması 26.
+Bunun dışındaki her şey lüks.
+Drug.clan aynı fikirde değil.
+Lego bu yıl 50 yaşına bastı.
+Fondiaria teklif veren tek şirketti.
+Ancak hükümet sözünün arkasında duruyor.
+Savaş olamaz.
+Bu arada enerji piyasası da serbest bırakılacak.
+Balkan ülkeleri vizesiz rejime nasıl tepki gösteriyor?
+Bu yıl da tamamen tartışmasız geçmedi.
+On sekiz vekil ise 59 ve üstü yaşlarda.
+Bu insanlar her yerde olabilir.
+Arnavut kamu kuruluşları alarma geçirildi.
+Askeri gerginlik yok.
+Bu yaz Christina'nın çalıştığı işyeri kapanacak.
+O zamandan bu yana da hastalık yayıldı.
+Bugün Pobjeda'nın üretimi oldukça zayıf.
+Krivokapiç ise talebi reddetti.
+Etkinlikle baharı karşılamak amaçlanıyor.
+Rakam, hükümetin %6'lık büyüme hedefini aşıyor.
+Kuş kafesim artık boş, çeşmede bir damla su yok.
+Eski rekor 24 saat içinde 1508 km idi.
+Sergi 30 Mayıs'a kadar İstanbul'da kalacak.
+TeliaSonera şirketin yüzde 37'sinin sahibi.
+Emekliler ayda ortalama 235 Dolar alıyor.
+Sırbistan'da siyasi değişimin lideri mi doğuyor?
+O sihirbaz değil, sadece yeni seçilmiş bir lider.
+Sizce bölgede bir istikrar dönemi yaşanacak mı?
+Ancak şimdiye kadar durum böyle olmadı.
+Veliler öfkeliydi.
+Turnuvanın başında oyun kalitesi düşüktü.
+Hasan tercüman olarak çalışmaya devam etti.
+Sivil can kaybı sayısı da tartışmalı.
+Osmanov 74 kilo serbest stilde güreşecek.
+Lucaman buna katılmıyor.
+Bundan önceyse ekonomi bakanlığı görevindeydi.
+Sizce bu sorun çözülecek mi?
+Mahkeme kararlarını bozamayız.
+Onun gözüne özellikle iki fotoğraf çarpmış.
+Yasaya karşı oy verilmedi.
+Kazı ekibi kemik parçalarına da rastladı.
+Rönesans komedileri kent meydanında sahneleniyor.
+Yarı maraton yarışını bir çift Avrupalı kazandı.
+Şimdiyse bu rakam 20 bin kadar arttı.
+Ancak bu kliniklerin çoğunun ruhsatı bulunmuyor.
+Bunun sonrasında gelen ateşkes kısa ömürlü oldu.
+Sergi Mayıs ayı sonuna kadar gezilebilecek.
+Pişirmeyi bırakın ve diğer malzemeleri ekleyin.
+Projeyi iki hükümet de finanse edecek.
+Çin'in Balkanlar'daki ‘İpek Yolu'
+Peki söz konusu beklentiler gerçekçi mi?
+Güçlü bir hükümet iş başındadır.
+Görüşmelerden sonra hiçbir açıklama yapılmadı.
+Peki güvenilirliğinden de bir şeyler kaybetmiş olabilir mi?
+Bu güzergâh geçen yıl askıya alınmıştı.
+Etkinlikte 60 ülkeden 500 karikatür yer alacak.
+İkili, KariZma adlı bir grup kurdu.
+Kötü haberse devlet finansmanı.
+Bunlara ek olarak ülkenin ekonomik durumunda bir değişiklik olacağını düşünüyor musunuz?
+Bu noktada değil.
+Daha fazlası da imar izni bekliyor.
+AP milletvekilleri beş yılda bir seçiliyor.
+Bitiki de bağlantının net olmadığına katılıyor.
+Türkler terör olaylarına son derece aşinalar.
+Blackard yaklaşık 10 bin kişiye de iş verecek.
+Çiftliğin tavukları.
+Konkordiya bu eylemde rol alacak mı?
+Seferler Haziran ayında başlıyor.
+Eğitim, bu toplum için hayati önem taşıyor.
+Kosmocell lisans için 81 milyon avro ödeyecek.
+Sizce bu uygulama, onaylansaydı, seçim sonuçlarının güvenilirliğini etkiler miydi?
+Seçimlerden sonraki duruma ilişkin bilgileriniz ne yönde?
+Türkiye Kaddafi'ye karşı görüşlerini daha güçlü bir şekilde dile getirmekte neden tereddüt ediyor?
+Koruganın prototipi 1950'lerde geliştirildi.
+Mezarın Miken dönemine ait olduğu sanılıyor.
+Birlik, tamir edilemeyecek bir hasar olmadan, değişken geometriyi ne derecede taşıyabilir?
+Yerleşmek için en uygun yerlerse tepelerdi.
+Balkanlar'da yaşanan çatışmaların özelliklerini netleştirebilir misiniz?
+Çoğu zaman dövülüp cinsel tacize de uğruyorlardı.
+Proje önümüzdeki 24 ay içinde hayata geçirilecek.
+Bu kadarla da kalmadı.
+Bu açılımlar daha ilk adımlar.
+Toplam maliyete ilişkin bir tahmin verebilir misiniz?
+Benzer bir oran bu yıl da bekleniyor.
+Türkiye tek başına başarabilir mi?
+Yumurta aklarını şekerle karıştırın.
+Yine teknolojiye güvenip olanlara kayıtsız kalmak mümkün mü?
+Sonuç olarak Ashdown müdahale etti.
+Fakat bunu yapmak için ülke sınırını geçmek gerekmedi mi?
+Bina cepheleri rötuşlanıp ağaçlar dikiliyor.
+Muzar üç buçuk yıldır cemaatin bir üyesi.
+Tören 20 Ekim'de gerçekleşti.
+Foruma yaklaşık 150 hasta ve 30 uzman katıldı.
+O zaman her şey berbat oldu.
+Sergi 21 Mart'a kadar devam edecek.
+Bu koşullar altında, çalışanların özverili olmasını beklemek akıllıca bir şey mi?
+Broz, büyükbabasının başarılarını gururla anıyor.
+Savcılar 15 yıl hapis cezası önerdiler.
+Portal yedi bölümden meydana geliyor.
+Fakat söz konusu anlaşma imzalanmayacak.
+Ülkeye aday statüsü 1999 yılında verilmişti.
+Yerel halka gidilecek kulüpleri sorduk.
+Her iki krediye devlet garantörlük edecek.
+Olanları öğrendikten sonra bile sessiz kaldım.
+Ancak yönetmelik şimdiden ekonomiyi etkiliyor.
+Karadziç'i kimin oynayacağı henüz belli değil.
+İlk birkaç gün her zaman en zorudur.
+Hırvatistan ise 6.
+Ayrıca, dört de Sırp polisi vardı.
+Partinin hükümet gündemini sunmak.
+Ancak ülkenin puanı hafif düşerek 13.00 oldu.
+Bir anda bütün coşku yok oldu.
+Sırp paralı askerleri Libya'da mı?
+Sizi ayakta tutan nedir?
+Ücretlerin kaldırılması her iki ülkenin de ekonomik gelişimine fayda sağlar mı?
+Karadağ da burada bir şans görüyor.
+Olaylarda iki gösterici hayatını kaybetti.
+Simitis, böyle bir planın bulunmadığını söyledi.
+Kurbanlardan ikisi kadındı.
+Müzik sektörü de benzer sorunlar yaşıyor.
+Çoğu zaman karaborsa veya suçla uğraşıyorlar.
+Ülke neredeyse üç yıldır liderden yoksun.
+Şimdi bir nedenleri daha var.
+Tebrik edilmeyi hak ediyor.
+Mali sorunlara rağmen, bunu tekrar başardı.
+Saldırının görüntüleri tüm dünyaya yayıldı.
+Kampanya gelecek ay tamamlanacak.
+Şimdiyse daha çok sembolik bir yemek.
+Baskılar çoktan kaynama noktasına ulaştı.
+Ben çok okurum.
+Oda, köşedeki televizyon dışında sessiz.
+Proje tamamlandığında bu durum da değişecek.
+DiCarlo bunun bölgesel etkilerini de vurguladı.
+İlk olarak, sağlıklı ve yetkindir.
+Ancak yeni hükümet bir azınlık hükümeti.
+Bu adamlar iyi ve kibardırlar.
+Aynı alanda iş aramaya devam mı ediyorlar yoksa başka alanlara mı yöneliyorlar?
+Sürekli tetikte olmak ne demek iyi biliriz.
+Papadopulos 74 yaşındaydı.
+En zengin siyasi sicile Ivaniç sahip.
+Bu stratejide ne tür yenilikler öngörülüyor?
+Hiç hasta olmadılar.
+Irak savaşı Türk turizmine ağır darbe vurdu.
+Ancak bu sürecin yurtiçi ayağı ne kadar rahat geçecek?
+Bir sonraki seçimler 31 Aralık'ta yapılacak.
+Makedonya'da yaygın bir hayal kırıklığı yaşandı.
+Tabii ki burada olmanın kötü tarafları da vardı.
+Bir sorunu kabullenmezseniz çözemezsiniz.
+Fakat herkes mutsuz değil.
+Ziyaret 20 Aralığa değin sürecek.
+Ancak eylemin siyasi boyutu da var mıydı?
+Zaman geldi.
+Tablet yüzyıllarca ayakta kalmayı başarmış.
+Gelişmelerden tek etkilenenler siyasiler değil.
+Girilmişse, park görevlisi hiçbir şey yapmıyor.
+Restoranlar insanlarla doluydu.
+Şimdi ise gurur duyulacak bir tesis haline geldi.
+Dünya Kupaları da bunun için yapılmıyor mu?
+Bu ülkenin zamanı azalıyor.
+Vetëvendosje liderinin tutuklanması hareketin siyasete katılması için yakıt sağladı mı?
+Uzmanlara göre aksi takdirde hız kaybedilebilir.
+Biletler 50 avrodan satıldı.
+Bu durum bir an önce değişmeli.
+Bazı adaylar tanınmış küresel şirketlerden geldi.
+Sizce Sırp ekonomisi en büyük sıkıntıyı yılın hangi döneminde yaşayacak ve neden?
+Bu dallar Badnik'te yakılacak.
+Oylamanın Nisan ayında olması bekleniyor.
+Şimdilik yol istikrara gidiyor gibi görünüyor.
+Başka bir şey daha gördük.
+Yaralanmalara sık rastlanıyor.
+Cumhurbaşkanı bu sorunu çözecek mi?
+Mladiç 2000 yılından beri kanundan kaçıyor.
+Proje 2010 yılında tamamlanacak.
+Önceki ifadeleri kanıt olarak kullanılacak.
+Ancak bu talep geri çevrildi.
+Karadziç 12 yıldan uzun süredir kanundan kaçıyor.
+Herşeyi peşin nakit ödedim.
+Karı severim ama bu çok fazlaydı.
+Reformlar gerekli olacak.
+Ancak gelecek hala belli değil.
+Sadece bir tur oylamaya gerek duyuldu.
+Kamu istihsalleri de sorun olmaya devam ediyor.
+Hukukun üstünlüğü.
+Siz de aynı fikirde misiniz?
+Yetersiz ve yeterli olduğu noktalar neler?
+Eleftheriou 75 üzerinden 73 puan topladı.
+Gora, yaşamak için kolay bir yer değil.
+Hazır mısınız?
+Sergi 13 Aralık'a kadar açık kalacak.
+Her iki taraf da ayrı sorumluluklara sahiptir.
+Artık siyasi cinayet işlenmemesi de iyi bir şey.
+Türk hükümeti onu dört yıl rahat bırakmış.
+Konukların %66'sı yabancılardan oluşuyor.
+Ancak Glavas henüz gözaltına alınmadı.
+Dayton uygulamasında kim kimdir?
+Daha iyi bir hayat düşünülemezdi.
+Kopenhag kriterlerini hepimiz biliyoruz.
+Bu yılki dalış ekibinde Vandermeulen de yer aldı.
+Mevcut işsizlik oranı %12,4.
+Mantıklı uzlaşma nedir?
+Kim demiş futbol yalnızca erkeklerin ilgisini çeker diye?
+Olayla ilgili soruşturma devam ediyor.
+Ona göre çabalar işe yarıyor.
+Ve tabii ki İnternet.
+Kosor'u bir takım acil sorunlar bekliyor.
+Yine de seçenekler var.
+İhalede sadece bir rakip, İtalyan Air One vardı.
+Makedonya'ya dünyanın kapılarını da açıyor.
+Bir soruşturmanın devam ettiği söyleniyor.
+Lafı ağzımızda gevelemeyeceğiz.
+Bu sandık merkezleri ikinci turda açık olacak.
+Böylece insanlarla iletişim kurabildim.
+Kurallar kamptan kampa değişiyor gibi görünüyor.
+İnşaat iki yıl sürecek.
+Diğerleri de hep birlikte işi bırakabilir.
+Kimseyi savaşa gönderiyor değiliz.
+Popüler şarkıcının savcılarla anlaşma yapması, yasaların ona işlemediği anlamına mı geliyor?
+Papulyas seçimlere rakipsiz katılıyor.
+Mevcut ortam, bir tür balon olarak tanımlanabilir mi?
+Tabii ki menünün başında balık yer alıyor.
+Festival 24 Nisan'da sona eriyor.
+Ailenin ülkeden ayrılması yasak.
+Bu kuralı ihlal edenlerse 40 euro ceza ödeyecek.
+Arnavutluk, pazar sınırlamalarını kaldırdı.
+Bugüne kadar eyalette tespit edilen vaka yok.
+Kısıtlı kaynaklar tedavi kalitesini de etkiliyor.
+İngiltere'nin katkı iadesi karmaşık bir mesele.
+Bu, hükümetin projeye ikinci destek verişi.
+Bu ev sahipleri için büyük bir sorun.
+Yetkili bütün görevlerinden azledildi.
+Japonya'da ise özel sektörün payı yüzde 80.
+Kulelerde bir çok bar ve restoran bulunuyor.
+İlk ödül Mayıs ayında verilecek.
+Şirket bitmiş ürünlerini satmakta başarılı.
+Aralık 1993'e kadar bu görevde kaldı.
+Sırbistan'da 81 adet kayıtlı parti bulunuyor.
+Ülke Olimpiyatları 22. sırada tamamladı.
+Barysch bu görüşe katılıyor.
+Otosansüre yaygın şekilde rastlanıyor.
+Ancak hüsran da söz konusu.
+Daha somut konuşalım.
+Şimdi ise herşey yerine oturuyor.
+Ancak muhalefet aynı fikirde değil.
+Odalar dört kişilik ve oldukça genişti.
+Grupta iki kişide yüksek ateş vardı.
+Adalet yerini bulacak.
+Siz bu meseleyi nasıl değerlendiriyorsunuz?
+Genelde izinleri almak aylar sürüyor.
+Fakat süreci geciktiren iki etken oldu.
+Tesisi yılda 350 bin kişi ziyaret ediyor.
+Ancak Yanoku işin özünün zaman olduğuna inanıyor.
+Bir diğer mesele de domuz gribiydi.
+Teklif süresi 48 gün içinde sona eriyor.
+Yumurtalar daha sonra rahme enjekte ediliyor.
+Mitorvica'daki Sırplar bir gösteri yapıyor.
+Durum bir gecede değişmeyecek.
+Onur'un gözlerindeki büyü ...
+Verilen süre 29 Eylül'de sona eriyor.
+Acaba ülke, Moskova'dan gelecek destek konusunda gereğinden fazla umut besliyor olabilir mi?
+Bu da duruma siyasi bir açı getirmiyor mu?
+Madde, doğal uranyumun %1'den azını oluşturuyor.
+Peki bu devasa hesabı kim ödeyecek?
+Seçim pusulaları her iki oyda bir yakılacak.
+Olimpiyat için sağlık sistemi de iyileştiriliyor.
+Sırbistan kuzey Kosova'da vergi toplayabilir mi?
+Proje 700 milyon avro tutacak.
+Siparişin bedeli 40 milyon avro olacak.
+Cavcav her iki teklifi de geri çevirdi.
+En başarılı uygulamalar, herkes için aynı vergi oranlarının uygulanması anlamına mı geliyor?
+Bu da fiyatarda düşüşe yol açacak.
+Masada en az iki seçenek bulunuyor.
+Bu kez durum farklı.
+Peki Türkiye'nin çabaları sonuç veriyor mu?
+Credo Banka birkaç yıldır güç durumdaydı.
+Parlamento değişikliği geçen ay kabul etmişti.
+Bizim saymaya başladığımız nokta burası.
+Bu, bir yılda yapılan dördüncü zam oldu.
+Atık yönetimi bir ülkenin yaşam tarzını yansıtır.
+Anlaşmadan en az iki büyük fayda bekleniyor.
+Nikica üç yaşından beri tatil köyünde yaşıyordu.
+Bir de yatırım meselesi var.
+Bu yapılar güçlü ve işlevsel olmalıdır.
+Radikal Parti'nin parlamentoda 17 üyesi olacak.
+Hükümetin, bu ekonomik sorunların çözümüne yönelik etkin bir planı var mı?
+Fakat bu tezatın bir açıklaması var.
+Personel mümkün olan en iyi eğitimi aldı.
+Ancak o tarihte caminin sadece enkazı kalmıştı.
+Bu konuda mutlaka bir şeyler yapılması gerekecek.
+Ancak bu seçeneği uygulamak o kadar kolay değil.
+Daha önce böyle bir ifade kullanılmamıştı.
+Demokrasilerde çare tükenmez, ama herşey ulusal temelde bölünecekse seçim yapmanın mantığı ne?
+Romanya'nın arzında da bir düşüş meydana geldi.
+Tek sorun yatırım ve zaman kaybı da değil.
+Hamanov aleyhindeki davaysa beş yıl üç ay sürdü.
+Ama maalesef siyasi konular gündemi zaptediyor.
+Bu yıl söz konusu rakam ikiye katlanacak.
+Starova'nın kitabı dört aday arasından seçildi.
+Ayrıntılı bilgi verilmedi.
+Özellikle de genç kızlar size bayılıyor.
+İnsanlar neden grev yapıp bir günlük yevmiyeyi kaybeder?
+Bu müzakerelerin ilk turu 25 Ocak'ta yapılacak.
+Bunun temel nedeni ise vergiler.
+İsmin ne önemi var ki?
+Bu konuda gerçek nedir?
+Bu, blok içinde bölünmelere yol açabilir.
+Hırvatlar dostluk maçını 2-0 kazandılar.
+Rapor resmi olarak Cuma günü yayınlanacaktı.
+Para iki dilim halinde verilecek.
+Ancak bazıları duruma şüpheyle yaklaşıyor.
+Arnavutluk'ta ihracat zayıf.
+Sırbistan'da da tepkiler aynı.
+Dikkat Edin!
+Yeni anlaşma Mart 2012'de imzalanacak.
+Bu, Duka'nın görevdeki üçüncü dönemi olacak.
+Belgrad hareketi kesin bir dille eleştiriyor.
+Pahor bu hareketi eleştirdi.
+Ancak yasa yaygın bir şekilde uygulanmıyor.
+Ancak Sırpların hepsi değişikliği kabul etmiyor.
+Son on yıldır süren savaşı kazandı.
+İhracat mı dediniz?
+İsterseniz bu seçeneği seçebilirsiniz.
+İki milletvekiliyse oylamaya katılmadı.
+Türk medyası da yasağa ateş püskürdü.
+Sırbistan'da tepkiler karışık oldu.
+Başkent Fira bir tepenin üzerinde yer alıyor.
+Hırvatistan'a özgürlüğünü kazandırdı.
+Sizin bu konuda görüşünüz nedir?
+Bence olmama olasılığı oldukça yüksek.
+Herkes, Gana'nın kupayı kazanmasını hayal ediyor.
+Bunlar ilk adımlar.
+Diğer ikisiyse katılmayacaklarını bildirdi.
+Ama sonra pazarlık başlıyordu.
+Bu misyon doğrudan istikrar sağlama amacına yönelik olarak mı çalışıyor?
+Dragulescu kategorinin favorisiydi.
+Oğlum nereye uçup gitti?
+Yöntem her bölgede aynı.
+Etkinliğin bu yılki ortak ülkesi Türkiye idi.
+Bakış açıları çok farklı.
+Hastalık 430 bin hastada ileri seviyede.
+Açılış törenleri şahaneydi.
+Bu hiç de haksız bir heveslilik değil.
+Fikir karışık tepkilere yol açtı.
+Arnavutluk'ta turizm hâlâ emekleme çağında.
+Bu süreç de yıllar alabiliyor.
+Bunu beğenmeyen istediği yere gidebilir.
+Bu durumu nasıl açıklıyorsunuz?
+Sonuçta söz konusu isim ne anlama gelmektedir?
+Ülkenin Latin alfabesindeki alan adı ise bg.
+Hasta antibiyotik ve vitamin tedavisi görüyor.
+Çoğu zaman ehliyetler beş gün içinde veriliyor.
+Kazanan firma Şubat ayı sonunda açıklanacak.
+Şimdilerde oylar yeniden sayılıyor.
+Banka şu anda yeniden yapılandırma altında.
+Sırp Ordusu ihtilafı önlemek için nasıl tepki gösterecektir?
+Çok sevdiğimiz mutlu bir gün.
+Çalışmalar devam etmeli.
+Bunun gibi sorunlar uzlaşmayla çözülmelidir.
+Davanın tüm süreci adil şekilde gerçekleştirildi.
+Seyirci de onu gürültülü alkışlarla ödüllendirdi.
+Konuttan sonraki öncelik eğitim.
+Proje 2012 yılında hizmete girebililr.
+Diğerleri ise çeşitli azınlıklara ayrılacak.
+Muhalefet bu sava inanmıyor.
+Türkiye bir diktatörlük değil.
+Her iki oyuncu da takımdan atıldı.
+Mehmed D. olayla ilgili olduğunu reddetti.
+Burada oy kullanımına son verildi.
+Aile genelde hükümetin bir adım önünde gidiyor.
+Yasalarla da başı belaya girdi.
+Sadece Bükreş'te 1200 polis memuru açığı var.
+Bunun değişmesini beklemiyorum.
+Bu durumun vatandaşlar açısından anlamı nedir ve genel müdürlüğünüze ne gibi faydaları olacak?
+Artık güvenlik bütün ülkede sağlanacak.
+Sırbistan ve Karadağ sıralamaya alınmadı.
+Kalan yarısı ise doğaya atılıyor.
+Ben de, neden bunları burada yapmayalım ki dedim.
+Hazırlıklar sekiz yıldan uzun sürdü.
+Komite'nin bu konuya ilişkin görüşleri ne yönde?
+Ancak bu tarihten beri momentum tekrar durdu.
+Maç, en azından Sırplar için tam bir felaketti.
+Saldırgan tutuklandı.
+Görüşmelerden bir sonuç elde etmenin tek yolu bu.
+Müze Gecesi beş yıldır her yıl düzenleniyor.
+Priştine yeni, büyük bir heykele kavuşuyor.
+Bunun sonuçları ise oldukça ağır olabilir.
+Bölgede eşitsizlikler var ve hatıralar daha taze.
+Tehdit daha sonra geri çekildi.
+Ancak zanlı savaş suçu işlediğini reddetti.
+Ülke pek çok açıdan hızla büyüyor.
+Nüfusun çoğunluğunda kızgınlık var.
+Turnuva 3 Ağustos'ta sona eriyor.
+Mevcut kadronun yaş ortalaması 30'un altında.
+Bu profesyonelce verilmiş bir konser.
+Ancak Slaveski istifa etmeyi reddetti.
+İş böyle işliyor.
+Prosedürleri ve proje seçim kriterlerini gevşetmeyi düşündünüz mü?
+Fakat uzmanlar, buna değeceğini söylüyorlar.
+Bosnalı Sırplar mahkeme konusunda referanduma mı gidiyorlar?
+Şu anda ise bu İnternet üzerinden yapılabiliyor.
+Muhalefet potansiyel seçim kaosu hakkında uyardı.
+Kosor da bu duyguları yineledi.
+Almazsak, yine bir şey olmayacak.
+Şimdi ise yeterli düzeyde.
+Ülke şu anda iki federasyona üye.
+Adaylar arasındaki az fark sürpriz oldu.
+Oyuncu milli takımla 55 karşılaşmaya çıkmıştı.
+Güzel bir elyazısıyla bir kitap yazdım.
+Yunanistan'ın sorununu çözmek için asıl yükü kim taşımalı?
+Hükümet ayrıca bir dizi skandal da atlattı.
+Blok bu yönde 1,5 milyon avro kaynak sağlıyor.
+Birincisi birliği ikiye bölmek.
+Kampanyası kapsamında eğitim kursları düzenlendi.
+Diğer üç koltuk bağımsız adaylara gitti.
+İşe kabul edilmenizi sağlayan özellikleriniz nelerdi?
+O suçlu on yıldır hayatımızı yönlendiriyor!
+Taliban'ın İstanbul adresi mi var?
+Rodos'a gidiş dönüş biletiyse adam başı 250 avro.
+Grup eyaletin kesin statüsü konusunda rahat.
+Bence zaman bunun böyle olmadığını gösterecek.
+İlham her zaman içinizde olmalıdır.
+Belgrad'daki camiyi bile ziyaret etti.
+Birisi beyazlar için dediler.
+Çalışmaya sekiz ülkeden 18 bilim insanı katıldı.
+Bu olayı nasıl değerlendiriyorsunuz? Partiden ayrıldığınızda siz de benzer şeyler yaşadınız mı?
+İşlemi diğer hamurla tekrarlayın.
+Ancak ülke bunu henüz yapmış değil.
+Projenin tahmini maliyeti 190 milyon avro.
+Biz realiteyi dikkate alıyoruz.
+Sırbistan için tarihi zafer! 37 yıl sonra Almanya ile ilk maç.
+Orta büyüklükteki bir fırın tepsisini yağlayın.
+Hükümet de bu çağrılara kulak tıkamadı.
+Fakat Morar yılmıyor.
+Osmanagiç'in iddiaları henüz doğrulanmış değil.
+Soruşturma geçen yıl başlatılmıştı.
+Katılım oranı yaklaşık %47 olarak gerçekleşti.
+Çocuğumuz olsa ne yapacaktık?
+Romanya 1000 icat sundu.
+Gerisiyse henüz değerlendirilmedi.
+Mesleğinin yanlış anlaşıldığını söylüyor.
+Üç bebek olay yerinde boğularak can verdi.
+Arnavutluk'ta, sorun biraz farklı.
+Llapashtica, serginin benzersiz olduğunu söyledi.
+Altun, daha fazlasının gerekli olduğuna inanıyor.
+Peki yıllardır serbest ticareti savunan gelişmiş ekonomileri bu düşüncelere sevkeden ne?
+AB planın uygulanmasına nezaret etmeyi bekliyor.
+O zamandan bu yana 1.000 engelli iş buldu.
+Anlaşma Ekim ayı başlarında kesinleşti.
+Yeni tesisin yıllık kapasitesi 8,5 kWh olacak.
+Bu diyalogda siz de yer alacak mısınız?
+Sonuç olarak tarifelerde indirim bekleniyor.
+Militanlar neden Kürt aydınlar için ölüm fermanı çıkarıyorlar?
+Bunun için de çalışmak gerekli.
+Ohri Gölü'nde balık tutan turistler görülüyor.
+Protestocular salondan çıkarıldılar.
+Onun yerine öğretmen olmak istiyor.
+Tahsilat firmaları altın çağlarını yaşıyorlar.
+Priştine şehir merkezinden bir manzara.
+Skoriç görevinden iki ay önce uzaklaştırılmıştı.
+Şu anda şirket tam özelleştirmeye hazırlanıyor.
+Tesis 40 megawatt'lıkkapasiteye sahip olacak.
+İlk 1994 yılında gerçekleşmişti.
+Vatandaşlar en çok hangi ayrımcılık uygulamalarından şikayetçi?
+Kadın kaçıp Bulgaristan'a dönmeyi başarmış.
+Önerinin içeriği süpriz olmadı.
+Soygunda iki banka çalışanı hafif yaralandı.
+Sanatseverler de bu sonbaharı boş geçirmediler.
+Kuyruklar daha da uzayacak.
+Proje birkaç ay içinde başlayacak.
+Bu sefer hükümet çevrecilerden yana oldu.
+Biri gitti, geriye 600 binden fazla kişi kaldı.
+Aktör 12 Mart Çarşamba günü kanserden ölmüştü.
+Ne gibi faaliyetlerde bulunuyor?
+Ardelean tartışmalı bir seçimdi.
+Artık hareket geçme zamanı gelmişti.
+Sizce Kosova, bölgedeki diğer ülkelere örnek oluyor mu?
+Bunun üzerindeki miktarlar vergiye tabi olacak.
+Ancak pek çok Arnavut bundan şüpheli.
+Yaşlılara kim bakacak?
+Ancak daha yapılacak çok iş var.
+Yatırımlar 3,2 milyon avroyu buldu.
+Sonrasında Stoacı bir hava esti.
+Tadiç'in kararı Demokratlara da yarayacak.
+Benzer bir açıklama komiserden de geldi.
+Şirket haftada üç sefer yapmayı planlıyor.
+Bu süreçle ilgili fikriniz nedir?
+Daha ayrıntılı bilgi verilmedi.
+Aynı proje 2006 yılında Belgrad'da da başlayacak.
+Fakat bunun olacağına herkes inanmıyor.
+Proje 13 milyon avro değerinde.
+İki ayrı dava Salı günkü duruşmada birleştirildi.
+Hükümler sert tepkilere yol açtı.
+Kısa dönemli kamu dış borç oranı düşmüştür.
+Bu konuda bir yorumunuz var mı?
+Tatbikatta yaklaşık 1500 asker görev aldı.
+Anlaşma olumsuzluklar olmadan gerçekleşmedi.
+Tapınağın saat kulesi, 47 metre yüksekliğinde.
+Koleksiyonda 25 seçilmiş eser yer alıyor.
+Bir sonraki müzakere turu Şubat ayında yapılacak.
+Afrika dünya.
+Artık bu kesinlikle kader maçı olacak.
+Düşüş genel ekonomik krize bağlandı.
+Kamuoyunda karşıt görüşler var.
+Kıbrıs Türk kesimi ise evet oyu verdi.
+Umarım finalden sonra teklif getirirler.
+Polisin soruşturması devam ediyor.
+Olaylarda bir Arnavut ve dört polis yaralandı.
+Ancak anlaşmalardan herkes memnun değil.
+İçlerinden Sırp Rukavina çıktı mı?
+Etkinlik Haziran ayına kadar devam edecek.
+Parun şu anda otobiyografisi üzerinde çalışıyor.
+Bu faaliyetleri Bulgar uyruklular destekliyordu.
+Buradan gelen sinyaller ne yönde?
+Asıl geçişse Aralık 1997'de gerçekleşti.
+Ancak bu plan şimdilik suya düşmüş görünüyor.
+Sırbistan ilk olarak 13. yüzyılda krallık oldu.
+Bu oran, son 16 yılın en düşük oranı.
+Burası benim için harika bir yer oldu.
+Siz bu soruna nasıl bir nihai çözüm öngörüyorsunuz?
+Sahnede çalışırken hep birlikte gülüp eğlenmemiz.
+Ancak belge ileriki bir tarihte imzalanacak.
+Ancak ülkenin notları hemen revize edilmeyecek.
+En az destekleyenlerse 65 yaş üzerindeki kesim.
+O ana kadar meclis salonlarına kaos hakimdi.
+İki halterci Pekin'de de altın için yarışacak.
+Zanlı gıyaben yargılanmaya başladı.
+Sanader'i henüz ailesinden ziyaret eden olmadı.
+Ancak herkes bu kadar iyimser değil.
+Ön teklifler 26 Kasım'a kadar kabul edilecek.
+Günümüz Sırbistan'ı da bu yaklaşımı devraldı.
+Fakat bunlar yeni bir şeffaflık döneminin başlangıcı olabilir mi?
+Tahsis 2013 yılına kadar devam edecek.
+Romanya erkekler dalında ikinci oldu.
+Ödemeler, ticari bankalar tarafından yürütülüyor.
+İsrail'in önce bunu kabul etmesi gerekiyor.
+Niçin?
+Seçmen katılımı %80 civarında gerçekleşti.
+Dava büyük olasılıkla Hırvatistan'da görülecek.
+Fakat en önemli alan yerel yönetim.
+İki bölümlük ropörtaj dizisinin ikinci bölümü.
+Şenlikler üç gün sürüyor.
+Bu arabalar yakında dünya sahnesine çıkacaklar.
+Bunu sağlayan nedir?
+Bu yılki festival 28 Şubat'ta sona eriyor.
+Yaklaşık 15 otobüs yollara çıktı bile.
+Batı Balkanlar nereye doğru gidiyor?
+Kosova'nın kuzeyini kim kontrol ediyor?
+Peki bu iki ülkede ekonomi ne durumda?
+Slyivancanin ise hala kayıp.
+İki skandal halkın da güvenini zedeledi.
+Sizce ekonomik iyileşme, ülkeler ve uluslar arasında barışı sağlayacak mı?
+Anneler doğum iznindeyken tam maaş almıyorlar.
+Makedonya'nın iyi bir ev sahipliği yaptığını düşünüyor musunuz?
+Türkiye Fransız silahları da satın alıyor.
+Çalışma 12 Nisan'da yayınlanacak.
+Çocuklarını geri kabul ediyorlar mı?
+Foruma 400'de fazla kişi katıldı.
+Bu tavırlar spora da yansıyor.
+Onun görevi kültürel çeşitliliktir.
+En büyük ve en değerli firmalar hala devlet malı.
+Fabrikada 250 kişi çalışacak.
+"Siyasi kriz" güvenlik durumu üzerinde herhangi bir etki yarattı mı?
+Belki bu kez onların zamanı gelmiştir.
+Ardından Olimpiyat ateşi yavaş yavaş söndürüldü.
+Yunanistan'da hayat artık çok zorlaşmıştı.
+Sizce bölgede güvenlik koşulları açısından ilerleme kaydedildi mi?
+Oylar hala sayılıyor.
+Fakat yine sekiz çocuğumuzu öldürdüler.
+Amacımız kasabamızı marka haline getirmek.
+Şu anda mecliste oylanmayı bekliyor.
+Halandri'de yaşayan İoannis Zaharopoulos.
+AB hareketi büyük oranda memnuniyetle karşıladı.
+Ancak bazıları partinin dağılmasından korkuyor.
+Ancak rakibi yorum yapmaktan kaçındı.
+Sınır kapıları kısıtlı askeri bölge ilan edildi.
+Uygulamaya Mart 2008'de başlanacak.
+Bu da hükümetin elinde olmayan bir meblağ.
+Bunu Demokratlara durmadan söylüyoruz.
+Bosna-Hersek'te kampanya dönemi sona ererken, medya kuruluşları bunu adil şekilde yayınlıyorlar mı?
+Sırbistan için yeni bir yol ayrımı mı?
+Fakat mahallede hiçbir kültür mekanı yoktu.
+Artık kimseye zarar veremezler.
+Masalardan birinde dört kadın lafa girdi.
+Liste her yıl biraz daha uzuyor.
+İki diğer şüpheli halen aranıyor.
+Sorun şu ki ortada gerçekçi bir problem yok.
+İtalyan Giuliano Razzoli ise üçüncü oldu.
+Bu hiç de kolay olmadı.
+Buna rağmen sağlanan fayda çok büyük oldu.
+Yine de iki polis memuru hafif yaralandı.
+Bayanlar sekizlide Rumenler son şampiyondular.
+Kazançları iyiymiş.
+Onlara nerede çalıştığımızı bile soruyorlar.
+Diğer beş adayın daha da az oy alması bekleniyor.
+Soruşturma sekiz ay sürdü.
+Bunu derken sigara içiyordu.
+Hileler yapıldı.
+Görüntü tıpkı bir sirki andırıyor.
+Dilekçeye 5 bin civarında imza toplandı.
+Karar sizi şaşırttı mı?
+Herşeyi kendim yaptım.
+Anketler sonuç vermiyor.
+Türkiye reformu desteklemek için yeterli çaba gösteriyor mu?
+Genel anlamda reformlar hızlı ilerliyor.
+Önceden hakimleri milletvekilleri seçiyordu.
+Fiyatlar artarken, özel harcamalar düşecektir.
+Aslında koşullar epey çeşitlilik gösteriyor.
+Peki kaçı madalya alabilecek?
+Görüşler farklı.
+Üçlü 1 Ekim seçimlerinden galip çıkmıştı.
+Aralık ayındaki ortalama aylık ücret 375 avroydu.
+İstikrarı korumak önceliğimiz olacak.
+Bu da Cuma günü gerçekleşti.
+Bizlere görevinizi açıklayabilir misiniz?
+Seçimlerde toplam 46 bin 325 aday yarıştı.
+Yumurta aklarını bir çimdik tuzla çırpın.
+İnsanın temel bir ihtiyacı, temel bir hakkıdır.
+Halkın baskısı oldukça yüksek.
+Doğrudan bir yanıt alamadım.
+Söz konusu işlem Salı günü gerçekleşti.
+Etkinlik 1972 yılından beri düzenleniyor.
+Maktouf'un cezası Haziran ayında sona erdi.
+Orada yapılacak hâlâ bir dolu iş var.
+Yeni Kosova için çalışmalıyız.
+Filtreleri aşmaya çalışmak suç sayılacak.
+Ancak bu durum artık değişmeye başladı.
+Ama bunun dışında pek bir değişiklik yok.
+Her şey iyi.
+Romanya'da kurumlar gelir vergisi oranı yüzde 16.
+Bu kural Kosova için de geçerlidir.
+Yeterli kaynak yok.
+Çok az kişi mantıklı secenekler önerdi.
+Ancak bu iş şu ana kadar hiç de kolay gorunmuyor.
+Fakat toplantı asla gerçekleşmedi.
+Bu mesaj da anayasa taslağına eklendi.
+Dağa tırmanmaya devam ettik.
+Risk alacak cesareti göstermeliyiz.
+Vlasiç'in şampiyonluk derecesi 2.05 metre.
+Yanında patates kızartması da ister misiniz?
+Ne tür tepkiler aldınız?
+Onlar için yaptıklarınızdan memnun musunuz?
+Yetkililer Pazar günü kampı yerle bir ettiler.
+En değerli çıkartmalar en nadir olanlar.
+Güçlü patlama kentin büyük bölümünden işitildi.
+Hükümet bölünme olasılığını görüşüyor mu ve sizce bu iyi bir fikir mi?
+İyi haber Zagreb'de iyimserliği artırdı.
+İşin bittiğine dair resmen imza atmadım.
+Söz konusu bütçeye eğitim çalışmaları da dahil.
+Olayla ilgili iki şüpheli tutuklandı.
+Ne yazık ki insanlar şiddete fazla eğilimli.
+Olağanüstüydü.
+Yine de fırsatlar kapısı açık görünüyor.
+Podstrana turizm kurulu gelişmelerden memnun.
+Diğer iki zanlı henüz yakalanamadı.
+Tek sorun rekabetin giderek artması.
+Sırbistan krizi atlatırsa ekonomisi ne derece sağlıklı olacak?
+Neden on yıldan uzun bir süre bunun olmasına izin verildi?
+Şahsın uyruğu bilinmiyor.
+Mülteciler ise çok nadiren Türkçe konuşuyorlar.
+Kısıtlamalar 31 Aralık 2011'e kadar sürecek.
+O çift hâlâ birlikte mi?
+Parti son seçimlerde parlamentoya girememişti.
+Çekimlere 2011'de başlayacağız.
+Gemi seyahati düzenleyen şirketlerin, yeterli rıhtımı bile olmayan bir yeri niçin tercih etsin?
+Katılımcılar eğitim reformunu tartıştılar.
+Ankette 1.255 vatandaşın görüşleri alındı.
+Çok büyük bir musibet.
+Yani durumda bir değişiklik olmayacak.
+Dünya ekonomisinde kamu mallarının üretiminden kim sorumlu?
+Bunların çoğu 20 ile 24 yaş arasında.
+Ancak 126 sandalyelik çoğunluğu sağlayamadı.
+Bu hızlı çözüme rağmen sorunlar hâlâ karışık.
+Modernizasyon projesi iki yıl önce başladı.
+Toplam nüfus sadece 2 milyon.
+Bu kampanya da benzer sorunlarla karşılaştı.
+Konferans 4 Ekim'de sona erdi.
+Para enerji ithalatına harcanacak.
+Ancak ardından hükümet imrenilecek iki adım attı.
+Tose Proeski'nin barış hayali gerçeğe dönüşebilecek mi?
+Bu miktar fazla olmasa da zamanında ödeniyor.
+Ancak habere Belgrad'daki herkes sevinmedi.
+Şu an bu konuda gelinen aşama nedir?
+Sadece iç siyasete bakmamalı.
+Sonunda kendisini güvende hissetmeye başlamış.
+Taşınmaz ordu malları konusunda anlaşmaya varmaya yetecek kadar iyi mi?
+Türkiye, Libya'da çok büyük işler yapıyor.
+Hiçbir zaman belli bir örneği takip etmedim.
+Fakat tek yön bu değildir.
+Fikir dünyanın pek çok ülkesinde başarı kazandı.
+Ancak bu hedefi tutturmak biraz zor oldu.
+Sırbistan'ın şu anki nüfusu 7,3 milyon.
+Değişen tek şey teknoloji.
+Buun nedenlerinden birisi trafik sorunuydu.
+Ancak Yunanlılar işini biliyordu.
+Festivale bölgeden katılım da yoğun oldu.
+Bu girişimin amacı nedir?
+İkinci sırada Slovenya bulunuyor.
+İşte o zaman gerçekten gittiğinin farkına vardım.
+Hadziç hâlâ firarda.
+Sırbistan bu sorunlar nasıl başa çıkacak?
+Başbakan, muhalefetin katkılarını da kabul etti.
+Moisiu bölgenin Avrupa hedeflerini de vurguladı.
+Fakat diğerleri ona katılmıyor.
+Bu örnekte ise iki farklı görüş var.
+İlk tur seçimler 27 Aralık Pazar günü yapılacak.
+Oylama 7 Kasım'da yapılacak.
+Grup bis için sahneye iki defa geri geldi.
+Bazı işçiler de aylardır maaşlarını alamıyorlar.
+İçki perakende sektörü içindeki tepkiler karışık.
+Anlaşmanın gelecek ay imzalanması bekleniyor.
+Bu iki ülke ile ilişkileriniz nasıl?
+O bile böyle diyorsa ben daha ne söyleyebilirim?
+Bu bizi mahveder ...
+Felsefemiz?
+Fakat morallerin yüksek olması, Makedonya'nın zor zamanları atlatması için yeterli olacak mı?
+Prensipte aynı.
+Ana kara zamanda seyahat izlenimi veriyor.
+Teklif verme süresi 4 Ekim'de sona eriyor.
+Peki bu para yerinde harcandı mı?
+Siz buna inanıyor musunuz?
+Kıbrıs 1959'da bağımsız bir cumhuriyet olmuştur.
+Meclisin görev süresi Mart ayında sona erdi.
+İki taraf da Ashdown'un kararından hoşnut değil.
+İlki 17 Mart'ta Doboy'da öldü.
+Ne olsa herşeyin büyüyüp çiçek açtığı bir zaman.
+Sırp diva Ceca hapse mi girecek?
+Ulusoy 2 dakika 24 saniye su altında kaldı.
+Böyle bildirgeler açıkça yayınlansa nasıl tepki verirsiniz?
+Bunda ne kadar ciddiler acaba?
+Amerika'da çok çeşitli filmler var.
+Gözleri burada, ama yurtdışını da takipteler.
+Parti, kararı temyize götürdü.
+Bunlara bile geçici çalışma izni verilecek.
+Ve evet, doğru karar vermişiz.
+Festivale Balkanlar'dan da gelenler oldu.
+Fakat bu, sendikaların zaferini perçinlemiyor.
+İşe alım planı işsiz oranını da azaltacak.
+SC yetkilileri yanıt vermekte gecikmediler.
+Fakat başkan suçlamayı reddediyor.
+Stratejik özelleştirme kolay bir girişim değil.
+Bu konudaki yorumlarınız neler olacaktır?
+Ancak, bunun kolay olmayacagi belirtiliyor.
+Ancak Rusya hala şüpheli.
+Aslında ciddi ilerleme kaydedildi.
+Shevchuk modern bir siyasetçi.
+Ancak yeni yasa herkese uygulanmayacak.
+Sohbete oturuyor.
+Gösteriye 30 ülkeden 120 genç sanatçı katıldı.
+Bir önceki zam Ocak 2010'da yapılmıştı.
+Gündemde ilk sırayı ikili askeri işbirliği aldı.
+Kilisenin buldozerle yıkılması yedi gün sürdü.
+Borovcanin de soykırımda işbirliğiyle suçlandı.
+Zirve iki yılda bir düzenleniyor.
+Sizce iki ülke arasında bu bağlamda bir parallellik kurulabilir mi?
+Araç geri verilmedi.
+Oysa o bundan çok daha fazlasıdır.
+Ayrıca 50 istihkamcı da yaralandı.
+Biz dürüstlük istiyoruz.
+Her ikisi de bunu daha önce kabul etmişti.
+İlk mağaza ise 2011 yılında Belgrad'da açılacak.
+Ancak sendika liderleri buna istisnalar.
+Sırbistan nükleer enerjiye hazır mı?
+Top artık uluslararası toplumun karar organında.
+Aynı kural bakan yardımcıları için de geçerli.
+Kısa vadeli kredilerin notu ise F3.
+Yine de farklılıklar sürüyor.
+Podujevo tek örnek değil.
+Sayılar şaşırtıcı boyuttadır.
+Bu konuda Balkanlarda pek çok şey söyleniyor.
+Özür dileriz.
+Bu yaklaşıma katılıyor musunuz?
+Özelleştirme fonu 520 milyon avroya ulaştı.
+Şimdi tekrar mücadele ediyorlar.
+Türkiye gözlemci ülke olarak katılım gösterdi.
+Birlik, ekonomik milliyetçilik konusuna nasıl yaklaşmalı?
+Patlamanın 10 km uzaktan işitildiği bildirildi.
+Bu da bir varoştan başka bir şey değildir.
+Avrupa Komisyonu anlaşmaya yeşil ışık yaktı.
+Muhalefet partileri oylamayı boykot ettiler.
+Hatta sürdürmeye mecburlar.
+İlk gecede yaklaşık 2 bin kişi bir araya geldi.
+Bu her zaman ve her yerde doğrudur.
+Arnavutluk'ta turizm hala emekleme döneminde.
+Biletler 27 Mart'ta satışa çıkacak.
+Organize suç olasılığı da dışlanmadı.
+Bu süreç sizce nasıl çözümlenecek ve Sırbistan açısından ne gibi anlamlar taşıyor?
+Mevcut ihale planlanan üç santralin biri için.
+Burada ordu veya polis olmayacak.
+Ancak bazı sektörler bundan zarar görebilir.
+Bunu söylemek için hala çok erken.
+Artık bunu yapmaya başlıyoruz.
+Peki eğitim devlet okullarından verilen eğitimden daha mı iyi?
+İskelet bir Kelt mezarlığında ortaya çıkarıldı.
+Bölgesel girişimlere dahil olabilecek mi?
+Budva bu sefaletinde yalnız da değil.
+Dördüncü kategoride ise 848 konut yer aldı.
+Çözüm bulmak zorundayız.
+Fakat sadece reklam yetmiyor.
+Kentin sokakları iki metre su altında kaldı.
+Davetler, 2009 yılında üyelik anlamına gelebilir.
+Asker sayısı 19 bin 200'den 12 bine düşürülecek.
+Ve sadece Kürtçe söyleniyor.
+Demokratik partilerin iktidara geldiği 2000 yılından bu yana ilerleme oldu mu?
+Şu anda Makedonya'nın cezaevi nüfusu 2 bin 200.
+Türk liderlerin, 16.
+Ellerinizin yanmamasına dikkat edin!
+Bu alanda daha neler yapılması gerekiyor?
+Sokaktaysa, vatandaş sonuç bekliyor.
+Bu yıl da bir tane düzenlenmesi planlanıyor.
+Ancak bunun için anayasa değişikliği gerekiyor.
+Yunanistan'da ise karışık tutumlar görülüyor.
+Miletiç ise sessiz kalma hakkını kullandı.
+Hepsinin ortak noktası, futbol sevgisi.
+Kısır döngüleri ve az gelişmişlik tuzaklarını kırmak neden bu kadar zor?
+Makedonya resmi aday ülke statüsüne kavuştu.
+İlgili müzakere faslı ise henüz açılmış değil.
+Dokuz yıl sonra ise tekrar cumhurbaşkanı oldu.
+Kimse ne olduğunu bilmiyor.
+Yetkililer oybirliğiyle planı reddettiler.
+O olaydan beri çalışmalar askıya alındı.
+Üyeler beş yıl süreyle atanacaklar.
+Aşırı derecede kapalı bir ortamımız var.
+Projenin ihalesi geçen ay açıldı.
+Selin kontrol edilememesi ihtimali hakkındaki fikri sorulan cumhurbaşkanı, "Allah korusun!" dedi.
+Saraybosna'ya bir niyet mektubu gönderildi bile.
+Pişirme yaklaşık 35 dakika sürer.
+İki ülke, aralarındaki sorunları çözüme kavuşturmanın eşiğinde mi bulunuyor?
+Bunları yapmak zorundalar.
+Mahkeme böyle bir talebin gelmediğini söyledi.
+Aklını kullanmak zorunda kalarak büyümüş.
+Sizce özgür, adil ve demokratik bir seçim mi oldu?
+Ancak bir klinik değil.
+Umarım turnuvada ilerlerler.
+Malların bir kısmı Almanya'ya ulaştı.
+Ancak resmi bir ateşkes anlaşması yapılmadı.
+Bu durumun sağlık üzerindeki etkisi büyük.
+Bu deliği de tıkadılar.
+Seçimler 14 Nisan Çarşamba günü yapılacak.
+Sayısız evcil hayvan telef oldu.
+Fakat artık bu durum değişti.
+Türkiye bir "polis devleti" mi?
+Fakat burada din hassas bir konu.
+Hırvatistan'ın da iyimser olmak için nedeni var.
+İhracat yüzde 14, ithalat ise yüzde 5,7 büyüdü.
+Göreve iki isim daha aday oldu.
+Suçun vahşiliği ülkeyi şok etti.
+Biz ikinci sınıf Avrupalılar değiliz.
+Bu arada Romanya da yeni salgınlar bildirdi.
+İlk katılım Haiti'de olabilir.
+Mültecilerin çoğu daha sonra infaz edildi.
+Peki ülke buna yeterince hazır mı?
+Tavuk eti satışları yüzde 90 düştü.
+Yetkili ayrıntılı bilgi vermeyi reddetti.
+Eşyalara soruşturmanın devamı için el kondu.
+Seçimlerde usulsüzlük bildirilmedi.
+Tek bir kart hepsinin kapılarını açıyor.
+Hükümetin Çarşamba günü ant içmesi bekleniyor.
+Şirket, karara itiraz edeceğini bildirdi.
+O yüzden sakın umudunuzu kaybetmeyin!
+Sefer her iki yöne de üç ila dört saat sürüyor.
+Halkın yaklaşık yüzde 33'ü oy kullanmayacak.
+Planda itiraz ettiğiniz temel noktalar neler?
+Açılışta bir de kutsama töreni düzenlendi.
+Şimdi Karadağ üçü için de tutuklama emri çıkardı.
+Bu kış ziyaretine gittim.
+Her iki yapının da avantaj ve dezavantajları var.
+Şimdiyse iki yakamızı zor bir araya getiriyoruz.
+Çocuklar şu anda ailemin yanında.
+Bunun bir çeşit etnik temizlik olarak görüyor musunuz?
+Sunulan bütün teklifler İngilizce idi.
+Yüzlercesi hakkında ise davalar açıldı.
+Fakat bu umutlar boşa çıktı.
+Bu rakam şimdiki değeri 51 avro.
+Ancak bütün işletmeler zor durumda değil.
+Öte yandan Kosova'da da hâlâ pek çok akrabam var.
+Bu ifade de davanın dönüm noktası oldu.
+Yetkililer silahları hala geri alamadılar.
+Suçlamalar yaygındı.
+Bugüne kadar bu girişimleri sonuçsuz kaldı.
+Türkiye tutuklamaları memnuniyetle karşıladı.
+Performans kriterleri henüz belirlenmiş değil.
+Ancak hastalığı bu arzusuna engel oldu.
+Bu alanda bir aksama mı var?
+Bu şekilde hiçbir şey israf olmuyor.
+Rus Casusu?
+İnşaatın yedi yıl sürmesi planlanıyor.
+Dışardan bakıldığında hayat sakin görünüyor.
+Kabaşi mahkemeye saygısızlıkla suçlandı.
+Teklifleri sunma süresi 26 Mayıs'ta sona eriyor.
+Cotard, bunların patlamadığını da belirtti.
+Kitabım da bu hikayeyi anlatıyor.
+Adım adım gideceğiz.
+Ayrıca, bölgede yeni bir şey de değil.
+Yemedik ve içmedik.
+Onay, iki gün süren tartışmalar sonrasında geldi.
+Her bir firma günde 2,32 kWh elektrik sağlayacak.
+Yeni hükümette 15 bakanlık bulunuyor.
+Ülkelerin katılımı 2007 başlarında planlanıyor.
+Şimdilerde ise sektörde bir canlanma yaşanıyor.
+Ekonominin genel görünümü kasvetli.
+Çocuklar için geçerlilik süresi daha kısa.
+Bir de Arnavut partilerin hızlı bir çözüm çağrısında bulunmasını nasıl değerlendiriyorsunuz?
+Turnuvaya 35 ülkeden yaklaşık 400 atlet katıldı.
+Şimdiye kadar bunu sadece 13 ülke yaptı.
+Bazı durumlarda da, yakınlık öncelik olmuyor.
+Belgrad ise iki iddiayı da reddediyordu.
+Bazıları ilkokulu bile bitiremiyor.
+Görev sırasında hiçbir asker hayatını kaybetmedi.
+Bulgar takımı Kıbrıs'ı 3-0 yenerek birinci oldu.
+Hukuk düzeninin doğası bu.
+Tarihi Prizren'de dar sokaklar parke taşından.
+Ancak Kostunica bunu yapmaya istekli değildi.
+Türkiye ticari çıkarlarını Libya'daki insanlık krizinin üstünde mi tutuyor?
+Etkinlik 30 Ekim'e kadar devam edecek.
+Bulgaristan'da şimdiye kadar vaka bildirilmedi.
+Diyaloğun sonuç üretmeye devam etmesini umuyorum.
+İktidar koalisyonu parlamentodaki salt çoğunluğunu koruyabilecek mi?
+Bunu kanıtlayacak pek fazla delil yok.
+Ayaklarımızın üzerinde sağlam duruyoruz.
+Bu aşamaya gelebilen dava sayısı zaten çok az.
+Festival 1961 yılından beri düzenleniyor.
+Erdoğan'ın eşi de türban takıyor.
+DiCarlo da bu sözleri tekrarladı.
+Sergi 3 Aralık'a kadar açık kalacak.
+Resmi sonuçlar birkaç gün içinde ilan edilecek.
+Gümrüksüz ithalata da son verildi.
+Yugoslavya, bir Çağaşım!
+Bir diğer önemli konu da enerji.
+Ancak bu meclisin yetkileri azaltılacak.
+Toplu taşımacılığın da değişmesi gerekiyor.
+Karadağ ise 0,63 ile en düşük puanı aldı.
+Sırbistan-Karadağ bu sefer altın madalyaya uzanabilecek mi?
+Lidra bir veresiye defteri tutuyor.
+Şimdilik anlaşmaya varmak için çalışacağız.
+Çift Saraybosna'dan Karadağ'a geçti.
+Festivalde 1.500'ün üzerinde film yarıştı.
+Hırvatistan golf dünyasında geride kalmıştı.
+Bunu uluslararası yankılar izledi.
+Yaşam boyu eğitim olgusu desteklenmeli.
+Hükümetin bu meseleyle ilgili görüşünü destekliyor musunuz?
+Halkın güveni %4 oranında azalarak %36'ya düştü.
+Orkestramızın yaş ortalaması 35'in altında.
+Yeni modelin fiyatı 9200 avro olarak belirlendi.
+Bu durumun sonuçları ise oldukça ciddi.
+Ödül aynı zamanda yönetmenin 70.
+Bu iddialı bir hedef, ancak imkansız değil.
+İsviçre ise 9,0 ile 5. sırada yer aldı.
+Yeni yapı 2011 baharı civarında kesinleşecek.
+On iki ülke henüz tanımadı.
+Sunum seçimler yüzünden ertelenmişti.
+Bisiklet adalar için de ideal bir araç.
+Bunlar haberden ziyade kısa birer film gibiydi.
+Mesiç'in görev süresi Şubat ayında sona eriyor.
+Bunun en yaygın örneği çocuklar.
+Ancak şimdi kasabada yalnızca bir Sırp yaşıyor.
+Yasada korsancılık suç sınıfına sokuluyor.
+Artık insanlar daha bireysel yaşıyor.
+Reformları uygulamak için çok çalışmalıyız.
+Fuarda 15 ülkeden 1800 katılımcı bir araya geldi.
+İşsizlik oranı ise %20 civarında.
+Bu da oyların bölünmesine yol açabilir.
+Değişiklikler fark edilmeden kalmadı.
+Atık dökme çok önemli bir sorun teşkil ediyor.
+Belgrad makamları ise bunu reddettiler.
+Bu ayinle ilgili olarak ne düşünüyorsunuz?
+Bazıları biraz hayal kırıklığına uğradı.
+O kadar suyla ne yapacağım?
+Çocuklar hangi kategoriyi tercih ediyorlar?
+Kosova makamları da bu fikre karşı çıktılar.
+Papanın bu, ülkeye yaptigi ucuncu ziyaret oluyor.
+İnşaatın iki yıl içinde tamamlanması bekleniyor.
+Birkaç günde öğrenmek için çok fazla şey vardı.
+Su parkı da 2006 yılında açıldı.
+Türk takımı 42 puanla üçüncü oldu.
+Bu arada da, dört yıldır hiçbir şey yapmadık.
+Geri dönüşüm makinesi çok amaçlı.
+Ancak anlaşmanın onaylanma şansı zayıf görünüyor.
+Söz konusu kardinaller papanın halefini seçecek.
+Baba kapıyı açar ve tüm aileyi içeri davet eder.
+Noel ikramiyesinin ortalama miktarı 170 avro.
+Nekra, 68 ülkeden 1053 adaya karşı yarıştı.
+Yine de her iki grup farklı sorunlar çıkarıyor.
+Kodra 88 yaşındaydı.
+Adeta küçük bir kasabayı andırır.
+Ancak iki taraf da konuşma yapmadı.
+Savunma makamı karara itiraz edeceğini belirtti.
+Belgrad, aday statüsü hakkında beklenen karar öncesinde büyük bir politika değişikliği mi yaptı?
+Fakat bir çok kişi için geçiş acı tatlı oldu.
+Projenin üç ay içinde hazır olması bekleniyor.
+Rus salatası da sevilen mezelerden biri.
+Yine de, bu da bir gelişme.
+Mevki Ocak 2003'den bu yana boş duruyor.
+Hükümetten gelen tepkilerse pek olumlu olmadı.
+Şimdi ise satmayı düşünüyor.
+Biri 38 diğeri 40 numara.
+Kanada dışişleri bakanı Zagreb'i ziyaret etti.
+Kanıt olmazsa, bir ülke kendi tarihine nasıl sahip olabilir ki?
+Birkaç saat sonra, Belçika da aynı yolu izledi.
+Kurul, Salı günü tekrar toplanma kararı aldı.
+Bunları suçlular da kullanabilir.
+Kampüs örgütlerinin tepkileri farklı oldu.
+Pekin'de Sırbistan'ı 91 sporcu temsil edecek.
+Yaşlı kadınlar Belgrad'da bir parkta dinleniyor.
+Erkekler kesinlikle orada olacaktır.
+Fakat bu kez protestolar olaysız geçti.
+Gurur duyduğumuz ortak bir tarihimiz var.
+Noel Baba'ya inanıyorlar.
+Kosteliç efsanesi çok büyük bir efsane.
+Savunma harcamalarının da kısılması planlanıyor.
+Her iki zanlı da saklanıyor.
+İç yargı sistemi onlardan çok şey öğrendi.
+Yine de Sarkozy'nin fikri destek buluyor.
+Raporda Bulgaristan'a altı tavsiyede bulunuldu.
+Burada yaşayanlar oldukça endişeli.
+Konvoydaki memurlar ateşe yanıt verdi.
+Cumhurbaşkanlığı için 12 aday mücadele ediyor.
+Bu kararda çeşitli faktörler rol oynadı.
+Meta bu önerileri reddediyor.
+Üretimin 2010 yılına kadar başlaması bekleniyor.
+Hareket, etnik Rusların protestolarına yol açtı.
+Şu anda fabrikada 74 işçi çalışıyor.
+En ucuz bilet 19 avro civarındaydı.
+Bu ödülün sizin için anlamı nedir?
+Kaplanoğlu 12 diğer yönetmeni geride bıraktı.
+Bu kalıplaşmış düşünceye tepkiniz nedir?
+Bu örnek iki farklı açıdan değerlendirilebilir.
+Kavgada bir eylemci hayatını kaybetmişti.
+Bu tutuklular Sırp mahkemelerinde yargılanacak.
+Operasyon şu anda halktan büyük destek görüyor.
+Bundan önce, ülke 123 belediyeye bölünmüştü.
+Fakat görev andının içilme şekli değişebilir.
+Kırmızı kartlar, penaltılar, ofsaytlar.
+Arnavutluk'ta da bu modeli uygulayacak mısınız?
+Sırp havayolu şirketini satmak kolay olmayacak.
+Bu, işbirliğine dayalı bir ortaklık mı?
+Peki yeni bir karışıklığın kapıda olduğunu gösteren işaretler var mı?
+Hint kültürünün müziğiniz ve yaratıcı çalışmalarınız üzerinde doğrudan bir etkisi oldu mu?
+Kosova ve 36 ülkenin 14'ü yorumlarını sundular.
+Biliç takımının başında kalmayı planlıyor.
+Akrabalar şafakla birlikte sökün etmeye başladı.
+Ahtisaari planının ayrıntıları ne söylüyor?
+İsim anlaşmazlığında sona mı geliniyor?
+Bunu 12 yıldır yapıyorum.
+Ancak diğer taklitler ülkede üretiliyor.
+Babalar mahkemede de aynı muameleyi görüyor.
+Proje 20 milyar dolara mal olacak.
+Önceden, sanatçılar proje başına tazmin edilirdi.
+Fakat ilerleme vakti geldi.
+Ama artık durum daha iyi.
+Koruganlar en ücra noktalara yerleştirildi.
+Yetkililer bunları geçen ay yayınladılar.
+Yunan uzmanlar robotlu cerrahiyi tartışıyorlar.
+Bu hareket bir şok etkisi yarattı.
+Daha çok, arz ve dağıtımın kontrolüne bağlıdır.
+Vadi'deki evler taş, ahşap ya da kerpiç.
+Sergi 30 Ekim'e kadar açık kalacak.
+Burası ruhumu doyuruyor.
+Üç kuruma da danışmadan bir karar verilmemeli.
+Okul teknoloji ve ekonomi odaklı olacak.
+Fransız taraftar 12 gün sonra yaşamını yitirdi.
+Özellikle endişe yaratan bir sektör tarım.
+Bu yıla ilişkin beklentileriniz nelerdir?
+Bir porsiyonda kaç gram yağ vardır?
+Bence bu olasılıklar arasında yer almıyor.
+Dayton sistemi yıprandı artık.
+Türkiye'de hükümetle ordu çatışmak üzere mi?
+Bir sürü gazete kapatılıyor.
+Ancak Kabakçı aynı fikirde değil.
+Gana da buna kurban gitti.
+Bu, harika bir kaçış mekanizması da olur.
+Aynı zamanda, gazete sayısı da artıyor.
+Ülkede şimdiden koalisyonlar kuruldu.
+Resmi yarışma programında dokuz film yer alıyor.
+Sizce tarafların yakın bir gelecekte anlaşlamaya varmasını beklemek gerçekçi mi?
+Toplam 1200 civarında test yapılması bekleniyor.
+Pambuccian girişimini savundu.
+Bu çerçevede pek çok ev yenileniyor.
+Berişa'nın ekibini çoktan kurduğu bildiriliyor.
+Bir ekonomi, salt kimi kurumları taklit etmeye çalışarak, ileri düzeylere sıçrayabilir mi?
+İnsan ne yapar?
+Pek çok çiftlik rekabet edemediği için kapandı.
+Çok sayıda ülke ileri yönde dev adımlar attı.
+Bu değerlendirme Temmuz ayında yapılacak.
+Bunu yapanlara verilecek cezalar belirlendi.
+Sırbistan savunma bakanı Bağdat'ı ziyaret etti.
+İlişkileri etkileyen birkaç sorun var.
+Kendi kültürüm hakkında pek fazla şey bilmiyorum.
+Bulgaristan da aynı tarihte üye olacak.
+Şu anda bitmiş durumdayım.
+Ödemelere, 1 Mart 2008'de başlandı.
+Rock grubu Metallica da ateşi canlı tutuyor.
+Fakat bu da daha başka sorunlara yol açabilir.
+Otobüsler gönüllüleri alana taşıyamadı.
+Bunlar yalıtılmış örnekler değil.
+İlkiyse 1959 yılında meydana gelmişti.
+Makedon yetkililerdense yanıt çabuk geldi.
+Üstelik çok stresli.
+İki lider sokaklarda dolaşarak halkla selamlaştı.
+Oranda 2000 yılından beri ilk defa düşüş yaşandı.
+Birini sınıf müfredatı hazırlık niteliğinde.
+Berişa komşu Kosova'daki duruma da değindi.
+Etkinlik 7 Temmuz'a kadar devam edecek.
+Etkinliğe 18 ülkeden 36 şarkıcı katıldı.
+Ancak gazete başka ayrıntı vermedi.
+Kilise ihtilafta yıkılmıştı.
+Şimdi de devletten yardım istiyorlar.
+Raporda sabit önerilerde de bulunuluyor.
+Fakat geçmiş tarihçilerin işidir.
+Priştine'nin yasa tasarısı iki yıldır beklemede.
+Ancak bazıları farklı görüşte.
+Ancak değişikliklerden herkes memnun değil.
+Bu galeri Balkanlar'da türünün ilk örneği.
+Fakat plan hedeflerine ulaşabilecek mi?
+Seçim suçu davaları da öncelikli.
+Siotis'in kendisi de tanınmış bir şair.
+Savunma en güçlü unsur.
+Miloja da buna katılıyor.
+Ülke bir sıra yükselerek bu yıl 84. oldu.
+Çiçek'e göre, türbin her an faaliyete geçebilir.
+Oysa bu on yıl sonra gerçekleşti.
+Sürecin aylarca sürmesi bekleniyor.
+Brüksel adresli bu mektuplu protesto ne gibi bir etki yarattı?
+Ardından da silahlı çatışmalar çıktı.
+Sahiden öyle mi?
+Önce çok yavaş başlar, ardından hızlanırız.
+Atina'nın merkez pazarı.
+Bu durum özellikle gençler arasında yaygın.
+Ancak bazı uzmanlar duruma şüpheyle yaklaşıyor.
+Bunun karşılığında ne yapacaklar?
+Bu uygulama ilk kez yapılmiyor.
+Savaş rüzgarları kuzeyden hızla yayıldı.
+Projenin maliyeti 41 milyon avro.
+Ancak ilaçlarını kendileri ödeyecekler.
+İki bölümden oluşan röportajın ikinci bölümü.
+Sizce, söz konusu toplumlar arası ilişkilerde hangi alanlarda gelişme sağlanmalı?
+O belgeyi biliyoruz, fakat yenisini bilmiyoruz.
+Birlik yerine ayrılık görüyoruz.
+Bazıları onu kahraman olarak görüyor.
+Fakat önce inşa edilmeleri gerekiyor.
+Bu işbirliğinin ne derece iyi yürüdüğünü söyleyebilirsiniz?
+Projenin üç yıl içinde tamamlanması bekleniyor.
+Bu soruşturmalardan ne zaman sonuç almayı bekliyorsunuz?
+Cinayet kamuoyunu şiddetle sarstı.
+Sonuçta o bölge de Avrupa'nın bir parçası.
+Güzel, alternatif hedefler aramadığını belirtti.
+Aramalardan şu ana kadar bir sonuç alınamadı.
+Costi Rogozanu meseleyi küçümsüyor.
+Tüyler ürpertici bir andı.
+Yarışmanın tarihi 1357 yılına kadar uzanıyor.
+Coşkudan tam bir hayal kırıklığına.
+Belge 2006 yılını kapsıyor.
+Erteleme ekonominin düzelmesini sağlamayacaktır.
+Aksi takdirde yeni seçimler yapılacak.
+Panasonic Sırbistanda üretime başlıyor.
+Buna mahkemede karar verilecek.
+Moldavyalı kadın da Karadağ'ı terk etti.
+Fikir herkes tarafından hoş karşılanmadı.
+Mevcut durum, bu tür bir güce ihtiyaç duyulmayacak kadar güvenli mi?
+Operasyonda üç işadamı da gözaltına alındı.
+Zrvenkovski de benzer itirazlarda bulundu.
+Makedonya'daki her ev ankete katılacak.
+Bu imkansız.
+Bu toprakların özü İslam'la yoğrulmuştur.
+Bakan gördüğü zarardan toparlanabilmiş değil.
+Bu konuda görüşünüz nedir?
+Rapor 6 Ekim'de yayınlanacak.
+Mara danışmanlık yapıyor.
+Fakat zaman komünistlerden yana değildi.
+Fakat ömrü bunu görmesine yetmedi.
+Tarih henüz açıklanmadı.
+"Fransa'da insanların kafelerde sigara içmekten vazgeçeceğini kim düşünürdü?" diyor.
+Kosova'daki yolsuzlukla mücadeleye siyaset karışıyor mu?
+Sırada yeni parlamento seçimleri olabilir.
+Maja Nikoliç de benzer görüşte.
+Bizim kendimize bakmamız lazımdır.
+Bravo Sırbistan!
+Sanader artık siyasete girmediğini de vurguladı.
+Öte yandan süreç henüz sona ermiş değil.
+Beş zanlı hala kaçak durumda.
+Grup kazanmaya yabancı değil.
+Ödül için dokuz film son elemeye kaldı.
+Yedi gazete 16 adet reklam yayınlayacak.
+Turistlerin büyük kısmı Kosova'dan geliyor.
+On iki tane de bağımsız aday var.
+Milletvekili sayısı 120'den 133'e çıkacak.
+Bu arada Sırplar vatanlarını gururlandırıyorlar.
+Kıbrıs da buna istisna olamaz.
+Parti Mostar'da da kazandı.
+Siyasi istikrar da bunda rol oynadı.
+Sizce sizi efsane yapan ne?
+Sıkıyönetim ilan edildi.
+Finansman, çözüm bekleyen bir diğer sorun.
+Lider Kosova'nın dördüncü başbakanı oldu.
+Tesis 40 izleyiciyi ağırlayabiliyor.
+Hükümet ise bilgi sızdırıldığını inkar etti.
+Hareket yaklaşık 2 bin 200 çalışanı etkileyecek.
+Irak televizyonu bütün etkinliği belgeledi.
+Akşama doğru kuzu hazır hale gelir.
+Kabine üç potansiyel yatırımcıyı inceliyordu.
+Bu yolda da Rusya var gibi görünüyor.
+Brkiç'e göre rekabet artıyor.
+Projeye ilişkin müzakereler 1998'de başlamıştı.
+Bunlar önemli şeyler.
+Numara değiştirme hizmeti Ekim ayında başlamıştı.
+Bu sanıklara da 15'er yıl hapis cezası verildi.
+Yunanistan'da idam cezası yok.
+Girişimin hazırlanması yıllar sürdü.
+Çok sayıda mimar da yıkım önerisini eleştirdi.
+Blogcular da tam bundan bahsetmek istiyor.
+Festival 4 Haziran'da sona eriyor.
+Büyükbabalarımıza ayrımcılık yapılmış.
+Bu Arnavutluk'taki ilk mali af ihtimali değil.
+Bittiğine çok seviniyorum.
+Üyeliğin Arnavutluk açısından faydaları neler?
+Hepimizin emniyet kemerleri bağlı.
+Ancak bugüne kadar paranın geldiği yok.
+Vlasiç, sporcu bir ailenin en büyük çocuğu.
+Ama Arnavut halkının çoğu yasayı pek takmıyor.
+Hisselerin geri kalanı yerel İş Bankası'na ait.
+Fabrikada 50 kişiye iş sağlanacak.
+Eğer Türkiye'nin herhangi bir rolü olmayacaksa, niçin risk alsın?
+Sırp halkının konuya yaklaşımı ise çok olumlu.
+Yetkili, üyeliğin mümkün olduğunu belirtti.
+Toplam 1,9 milyon oy kullanıldı.
+Ülkede topla 6 bin 300 bina sular altında kaldı.
+Bunlar doğal olarak akla gelen sorular.
+Makedon başkenti haftasonu cazla dolup taştı.
+Makedon hükümeti öneriyi reddetti.
+Ancak muhalefet plandan pek memnun değil.
+Projede yer alan herkes bundan faydalanıyor.
+Halk, hızlı ve kolay kazanca pek hevesliydi.
+Dış politika alanında, başlıca konu Kıbrıs'tı.
+Bu, kaotik ve uydurma bir girişim.
+Göçmenlerden 1000 ila 1500 avro para alınıyordu.
+Bize büyük sorumluluk düşüyor.
+Kitle iletişim araçlarının çoğalması kaliteyi de beraberinde getiriyor mu?
+Çok sayıda işçi işten çıkarıldı.
+Görüşmelerin sonbaharda yapılması planlanıyor.
+Katılım ilk turdan düşük gerçekleşti.
+Bir kimse ‘tek millet' ilkesine karşı olduğunu söyleyebilir mi?
+Exit'in yerel faydaları ve en büyük katkısı nelerdir?
+Herkesi teröre karşı tavır almaya çağırıyorum.
+Bu olay daha büyük yankılara yol açacak mı?
+Erkekler kaldı.
+Kimin uygun olacağını ise yasalar belirler.
+Kosovalı Sırp temsilciler öfkeyle tepki verdiler.
+Planın ardından yatan mantık tam olarak nedir ve Yunanlıları uzun vadede nasıl etkileyecektir?
+Hırvatistan da bu fikri reddetti.
+Orijinalin aksine, kıyafetler çıkarılmadı.
+Festivalde canlı müzik de vardı.
+Bakan buradan Bulgaristan'a geçti.
+Türk dışişleri bakanı Bükreş'i ziyaret etti.
+Sanıkların tümü suçlamaları reddetti.
+Rapora göre enerji üretim kapasitesi geriliyor.
+Pek çok kişi başkalarının attığı şeyleri istiyor.
+Yetkililer pasaportu 14 Mart'ta açıkladılar.
+Bu rakamlar belirgin şekilde artabilir.
+Erken parlamento seçimlerine gidilmesini bekliyor musunuz?
+Bu suçlamalara ne yanıt veriyorsunuz?
+Muhalefet partileri öneriye isyan ettiler.
+Acaba taraflardan hangisi diğeri üzerinde etkili oluyor?
+Sporcuların antrenörleri de soruşturulacak.
+Odasına bile giremezdim.
+Bazı ikili toplantılar da yapılıyor.
+Hükümet anlaşmayı Haziran ayında imzalamıştı.
+Avro olmadan, ülke parçalanır.
+Fakat basın standartları da tehlikede bulunuyor.
+Sendikalar, bir dizi grev yapılacağını duyurdu.
+Mevcut sayı 6 bin 300 civarında.
+Bu bina bir dini yapıdan fazlasıdır.
+Sizce bu sayede bölgede reformlar hız kazanabilir mi?
+Hamam gelecek yıl ziyaretçilere açılacak.
+Makedonya'nın adının değiştirilmesini destekler misiniz?
+Komşu Makedonya'da bu rakam beş kat daha yüksek.
+Seçmen listelerinin her vatandaşın oy kullanma hakkını güvence altına almasını sağladınız mı?
+Seçmen azlığı sorunu sıkıntı vermeye başladı.
+Gündemde karşılıklı siyasi işbirliği de yer aldı.
+İnsanlar kadınlara güvenme konusunda şüpheciler.
+Karadağ, Türkiye'nin bölgede giderek büyüyen rolünü nasıl değerlendiriyor?
+Çetenin 11 üyesi tutuklandı.
+Etkinlik 29 Kasım'da sona erecek.
+Çin, ayı piyasasında boğa performansı sergiliyor.
+Bu ikili halen kacak durumda.
+Ford projeye 1,2 milyar avro yatırım yapacak.
+Bir kasabanın yarısını boşaltmak zorunda kalırsanız bu kadar insanı nereye taşıyacaksınız?
+İki kıyı bir tünelle birbirine bağlanıyor.
+Onun ifadesi büyük bir atılım olabilirdi.
+Bu kriz, bir mali krizin sınırlarını aşmıştır.
+Yunanistan Formula 1 pisti için yeri seçti.
+Peki bu siyasi irade mevcut mu?
+Egmont Grubu bu meselelere nasıl yaklaşıyor?
+Saldırıda hasar veya yaralanma bildirilmedi.
+Sorun tek bir sporla sınırlı değil.
+Dementieva maçı 7-6 ve 3-0 önde götürüyordu.
+Sizin hikayeniz, kitabın hikayesi ile ne ölçüde benzerlik gösteriyor?
+Listede 25 ülkeden filmler yer alıyor.
+Hükümet satış için başka bir neden daha sunuyor.
+Sizin bu konudaki görüşünüz nedir?
+Yurtta da bütün çocuklara kapısını açtı.
+Bu program kesinlikle sonuna kadar yürütülecek.
+İngiliz takımı toplamda 6. oldu.
+Sevilen bir kış içkisi de juva.
+Bu şirketlerle ilgili mali soruşturma açıldı.
+Benzer sözler İngiliz büyükelçisinden de geldi.
+Geçen yılki rekor Rusya'ya aitti.
+Ne demek istediklerini anlıyordum.
+Fikri uluslararası örgütler de kınadı.
+Nobel ödüllü İvo Andriç.
+Lukiç Lahey'e iadesine karşı çıkmadı.
+Bu kaynaklar istihdam da yaratırlar.
+Ancak hiçbir önemli şahıs tutuklanmış değil.
+Sonunda bütün suçlamalar düşürüldü.
+Yetkili Şubat 2010'a kadar bu görevde kalacak.
+Tüm bunlar, ülkeye çok olumsuz olarak yansıyor.
+Sırbistan'daki fabrika 2006 yılında açılmıştı.
+Fakat sadece aileler değil.
+Ancak bu hareketi eleştirenler de var.
+Belge Ekim ayında yürürlüğe girecek.
+Ancak bu strateji sandıkta karşılık görmedi.
+Ekonomide istikrar şart.
+Tepe zamanları ise sabah ve öğlen saatleri.
+Söz konusu vergi %10'dan %15'e yükseltilecek.
+Bu da yıl sonuna kadar gerçekleşebilecek.
+Yannoulatos'u 250 yerli aydın aday gösterdi.
+Yasa 20 Nisan'da yürürlüğe girdi.
+Yasa taslağı geçtiğimiz hafta meclise sunuldu.
+Bu durum beni endişelendiriyor.
+Karasu buna katılmıyor.
+Dernek sadece sekiz sandıkta sorun bildirdi.
+Bunun olacağına dair umudum var.
+Benzer talepler Hırvat azınlığından da geliyor.
+Siyasi analistler bölünmüş durumda.
+İlk fırın altı aydır atıl durumdaydı.
+Kosteliç komisyona seçilen ilk Hırvat oldu.
+Parti içindeki güç mücadelesi devam ediyor.
+Çok yazık ...
+Türk dış siyaseti yön mü değiştiriyor?
+Meclis'ten, mahkemelerden söz ediyorum.
+Sıcak hava Radikal destekçilerini durduramadı.
+Konsere Yunan ve yabancı siyasi isimler katıldı.
+Burada bir savaş yaptık.
+Yaptığım işte duygulara yer yok.
+Onların savlarını bizimkilerle yüzleştirdik.
+Katılım yaklaşık yüzde 70 oranında gerçekleşti.
+Dersler tamamen İngilizce veriliyor.
+Öncelikle karşılıklı güven sağlanmalı.
+Parlamento değişikliği Cuma günü kabul etti.
+Lisedeki öğrencileri, müdürleriyle gurur duyuyor.
+Burası güvenli bir yer izlenimi veriyor.
+En başarılı uygulamalar olarak neleri dikkate alacağız?
+Milutin, "Bu tür bir filmin gösterime girmesi mümkün mü?" diye soruyor blogunda.
+Kim kime ne ödeyecek?
+Noelle birlikte kırmızı ete dönüş geliyor.
+Zincirin bir sonraki halkası ise İstanbul.
+Kosova, Brüksel tarafından belirlenen %20 kriterine ulaşabilir mi?
+Ama arabuluculuk rolünü Türkiye üstlenebilir.
+Arnavutluk Çad'a 62 barış gücü askeri gönderecek.
+Bulgaristan iki boru hattı projesinde yer alıyor.
+Cinayet hâlâ çözülemedi.
+Hüseyni hâlâ Malev'den tazminat bekliyor.
+Kelmendi'nin eşi Makbule iyimser görüşe sahip.
+Fakat bu durum 6 Aralık 2008'de değişti.
+Diğer iki kişi Bosnalı.
+Bölüm o tarihten beri gelişmekte ve genişlemekte.
+Balkanlar'da gazeteci olmak zor olabilir.
+Ne var ki proje başarısızlığa uğradı.
+Festival Salı günü sona eriyor.
+Bu arada hükümet de önleyici tedbirler alıyor.
+Sizce nerede yanlış yapıldı?
+Bu sorun bir kısırdöngü haline gelebilir.
+Bu insanlar da iş bulmakta zorlanıyor.
+Dahası, kapitalizm evrimine devam ediyor.
+Fakat yine de Brüksel'den iyimser sesler geliyor.
+Kriterleri yerine getirmek için neler yaptınız?
+Bu davaya 18 hakim baktı.
+Bütün bu süreçleri de belgelemek zorundalar.
+İki lider ayrıntılı bilgi vermedi.
+Rusya ise temsilcisini henüz açıklamadı.
+Polis olaya müdahale ederek düzeni sağladı.
+Sergi 31 Aralık'a kadar devam edecek.
+Bombanın büyüklüğü belirlenemedi.
+Bu tür yatırımlar aracılığıyla bütçeye ne oranda bir kaynak girişi sağlanması bekleniyor?
+Fabrikanın bir yıl içinde açılması bekleniyor.
+Racan arkasında güçlü bir siyasi miras bıraktı.
+Fakat bazılarının tek istediği şey hediye değil.
+Referandumun kabulü için salt çoğunluk gerekiyor.
+Ancak ilk yıl boyunca not verilmeyecek.
+Fakat Yugoslavya bir gün parçalanıvermiş.
+Peki sanat?
+Belgrad'daki dava 2005 sonlarında başladı.
+Eleştirileri ise dikkate almıyorum.
+Makedonya, Moskova'da düzenlenecek 23.
+Bu sıradan ya da tesadüfi bir olay değildir.
+Polis grubun 21 üyesini tutukladı.
+Kimliği belirsiz bir kurban da anılıyor.
+Yine de durum o kadar da kötü değil.
+Beni terk edip nereye gitti?
+Hepimiz doğru yoldayız.
+Burada iyi de kötü de birarada.
+Sizce kültür birleştirici bir unsur mu?
+Ama aldıran yok.
+Kosova ve Sırbistan -- şimdi ne olacak?
+Bu teklifleri hangi koşullarda kabul edersiniz?
+Yine de herşey Kıbrıs'ın kendi kararına bağlı.
+Profesyonel kariyeriniz nasıl başladı?
+Program özel amaçlar için kullanılmayacak.
+Adaylar Kasım ayı başlarında duyurulacak.
+Ancak şirketin 3 milyon avroluk borcu duruyor.
+AB projesi en az iki açıdan değerlendirilebilir.
+Ancak üçüncü turda salt çoğunluk yeterliydi.
+Pamuk 91. sırada yer aldı.
+Sırp siyasiler tepki göstermekte gecikmediler.
+Bu rakamın %46,79'unu kadınlar oluşturuyor.
+Latin konuyu irdelemeye karar verdi.
+Bu yasalar cezalarla da gayet iyi uygulanıyor.
+En az bir kişi hastaneye kaldırıldı.
+Ama bu amacına da ulaşamadı.
+Yeni reformlar bazı vatandaşları da şaşırtıyor.
+Priştine-Belgrad diyaloğu kurtarılabilir mi?
+Yalnızca sol ön kolu kayıp.
+Dişil mesleki unvanların gelişi Sırbistan'da kadınlara daha fazla eşitlik sağlayacak mı?
+Gidenlerin çoğu da ülkelerine geri dönmeyecek.
+İkisi de bu sorgulardan beri suçlanmadı.
+Bunların ilki bir stadyum dolusu bilet satmaktı.
+Hırvat makamları değişiklik istiyorlar.
+Bahis oldukça yüksek.
+Eski sabıkaları olanlar ülkeye giremeyecek.
+Düşüş bir noktada %6,07'ye ulaştı.
+Grup üyeleri kişisel nedenleri öne sürdüler.
+Sizce etnik çeşitlilik yakın zamanda Kosova'da gerçeğe dönüşebilir mi?
+Sonunda Hırvatistan bu fikri rafa kaldırdı.
+Bu önemli değil.
+Bunlar yalnızca benim başıma gelmiyor.
+Türk halkı ile dost ve kardeşiz.
+Ondan sonra gelen her şey bize ödül gibi göründü.
+İlgili makamlardan başka adımlar da bekleniyor.
+Peki şimdi durum nasıl?
+Makedon medyasında tek bir şeyi değiştirebilecek olsanız, bu ne olurdu?
+Anlaşmanın değeri 1,6 milyar dolar.
+Milletvekili dokunulmazlığı 24 saattir.
+Zanlı hala yakalanamadı.
+İnşaat, Sırbistan'da da en tehlikeli meslek.
+AK de zor bir görevle karşı karşıya kaldı.
+İlk teslimatın 2006'da gerçekleşmesi bekleniyor.
+Satış çok safhalı olarak gerçekleşecek.
+Türkiye ile çok iyi geleneksel ilişkiler var.
+Ödül için tüm dünyadan seksen film yarıştı.
+Kosova sorunu da hala çözüme kavuşturulamadı.
+Biz diğerine gittik.
+Rijeka yatı 107 bin avroya satın aldı.
+Bilgilerin sızmamasını nasıl sağlıyorsunuz?
+Bir de eski otomobiller var.
+İzmir Türkiye'nin en büyük ihracat limanı.
+AB üyeliği ise daha zorlu bir yol.
+SC vatandaşlarının tepkileri karışık oldu.
+Patlamada 60'tan fazla insan yaralandı.
+Üç sporcu birçok Sırp'ın gözünde kahraman oldu.
+Söz konusu karar, aylar önce yürürlüğe konmuştu.
+Uyuşturucu kaçakçılığı azalıyor.
+Karara karşı çıkan kesimler oldu.
+Her gün en fazla 4 sandık taşınıyor.
+Bence bu siyasi oyun çok tehlikeli.
+Fakat bu anlaşmanın bazı yükümlülükleri de var.
+Etkinliğe 24 ülkeden toplam 48 dansçı katıldı.
+Kosova'daki herkesin bunda çıkarı vardır.
+Başlıca reform alanlarından biri tarım olacak.
+Peki ya çocukların, sadece benim değil, Yunan ailelerinin yetiştirdiği bütün o çocukların geleceği?
+Plastik ürünler önemli kirleticiler.
+Sürekli bir korku içinde yaşıyoruz.
+Kotooşu'nun yüksek mevkilerde de hayranları var.
+Bunlarla nasıl başa çıkmayı planlıyorsunuz?
+İki başkası da aynı cezayı almıştı.
+Daha net ifade edelim.
+Şüphecilerin sayısı hiç de az değil.
+Aynı şey bilgisayarlarda niye yapılmasın?
+Bu kadar kanıta rağmen mi?
+Azınlık partilerine sekiz sandalye kaldı.
+Ancak öngörülen tedbirler henüz uygulanmış değil.
+Politika hedeflerinin iki yönü dikkat çekiyor.
+Ancak komünistler, 2.
+Henüz meclis çoğunluğu elde edilemedi.
+Temmuz ayında evleniyor.
+İsrail ve Portekiz'in ise beşer puanları var.
+Zihniyet değişimi eğitimle başlar.
+Teklifler 21 Mayıs'ta değerlendirilecek.
+Dünya Kupası'ndan büyük kariyerler başlamıştır.
+Zengin ve ünlü olmaya çalışmıyoruz.
+Damat yanında bir oğlan çocuğu getirir.
+Ve en zorlu seyirci, yani çocuklar arasındaki ilgiyi nasıl devam ettirebiliyorsunuz?
+Bazı aileler için hiçbir veri bulunmuyor.
+Fonların 2006'dan önce ödenmesi gerekiyor.
+Bu, Arnavutluk için büyük bir zafer.
+Anlaşmadan Türkiye de kazançlı çıkıyor.
+Interliber büyük başarı elde etti.
+O konuda ne yapacağız?
+Neden?
+Gruevski de benzer umutlarını dile getirdi.
+Duruşmalar 1 Aralık'ta başlayacak.
+Grup olarak özel ilgi görmeyi hakediyorlar.
+Kavga stadyumdan sokaklara taştı.
+Projenin 2005 yılında tamamlanması planlanıyor.
+Bunun nedenleri ise ortada.
+Ancak kara mayını sorunu buna bir engel.
+Aylardır süren siyasi kriz artık sona mı eriyor?
+Bu da ceza verilmesini zorlaştıran bir durum.
+Programın toplamı 30 milyon dolar değerinde.
+Ancak bu kaçış çok uzun sürmedi.
+Ancak ciddi engeller var olmaya devam ediyor.
+Kosova'da da benzer bir durum söz konusu.
+Etkinliğe 12 ülkeden 176 sporcu katıldı.
+Değişiklik 1 Nisan itibarıyla yürürlüğe girdi.
+Pek çok bölgede yağmurlar heyelanlara yol açtı.
+İlk arama çalışmaları gelecek yıl başlayacak.
+Gereksiz askeri mülkler elden çıkarılıyor.
+Ülkesi için savaştı.
+Bugünse, bu kasa dolu olmaktan çok boş.
+Makedonya'da şu andaki işsizlik oranı %33,8.
+Çoğu için, bunlar hiçbir zaman yaşanmadı.
+Yetkililer yenilenebilir enerjinin faydalarını inceliyorlar, fakat bürokrasi engel çıkarır mı?
+Kosova konusunda zirve ikiye bölündü.
+Kartlar on yıl süreyle geçerli olacak.
+Her iki taktik de tartışmaya açık.
+Mahkeme diğer üç sanığın beraatine karar verdi.
+Kazı çalışmaları 2005 başına kadar sürecek.
+Ancak katılım nispeten düşük gerçekleşti.
+Bölge durgun bir dönem yaşıyor.
+Hapis cezamı parayla ödemeyi düşünüyorum.
+Her iki ülke de Ganiç'in iadesini istiyor.
+İçişleri bakanlığının bu listedeki kişiler hakkında bilgisi var mı?
+Ancak kamuoyu bu durumu pek de affetmiyor.
+Fuar 4-10 Mayıs tarihleri arasında gerçekleşti.
+Siyasi açıdan sular durulmuş görünüyor.
+Racan liderliği sakince devretti.
+Tahminler artık doğrulandı.
+Etkinlik 14 Haziran'a kadar sürecek.
+Depremde ölen oldugu yolunda haber alinmadi.
+Bunun süreci hızlandırması bekleniyor.
+Ben henüz böyle bir uzlaşma göremiyorum.
+Bu planın bölge açısından anlamı açık.
+Endeks gün sonunda %3,93 oranında düştü.
+Sırp yetkililer de aynı umutları besliyor.
+Sonuç olarak, park için başka bir yer seçildi.
+Avrupa genelinde elle tutulur bir endişe hakim.
+Failler kimlerdi?
+Tava dolduğunda fırına koyun.
+Fakat bunların yanında kötü haberler de var.
+Makedon hükümeti reform düşündüğünü söylüyor.
+Sizce bu inanış doğru mu?
+Fakat devletin sunduğu yardımlar kısıtlı kalıyor.
+İzbasa denge çubuğunda bronz madalya aldı.
+Bu esirler de Kamenica kampına gönderildiler.
+Ancak bütün haberler de karamsar değil.
+Sonucun ne olmasını bekliyorsunuz?
+Bizim için, silahlı kuvvetler kutsaldır.
+Şiddeti icat edenler Balkan halkları değil.
+Eğer diyalog mümkünse, bu nasıl ve hangi uluslararası unsurların arabuluculuğu ile olabilir?
+Borç anlaşması Yunanistan'ı şimdilik kurtardı, ama yatırımcılar geri dönecek mi?
+Stamboliç'in cesedi geçen yıl bulunmuştu.
+Bunun üzerine Gaşi ateş açtı.
+Bu eski teknolojinin riskli olduğu düşünülüyor.
+Reform çabalarının hızlandırılması gerekiyor.
+Bir o kadar yaşlı da bekleme listesinde.
+Beyin göçü Hırvatistan'da kalkınmayı baltalıyor.
+Gündemdeki diğer bir madde de Kıbrıs sorunu.
+Bazı Sırp vatandaşları yeni programı destekliyor.
+Projenin 2012 yılında tamamlanması düşünülüyor.
+Ancak mahkemede sessiz savunma yapmayı seçti.
+Kredi 20 yıl vadeli olacak.
+Bu anlaşmanın uygulanmasını destekliyor musunuz?
+Üye sayımız 32, 33, hatta belki 34'e çıkacak.
+Belgrad ise bunu inkâr ediyor.
+Gözden geçirme 8 Ocak 2003'te başlatıldı.
+Bize bu film projesinden biraz bahseder misiniz?
+Kosteliç'in madalya umudu mahvolmuş görünüyordu.
+Ancak diplomat bunu yapmayı reddediyor.
+Tava dolana kadar bu işleme devam edin.
+Bu hedefe ulaşıldı mı?
+Bu ilginin sonuçları ne oldu?
+Ülkede elle tutulur bir heyecan var.
+Kesin sonuçlar 30 gün içinde açıklanacak.
+Yunan takımı Rusya'yı 13-10 yendi.
+Projelerimizin bitiş tarihi ise 14 Aralık.
+Bir diğer sorun da gümrük.
+Bu oran 2004 yılında %67 idi.
+Burada dikkati çeken ilk şey mimari.
+Yalnızca ücretin bir kısmı alınabiliyor.
+Ancak kimi eylemciler aynı fikirde değil.
+Yasa beş yıl süreyle geçerli olacak.
+Bunu, sessizliğin kalitesinden anlıyorsunuz.
+Kaliteli bireysel oyuncu sayısı daha fazlaydı.
+Anıtın yeri henüz belirlenmiş değil.
+Kendimizi yenilmiş hissetmiyoruz.
+Mimari 19. yüzyıl sonlarına oldukça benziyor.
+"Bu yıl farklı!"
+Tekne 1979 yılında tekrar tasarlanmıştı.
+Rice'ın sözleri, 1.
+Hükümet, eli kolu bağlı olduğunu ileri sürüyor.
+Üç gün süren konferansa 15 şair katıldı.
+Yeni kabinede 15 bakanlık yer alacak.
+Yapılacak çok şey var.
+Yunanistan'daki gençlerin hepsi aynı değil.
+Peki Brüksel'den gelen olumsuz haberler yerel siyasileri harekete sevk edecek mi?
+Taçi, emekli aylıklarına da zam sözü verdi.
+Bir diğer engel de kaynak yetersizliği.
+Moskova da olaya karıştı.
+Bunun olmayacağını da düşünüyorum.
+Sergide 11 ülkeden 60 eser yer alıyor.
+Şimdiye kadar kaç kızı kurtardınız?
+Bu açıdan, doktrini evrenseldir.
+Nasıl bir Makedonya düşünüyorsunuz?
+En sonunda oturum 16 Ekim'de başladı.
+Yarışmayı İtalyan takımı kazandı.
+Yargı mevkilerine adaylıklar sürüyor.
+Bu da ülkenin gelişmesine engel oluyor.
+Olayın failleri hala yakalanamadı.
+Bu çok üzücü bir durum.
+Avrupa'nın bütünleşmesi için yeni bir yaklaşımın hızla uygulamaya konması gerekiyor mu?
+Moreno Godoy para aklamakla da suçlanıyor.
+Kosor bekâr bir anne ve iki adet şiir kitabı var.
+Müzakereler bu yıl da devam edecek.
+Harika filmlerin uzun olmaları gerekmiyor.
+Onu fetheden komutan ne güzel komutandır.
+Umarım çok yakında olur.
+Edita Tahiri bunu sınır olarak yorumluyor.
+Arnavutluk'un ekonomisi ikinci çeyrekte iyileşti.
+Yine de diğerleri katılım konusunda temkinli.
+Gruevski pek çok vaatte bulunuyor.
+İdarenin başında ise yine bir kadın var.
+Bu listede eksik kaldığını hissettiğiniz bir şeyler var mı?
+Kendinizi "çingene" olarak tanıttığınız için hiç eleştiri aldınız mı?
+Uymayanlara 14 avro ceza kesiliyor.
+Ankete toplam 1115 kişi katıldı.
+Bazıları şimdiden başarıya ulaştı.
+Ashton geleceğe de baktı.
+Yetkililer bu yıl da aynısını bekliyorlar.
+Teklif 45 gün süreyle geçerli olacak.
+Aşırı kadrolaşma çözüm bekleyen sorunlardan biri.
+Kredinin vadesi sekiz yıl olarak belirlendi.
+Hükümet şirketin %25'ini elinde tutmak istiyor.
+Dış ticaret açığı dört kat arttı.
+Öte yandan Priştine ise sevincini ifade etti.
+İlk hat 2010 yılında hizmete girecek.
+Ancak bu sadece son bölümdü.
+Çekimlerin 2009 başlarında başlaması bekleniyor.
+Peki bu durumda biz, Avrupa modeline göre hangi noktadayız?
+Sırbistan'ın Sancak'taki savaşan partileri müzakerelerle birleşebilir mi?
+Kışın, evler odun sobalarıyla ısınıyor.
+Muhalefet partileri hükümete karşı ciddi bir mücadele ortaya koyabiliyorlar mı?
+Proje gelecek yılın sonuna kadar uygulanacak.
+Zafer, Türkiye ile oynanan finallerde geldi.
+Bu düşüş de yine işten çıkarma anlamına gelecek.
+Kosova, fiili ve meşru bir devlettir.
+En yaygın bağlantı hızı 200 Mbps.
+Bitola, Makedonya.
+Sergi 7 Nisan'a kadar açık kalacak.
+Ne yazık ki anlamam uzun sürmedi.
+Fakat operasyonun zamanı henüz belirlenmiş değil.
+Turnuva Cumartesi gününe kadar devam edecek.
+Çok sayıda siyasi de tutuklama olayını kınadı.
+Artık ne kadar başarılı olduğunu görebiliyoruz.
+Ohri Anlaşması'ndan geriye yapılması gereken ne kaldığını açıklayabilir misiniz?
+Küresel çapta tanınma konusundaki yeni strateji nedir?
+Sefer yaklaşık 10 dakika sürecek.
+Ve sonumuz geçmişteki gibi olacak.
+İdeoloji yok olmadı.
+Kendisine Çingene denilmesine de aldırmıyor.
+Fakat asla sakin olamıyorsunuz.
+Yerel halkın bu polislere olan tepkisi nasıldı?
+Çatışmalar ateşkesin ardından devam etti.
+Ancak planları tutmadı.
+Pek çok kişi orduya destek verdi.
+Ancak bu yıl, bu yolda bir bayrak açıldı.
+Proje 1994 yılında başlatıldı.
+Kampın nüfusu aylar önce 1800'e ulaşmıştı.
+Pahor sonuçtan duyduğu memnuniyeti gizlemedi.
+Tam olarak itiraz ettiğini noktalar neler? Sizce yasanın olumlu yönleri de var mı?
+Herkes buna şahittir.
+Kendimi zulme uğramış gibi hissettim.
+Ancak hükümet bunu kabul etmedi.
+Yargı sistemi hâlâ sağlıksız.
+Uzun tatiller Bulgar işletmelerine pahalıya mı mal oluyor?
+Borcun geri kalanıysa Kosova'nındı.
+Sırbistan'ın Sancak bölgesinde yeni seçimler mi geliyor?
+Teklif verme süresi 6 Kasım'da sona ediyor.
+Diğerleri için gelenekler önemli.
+Turkiye, parlamenter sisteme 1920 yılında geçti.
+Ancak bu insanlar inançları yüzünden öldürüldü.
+Koşuya 500'ün üzerinde atlet katıldı.
+Bu sorun oluyor mu?
+Bu sefer en ucuz bilet 35 avro civarında olacak.
+Uzmanlar ise ayda 560 avro civarında kazanıyor.
+Yunanistan'da ise bu oran %33.
+Ancak kimileri bu açıklamaya şüpheyle yaklaşıyor.
+Fakat bu durum önümüzdeki aylarda değişebilir.
+Toplam mal varlığı 288 milyon avro civarında.
+Yeşil, şartlar normal anlamına geliyor.
+Yine tatile çıkıyorlar, ama eskisi gibi değil.
+Bir diğer önemli engel de bilgi eksikliği.
+Bu fazlanın bu yıl daha da artması bekleniyor.
+Türkiye'nin ise daha çok çalışması gerekiyor.
+İvica ve Janica birlikte antrenman yapıyorlar.
+Lider, yüzde 34'lük artışla Eurofond oldu.
+AB üyeliği, bu soruya açık bir cevap sağlamıyor.
+Adlesiç ayrıntılı bir değişiklik listesi önerdi.
+Panteliç şimdi adli işlemleri bekliyor.
+Bosnalı Sırp polisi de destek verdi.
+Suça polis bakar, ordu değil.
+Seydiu şimdi iki mevkiyi de kaybetti.
+Satış sözleşmesi 15 Temmuz'da imzalandı.
+Katılım yüzde 62,8 oranından gerçekleşti.
+Başka yolu kesinlikle yoktur.
+Kosova'nın çok ırklı polis gücü ne zaman bu işi devralabilecek?
+Anlaşmanın bu sonbaharda imzalanması bekleniyor.
+Gelecekte ne olacağını hangimiz bilebilir ki?
+Toplam yatırım 20 milyon avroya ulaşabilir.
+Çok sayıda insan hastaneye kaldırıldı.
+İşsizlik oranı ise yüzde 16,4 seviyesinde.
+Yarışmaya bölgeden toplam 90 kişi katıldı.
+Harekatın 11 gün sürmesi planlanıyordu.
+Muhalefet geri adım attı ve anlaşma sağlanamadı.
+Ardından kötü haber geldi.
+Sanatçının yarışmaya ikinci katılışı olacak.
+Bu fiyata, filmin korsan olacağı kesin.
+Yeni mağazada 70 binin üzerinde ürün bulunuyor.
+Romanya'da faal durumda sadece 30 sinema var.
+Etkinliğe 107 ülkeden toplam 573 öğrenci katıldı.
+Ülkede 2256 sandık merkezi olacak.
+Vatandaşlar zam haberini iyi karşılamadı.
+Filmin senaryosu da Bagiç'e ait.
+Kampanyası sekiz ana tema üzerinde yoğunlaştı.
+Bekaj Musliu'nun akrabası.
+Gül'ün göreve aday olması bekleniyor.
+Altyapıda pek çok iyileştirme yapılması gerekir.
+Karşılıklı olarak bayram tebrikleri ediliyor.
+Olaylar uluslararası alanda da kınandılar.
+Fakat bazı iddiaların sınırları var.
+Bunun sonucunda üç bebek hayatını kaybetti.
+Fakat antolojiler yoğun şekilde tanıtıldı.
+Türkiye için müzakere sürecine geçildi.
+Bu, öngörülen yüzde 8.5'lik enflasyon oranını gözden geçirmeyeceğiniz anlamına mı geliyor?
+Krstiç şu anda 46 yıllık hapis cezasını çekmekte.
+Yine de ilerleme kaydediliyor.
+Şeffaflık eksikliği bunu anlamayı zorlaştırıyor.
+Uydu 720km irtifada yörüngeye oturdu.
+İngilizce ve Fransızca biliyor.
+En az 20 kişi donarak hayatını yitirdi.
+Genel başkanlık seçimi 11 Kasım'da yapılacak.
+Ama yenilmedik, diz çökmedik ve ezilmedik.
+Bir diğer yorumcuya göre bu doğru, fakat kime şikayet etmeli?
+Ancak diğer görüşler de gelmekte gecikmedi.
+Futboldan sonra hayat var mı?
+Diplomasi sabır ve zaman ister.
+Beş göstericinin silah taşıdığı iddia ediliyor.
+Çalışanlar 40 günden fazla süredir grev yapıyor.
+Genç Blerina, burada tıp öğrenimi görüyor.
+Pliva'nın çok büyük zarara uğraması bekleniyor.
+Bu plan yakında hayata geçmeli.
+Rakamlar, kaynağa göre değişiyor.
+Dünya Kupası geldi.
+Biz kaç kişiyiz?
+Sırp ve Hırvat aşırılık yanlıları da var.
+Bizler burada doğduk ve burada kalmalıyız.
+Kuş gribinin kuş göçleriyle yayıldığı sanılıyor.
+Ardından hamuru iki parçaya bölün.
+Cuma günü, eski başbakan parlamentoya seslendi.
+Maaşlar ve emekli aylıklarında kesinti yapıldı.
+Diğer görevler henüz belirlenme aşamasında.
+Sadece gelinlik yaklaşık 40 kilo gelir.
+Yoksa sadece bir hayalpereset ve sahte bilimadamının uydurduğu bir yanılsama mı?
+Bağış anlaşması 1 Ağustos'ta imzalandı.
+Turnuvaya 13 ülkeden 90 sporcu katıldı.
+Noel, bir sonraki gün yani 7 Ocak'ta kutlanır.
+Atina takımı dördüncü şampiyonluğunu kazandı.
+Sürecin bu sonbaharda başlaması bekleniyor.
+Bizim yükümlülüğümüz, belgeye harfiyen uymaktır.
+Yıllarca önce dünya dokuzuncusu olmuştu.
+Toplam 110 bin avro ödül dağıtılacak.
+Olayın ilk saatlerinde yaralanma bildirilmedi.
+Bu güne Badnik adı verilir.
+Köyler yok olurken binlerce kişi evsiz kaldı.
+Geçen yılsa bu rakam 510 milyon euro idi.
+Bu Sırbistan'ın ilk maç günüydü.
+Buzhala buna katılıyor.
+Fakat bu durum değişmek üzere.
+Herkes de iyimser değil.
+Olağanüstü oynadığımızı söyleyemem.
+Burada da Madrid'te olduğu gibi kamuoyunun görüşünün değişmesini mi bekliyorlardı?
+O zaman, sahneye yeni adaylar da çıkabilecek.
+Takım, finallere yükselecek 12 takımdan biri.
+Önerilen bakanlardan en az beşi otuzlu yaşlarda.
+Karar, yurtdışındaki iki olay sonrasında alındı.
+Soğuk Savaşın sonundan bu yana devam ediyor.
+Bence bu çok olumlu bir işaret.
+Ekonomik bir hac sanki.
+Manastır şu anda elden geçiriliyor.
+Sonuç elde etmek zorundayız.
+Bu miktar son safhada 1 milyon ton artacak.
+Projenin toplam maliyeti 154 milyon euroyu geçti.
+Satın alınan hisse miktarı açıklanmadı.
+Bu ekibe ayrıca üç yerel doktor eşlik ediyor.
+Uçuş planı dediğimiz şey budur.
+Gün boyunca aileler birbirlerini ziyaret ederler.
+Satıştan 84,7 milyon avro gelir elde edilebilir.
+Diğer tüm parti üyeleri 40 ve üstü yaşlarda.
+Müzakerelerde uluslararası varlık da gerekli.
+Balkanlar'da uyuşturucuyla mücadele beşlisi mi?
+Yeni işler 3 ila 11 aylık süreleri kapsıyor.
+Bu iddialara yanıtınız nedir?
+Başsavcı olayla ilgili soruşturma başlattı.
+Biz tam desteğimizi garanti ediyoruz.
+Operasyon olaysız geçti.
+Bunların her birinin kendi logosu ve damgası var.
+Sırbistan'ın organ donörlerine ihtiyacı var.
+Artık bunun için çok geç.
+Bulgaristan'ı güçsüzleştirir.
+Agogiatis ise daha iyimser.
+Ardından kilisede evlenme töreni yapılıyor.
+Onun konusu nedir?
+Etkinlik 26 Ağustos'a kadar devam edecek.
+Yasaya uymayanları ise ağır cezalar bekliyor.
+Etkinlik Cumartesi günü sona erdi.
+Memur maaşları reel bazda %6 oranında arttı.
+Anlaşmanın değeri 500 milyon dolar.
+Ürünlerimizin kabul edilmesini istiyoruz.
+Kosova 80'den fazla ülke tarafından tanınıyor.
+Bu noktada sizi bekleyen büyük güçlükler nelerdir?
+Yarışmaya 100'den fazla ülkeden katılım oldu.
+Bir kişi eksik kalan Sırp takımı vites yükseltti.
+Hiç umudum yok.
+Sırbistan, Kosova meclisini feshetti.
+Ve tüm dünyanın gözü onların üzerinde olacak.
+Sizce Hollanda bu tavrıyla ne tür bir mesaj veriyor?
+Sizi bu iş için birileri mi tavsiye etti?
+Önde gelen borçlular ise devlet kurumları.
+Üçlü yeni bir çözüm önerdi.
+O zamandan beri, filme bilet bulmak oldukça zor.
+Bunun nedeni kısmen hizipçilikte aranabilir.
+Şimdiye kadar toplam 13 kişi gözaltına alındı.
+Fakat bu dönüşüm nasıl gerçekleşebilir, bu açmazdan nasıl çıkılabilir?
+Calasan yetenekli çocuk bursu da aldı.
+Onlar şanslı olanlar.
+Mevcut hükümetin, bu sorunu çözüme kavuşturmayı başaracağını düşünüyor musunuz?
+Buraya daha önce hiç gelmedim.
+Bir kere çözdünüz mü bir daha donduramazsınız.
+Komisyon başbakana rapor verecek.
+Özel ve kamu yatırımlarında azalmalar var.
+İşlerin yapılması bu sayı yeterli mi?
+Fenerbahçe Ülker listesini kapattı.
+Kalogeresis aynı fikirde değil.
+Krstiç, 46 yıl hapis cezasına çarptırıldı.
+Bu konuda ne düşünüyorsunuz?
+Notlardaki görünüm istikrarlı olarak açıklandı.
+Kongreye 17 ülkeden katılımcılar katıldı.
+Bakan şu ana kadar bir yorum yapmadı.
+Ancak hükümet tutumunu değiştirmiyor.
+Bunun dışında bir başına bu yaşlıca teyze.
+Diğer partiler gereken baraja ulaşamadılar.
+Hepsi de hasta adamlar, çocuklar ve yaşlılardı.
+Belgrad da aynı derecede kuşkulu görünüyor.
+Ancak haklı olan taraf biziz ve kazanacağız.
+Obama bu konuya da değindi.
+Minsk'te bir Romen şampiyon parladı.
+Exit'i desteklemeye hazır mıydılar?
+Yeni ve modern gümrük yasası, Sırbistan'da yolsuzluğu önleyip normal ticareti tesis edebilecek mi?
+Oylama büyük olasılıkla 21 Ekim'de yapılacak.
+Pliva adını ve markasını koruyacak.
+Böyle bir durumda Kosova'nın temsil düzeyi ne olur?
+Projenin sonuçları Nisan ayında yayınlandı.
+Hırvat takımı, jüri özel ödülünü de aldi.
+Bununla, adalet yerini bulmuş oldu.
+Rojs'un iddiaları polisin de ilgisini çekti.
+Bunların 10 milyon avroluk bir bütçeleri var.
+Jonuz, kısa süreli görevi kabul eden tek adaydı.
+Bu arada seçimler de yaklaşıyor.
+Bu tür önkoşulları yerine getirmek kolay değil.
+Bulgaristan listede 33. sırada yer aldı.
+İstisnasız olarak dost canlısı insanlar.
+İki maçın toplu sonucu 2-2.
+Geri kalan iki oyu bulmak zorundalar.
+Sahil köy evleriyle çevrilmiş durumda.
+Zanlıların hepsi de Trabzonlu.
+Sonuç olarak da hizmetler ertelendi.
+Bazıları bu trende karşı çıkıyor.
+BU önlemlerin bazıları şimdiden alındı.
+Berişa Rama'ya, önerisini inceleyeceğini söyledi.
+Sizce bu görüş ayrılıklarının nedeni nedir ve bunların üstesinden nasıl gelinebilir?
+İnşaatın iki yıl içinde başlaması bekleniyor.
+Uzmanların söylediklerine kulak verelim.
+Ve Bayrami zamanın tükendiğini biliyor.
+Şimdi, ihalenin iptali, mali istikrarı da bozdu.
+Açılış 6 Nisan'da.
+Ana sorun finasman.
+Yüksek öğretimdeki rakamlar daha da düşük.
+İnşaata hemen 2013 başlarında başlanacak.
+Fonlar beş Türk bankası kanalıyla verilecek.
+Ancak yetkililer bu olasılığı dışlıyor.
+Şimdi başarılı olup bu bariyeri kırarlar mı?
+Yeni hükümeti zor bir görev bekliyor.
+Çok sayıda yorumcu da buna katılıyor.
+Yeni fiyatlar gelecek ay yürürlüğe girecek.
+Ancak grubun gündeminde sırf çalışmak yok.
+Bunun Kosova'daki genel güvenlik durumu üzerindeki etkisi ne olacaktır?
+Yarışmaya 27 ülkeden şarkıcılar katıldı.
+Toplam yatırım 20 milyon avroyu buldu.
+Binlerce kişi evlerinden göçe zorlandı.
+Hükümet geçiş için fon ayırdı bile.
+Peki ya yerli halk?
+Bu da Demos'un görevlerinden biri.
+Bu nedenle favori olarak görülmüyor.
+Muvazzaf subayların sayısı ise 60 bin civarında.
+Noel turtası eskiden bir ana yemekti.
+Festival 6 Nisan'da sona eriyor.
+Peki siz bu ilişkiyi nasıl nitelendiriyorsunuz?
+Seçim yasasında ne gibi değişiklikler yapılmalı?
+Anlaşma 1 Temmuz'da yürürlüğe girecek.
+Yeni büyüme motorlarına ihtiyacımız var.
+Anlaşmanın değeri 360 milyon dolar.
+Prag'ın baharı vardı, Belgrad'ın neden olmasın?
+Yaşamınız ve çalışmalarınıza herhangi bir etkisi oldu mu?
+Kitabı da bunun için yazdım zaten.
+Dünya Afrika kültürünü hissetme fırsatı yakaladı.
+Bazı durumlarda maaşlar yüzde 90 arttı.
+Seçimler 16 Kasım'da yapılacak.
+Bunlar faşist.
+Tipik Roman yüzü var bende.
+Dodik'e karşı olan tavrınızda herhangi bir değişiklik oldu mu?
+Toplantılar iki haftada bir yapılacak.
+Ve bunun ülke ekonomisine etkisi ne olacak?
+Sonra kendi de onlardan birisi oldu.
+Rakamlar da mevcut ilgiyi anlatmaya yetiyor.
+Genişleme, coğrafi açıdan da önem taşıyor.
+İki milletvekili ise çekimser kaldı.
+Profesöre göre, sürecin aşamalı olması gerekiyor.
+Peki tüm bunlar gerçekleştirilebilirse ne olacak?
+İki kadın aday var.
+Forumda 26 ülkeden temsilciler yer alacak.
+Faksın nereden gönderildiği belirlenemedi.
+Ancak Sırbistan bir zam dalgası da yaşıyor.
+Pek çok seçim sınavından başarıyla geçtim.
+Projeye 2010 yılında başlanması planlanıyor.
+Tesiste ağır hasar meydana gelmişti.
+Sergiye 14 ülkeden 145 sanatçı katıldı.
+Bu da Enstitüye 251 milyon avroya mal oldu.
+Hükümetin değişmesi halinde müzakereler ve katılım süreci ne yönde etkilenir?
+Bütçenin birkaç yıllık programlanması ise şart.
+Hustinx de bu görüşte.
+Ülkedeki son seçim kampanyası oldukça sönüktü.
+Güney Sırbistan'da ülkenin geri kalanına kıyasla daha fazla basın özgürlüğü mü var?
+Bu ilke ciddi trafik suçlarında uygulanmayacak.
+Seydiu'nun hareketi bazılarına sürpriz oldu.
+Proje Mayıs 2005'te meclise sunulacak.
+Bu konuda yapılmış pek çok şey var.
+Kararlı fakat dayatmasız tavrı öfkesini gizliyor.
+Sonuçta tüm bu ülkeyi, köprüleri, fabrikaları kim inşa etti?
+Cazseverler de kendi paylarına düşeni aldılar.
+Bu durum komisyonun kararlarını etkiliyor mu?
+Kampanyalar 15 Haziran'da başladı.
+Momo ülkenin sürpriz hareketine katılmıyor.
+Bu çok açıktı.
+Kotooshu unvanı 13-1'lik skorla kazandı.
+Diğer iki çocuğu ise Sırbistan'da.
+Çatışmada bir polis memuru hafif yaralandı.
+Ban ziyaret için kesin bir tarih vermedi.
+Peki, seçimlerin başarısını sağlayacak düzeyde katılım gerçekleşecek mi?
+Bir nanosaniye saniyenin milyarda biri oluyor.
+İki yıl önce de Belgrad'a taşınmış.
+Başbakanın mesajı açıktı.
+Yüzde 100 uygulama sağlayamayız.
+Sivil nüfus kaçtı.
+Bu durumda, iktidar partisi etkilenmeyecektir.
+Bu sözümü tutuyorum.
+Fakat gıpta etmek için çok daha iyi nedenler var.
+Bu yönde bazı önemli adımlar atıldı.
+Diğer kadın adaylar yarıştan çekildiler.
+Şimdiyse bu rakam 5 bine yaklaşıyor.
+Halka açık sigara yerlerde sigara içmek mi?
+Jani ve babası bu düşüncelerinde yalnız değil.
+Ayrıca devlet olmak herşeyin sonu da değil.
+Film yönetmenin memleketi Vaslui'da çekildi.
+Bizim politikamız budur.
+Toplam yatırım bedeli 6,5 milyon avroya ulaştı.
+Birbirimizle iletişim kurabiliyoruz.
+Ancak bölge bazı ciddi sorunlarla hala uğraşıyor.
+Fakat bazı ülkelerde Tamiflu bile zor bulunuyor.
+Ancak iyi haberler de yok değil.
+Gül'ün adaylığı sonra düşmüştü.
+Bu koalisyon konusunda ne kadar rahatsınız?
+Bu bile başlı başına bir başarı.
+Bunlar iyi işlemesi gereken ufak çarklar.
+İnsanlar bunun gibi şeyleri hatırlar.
+Görüşmelerde ikili işbirliği üzerinde duruldu.
+Her iki örgüt de aynı silahları kullanıyor.
+Arnavutluk 42'nci, Makedonya ise 72'nci sırada.
+Gürültülüydü, farklıydı, eğlenceliydi.
+General 1993 yılında öldürülmüştü.
+Bu takviye ne kadar önemli?
+Ancak çiftçiler duruşlarını bozmadılar.
+Tiran'da kaldırımda uyuyan evsiz çocuklar.
+Projelerine harcanan tek para kendi paraları.
+Kütle kaşıktan ayrılmaya başlayana dek kavurun.
+İlk BM barış gücü grubu bölgeye geldi.
+Arnavutluk'ta çeşitli gelişmeler yaşanıyor.
+Yarışmaya toplam 16 şarkıcı katıldı.
+Olayda çevre evler de hasar gördü.
+Analistler de kararların önemine dikkat çekiyor.
+Bombalardan biri patlayarak hasara yol açtı.
+İşaretler hiç de iyi değil.
+Programda on ülkeden 21 belgesel yer alıyor.
+Müzakerelere Slovenya davet edilmedi.
+Türk takımı, yarı finalde Sırbistan'ı yenmişti.
+Uçağın otomatik pilotta olduğu varsayılıyor.
+Anlaşmanın son imzalanma tarihiyse 1 Temmuz.
+O da çok iyi bir oyuncu olacak.
+Yatırım maliyeti 6 milyon avroya ulaştı.
+Şu anda ateşli bir tartışma sürüyor.
+Hükümet nihayet durumu fark etmeye başlıyor.
+Bugünse Türkiye'nin çıkarları çok daha karışık.
+Arabaların yüzde 80'den fazlası dizel motorlu.
+Başka kaynaklardan da eleştiriler gelmedi değil.
+Adalet, bu şekilde yerini bulurdu.
+Fakat projenin önünde bazı engeller var.
+Dragus filmde Klara rolünü oynadı.
+Hayal kuruyor değiliz.
+Etkinlik 4 Haziran'a kadar sürecek.
+Değişim dönemi başlamıştı.
+Ancak Celiç bu iddiaları reddetti.
+Siyasi irade var mı?
+Bunun kuzey kesimin Kosova'nın geri kalanından kopmasına yol açacağını düşünüyor musunuz?
+SC cumhurbaşkanlığı daha çok sembolik bir mevki.
+Makedonya 1.
+Küresel kriz kapıda mı?
+Ülkeler daha rekabetçi olabilmek için ne yapabilir?
+Elde edilen bilgiler halkı şok etti.
+Bu yüzden cenaze tarihi halka açıklanmayacak.
+Makedonya'daysa kayıplar %21 arttı.
+Dik uçurumlar adanın güney kıyısını süslüyor.
+Plamadeala 2005 yılında öldü.
+Kosova tüm alanlarda ilerleme kaydetmektedir.
+Maliyet 1.54 milyon euroyu bulabilir.
+Neden mi?
+Bu en yüksek risktir.
+Bir sonraki toplantının tarihi de belirlenemedi.
+En ucuz bilet 15 avroydu.
+Bunların çoğu tanınmış ve saygın kişiler.
+Yine de hala büyüme olanağı var.
+Pek çok vatandaş bu hamle konusunda hevesli.
+Bu ay içinde uluslararası bir ihale açılabilir.
+Bu şüphelere ne yanıt veriyorsunuz?
+Sergi 17 Haziran'da sona erecek.
+Onları bekleyen başlıca güçlükler nelerdir?
+Nokia fabrikanın inşaatına bu baharda başlayacak.
+Bu olursa, güvenlik durumu üzerinde nasıl bir etki yaratır?
+Onun yerine yeni tur müzakereler başlatıldı.
+Dünya Kupası için yeni inşa edilmiş.
+Bir tavayı yağ veya terayağıyla yağlayın.
+Makedonya toplam 6,33 puan aldı.
+Yine de, diğer açılardan aynı kaldı.
+İşbirliği ihtiyacı muazzam.
+Ve ilk defa, yıl sorunsuz başladı.
+Burada olmaktan son derece memnunum.
+Üzerine pudra şekeri ve vanilya şekeri serpin.
+Yatırımcılar bahisleri Yunanistan'a yatırdı, peki geri ödeyecek mi?
+İşin en zor kısmı aileleri ikna etmek.
+Tarih köprüyü bir Balkan simgesi haline getirdi.
+Merkez bankası üzerinde ne kadar politik baskı var?
+Aynı düzenleme yargı için de planlanıyor.
+Nasıl bu kadar çok izin verilebilir, anlamıyorum.
+Bunun nasıl başarılabileceği konusunda herhangi bir düşünceniz var mı?
+Bunlar ne tür değişiklikler olacak?
+Gotovina 2001 ortasından beri kanundan kaçıyor.
+Projeler programın gerisinde ve durmuş durumda.
+Erdoğan, yatırımlara mı öncelik veriyor?
+Programda 110 film yer alıyor.
+Bu bilgiler resmi olarak doğrulanmış değil.
+Andriç'in 1982 yılında dünyaya geldiği ev.
+Gerçekten.
+Kamuoyu ikiye bölünmüş durumda.
+Festival iki yıl içinde tekrarlanacak.
+Pek şimdi ne olacak?
+Adının açıklanmasını da istemiyor.
+Bugüne dek bunu kimse yapamadı.
+En zehirli yılan bile istediği yere gidebiliyor.
+Sizin bu çözümdeki rolünüz ne olur?
+Bu başarının sırrı ne? Sırp halkını klasik müziğe nasıl yakınlaştırdınız?
+Sınır hizmetlerinin işlevleri artırıldı.
+Sergi 17 Eylül'e kadar açık kalacak.
+En zor dönem buydu.
+Tum bu önerilerin sonucunu zaman gösterecek.
+Tutuklanan doktorların sayısı her hafta artıyor.
+Barış ertelendi mi?
+Ancak yeni tarzdan herkes memnun değil.
+Bir depo sahası bulma mücadelesi beş yıl sürdü.
+Bu, Johannesburg'da sahip olmadığımız bir lükstü.
+Bu durum 1990'larda ülkenin bölünmesiyle değişti.
+Yani hiç kâr etmedik.
+Ortak sınır aynı zamanda Schengen sınırı olacak.
+Sizce bu durum Kosova'da istikrarsızlık yaratıyor mu?
+Bunların yalnızca bir kısmı kaldı.
+Her hükümet aynı olacak.
+Hükümet bu hamleyi yapmaya tamamen hazır.
+Dava Nisan ayı başlarında sona erdi.
+Bir kırmızı kart, bir de penaltı.
+Daha sonra görüş belgesini oluşturduk.
+Türk kamuoyu bundan haberdar değil.
+Bu ülke Romanya'daki en büyük yatırımcıdır.
+Mesele Türkiye'de oldukça hassas bir sorun.
+Tzadari de temerrüt çağrısında bulundu.
+Bölgeden önemli haberlerin haftalık derlemesi.
+Lütfen yorumlayın.
+Bu göz yumulamayacak kadar ciddi bir sonuç.
+Beş yıldızlı bir eğitim kampı!
+Grguriç çocukluğundan beri bir Lego hayranı.
+İki gelirle bile zor geçiniyorlar.
+Arsa yaklaşık 7 milyon avroya satılacak.
+Bunların yalnızca birkaç bini geri döndü.
+Teller Mart ayı başlarında kaldırılacak.
+Eski tesis sadece 20 kişi alıyordu.
+Ancak yasanın geçirilmesi engellendi.
+O dönemi nasıl atlattınız?
+Dördüncü şahsın menşei belirlenemedi.
+Gözünüzün önünde değilken onları düşünmüyorsunuz.
+Sorun çözmek yerine sorun yaratıyorum.
+Şimdiki oran yüzde 52.
+Limaj ise ev hapsinde tutuluyor.
+Kurumlar vergisi de %10'a indirilecek.
+Yaşamla ilgili ayrıntıları neden netten herhangi biri görsün diye yayınlanır?
+Öte yandan Türkiye de bir karşı hareket başlattı.
+Evetse, bu sürecin arkasındaki itici güçler neler?
+Bir sürü yerde indirim hakları vardı.
+Santralin inşası 2012 yılı sonunda tamamlanacak.
+Sorunu çözer mi? Hayır.
+Bu hat başkent Lefkoşe'yi de ikiye bölüyor.
+Hayranlar sırılsıklam fakat heyecanlıydılar.
+Biz bir öneride bulunduk.
+Rakamlar korkutucu seviyede.
+Ve tabii ki, banyoda kaçak var.
+Kömür ihracatı da sekteye uğrayabilir.
+Kayak kulüpleri de iyimserler.
+Bu belge niçin çok önemli?
+Kimi zamlar ise dünya piyasalarına atfediliyor.
+Rekor sayıda 11 aday yarışıyor.
+Papa 16.
+Türkiye, Ortadoğu'da yaşanan demokrasi hareketlerinden fayda sağlayabilir mi?
+İbar Nehri'nin aşağısındaki Sırplar kuzeydekilerden farklı mı?
+Tahliyesinden sonra da ülkeden ayrıldı.
+Bu işlem, seçimlerden önce gerçekleştirilecek.
+Ancak Belgrad makamları isyan halindeler.
+Basescu lafı gevelemekten hoşlanmıyor.
+Fakat müşteriler durumdan memnun görünüyorlar.
+Kural 1 Haziran'da yürürlüğe girecek.
+İnsanlar zahmete girmiyor.
+Türkiye de yardım eden ülkelerden biriydi.
+Umarım bu şekilde anlaşılmıyordur.
+Etkinlik 22 Mayıs'a kadar açık kalacak.
+İnşaat için 1 milyar dolarlık yatırım gerekiyor.
+Program Nisan ayında başlayacak.
+İddia ettikleri gibi maske takmıyordum.
+Peki Kostunica daha ne kadar dayanabilir?
+En az 60 kişi hayatını kaybetti.
+Carrefour'un ülkede altı mağazası bulunuyor.
+English görevi bu ay devralacak.
+Adını aldığı ülkeden de daha uzun yaşadı.
+O tarihten bu yana festival değişti ve gelişti.
+Dağıtımcı firmalar fiyatları haksız yere mi yükseltiyor?
+Bu denli büyük bir başarı elde etmeyi bekliyor muydunuz?
+Kurban Bayramı'nın sabah namazı özel bir namaz.
+İstanbul'da protesto eden bir gazeteci.
+Maç, oldukça diplomatik bir sonuçla 1-1 bitti.
+Yine de bazı ilerleme kıvılcımları var.
+Kosova'daki yargı reformu bunlarla başlıyor.
+Birçok duvar resmi ve ikona 13. yüzyıldan kalma.
+Bir analist, ayrıntılı bilgi istediğini belirtti.
+Plan ile ilgili sorunlardan biri de zamanlama.
+Katılım oranı da diğer bir değişken.
+Yine de hükümet teknolojiye geçişi savunuyor.
+Bu düşüncesinde yalnız da değil.
+Bianca İngiltere'den Belgrad'a ilk kez gelmiş.
+Musliu, hakkındaki tüm suçlamaları reddetti.
+Tadiç ise bunu yapmayı reddetti.
+Bizim için utanç verici bir veda.
+Bankaysa bu iddiayı reddediyor.
+Buna karşılık hediye veya rüşvet kabul etmeyecek.
+Üç Bulgar filmine de ödül verildi.
+Bunlar devletin en yüksek mevkilerinde bulunmuyorlar mı?
+"Yaşamak istiyorum!" Rukavina'nın mektubunun ilk satırıydı.
+Aynı kültüre sahibiz ve dillerini biliyoruz.
+Sonuç konusuna iyimser mi bakıyorsunuz?
+Lükse yer kalmıyor.
+Bu yılki fuarda 25 binden fazla kitap tanıtıldı.
+Festivalde uzun yol kat edildi.
+İki parti de seçmene yabancılaşmak istemiyor.
+Ne tür değişiklikler yapılması planlanıyor?
+Gençler bizim geleceğimiz.
+Ancak sonuçları kimse inkar edemez.
+Nastase yenilgiyi Pazartesi günü kabullendi.
+Makedonya'nın Prilep kentinde düzenlenen 34.
+Öcalan beş yıldır İmralı Adası'nda tutuklu.
+Buraya fare düşse zehirlenir.
+Küreselleşmenin etkisi de dikkate alınmalı.
+Bazen baskı fiziksel şiddete de dönüşüyor.
+Bugün Goralılar üç ayrı ülkeye dağılmış durumda.
+Etkinlik 15 Mayıs'a kadar devam edecek.
+Tabii bu sadece bir ilk adım.
+Aliu gıyaben ömür boyu hapse mahkum edilmişti.
+Kosova-Sırbistan barış antlaşması mı geliyor?
+Bizim için belirleyici maç.
+Buna yanıtınız nedir?
+Vizeli mi vizesiz mi?
+Inga suçu tamamen başbakana atıyor.
+Festival 5 Ağustos'a kadar devam edecek.
+Bu sayede durum sakinleşebilir.
+Fakat Noel'de birazcık olsun savurganlık yapmaya güçleri yetti mi?
+Satış bedeli 120 milyon avro oldu.
+Bir diğer zanlı ise aranıyor.
+Alışkanlıkları ve adetleri nelerdi?
+İkinci gün, işler beklenmedik şekilde değişti.
+Bazıları hayatı oluruna bırakmıyor.
+Ancak verdiği kararlar önemli etik güce sahip.
+Önemli adımlardan biri atıldı bile.
+İstanbul forumundan 54 karar çıkması bekleniyor.
+Sınır ötesi harekât için meclis onayı gerekiyor.
+Sizin bu konudaki görüşleriniz nedir?
+G17 Plus partisine ise dört bakanlık verilecek.
+Eylül 2001'de yeni bir yarışma yapıldı.
+Ondan sonraysa yüzde 6,75'e yükseliyor.
+Vatandaş hergün aç.
+İhaleye sekiz başka şirket de katıldı.
+Tutuklananların ikisi de Sırp vatandaşı.
+İki yıllık abone olunca 15 avroya satın aldım.
+Fouere iki ülkeyi sorunu abartmamaya çağırdı.
+Ekonomik kriz yüzünden yaz tatiline çıkamıyor musunuz?
+Batı Balkanlar'da güvenlik konusunda ne düşünüyorsunuz?
+Buna karşın, Arnavutluk'ta asgari ücret 142 avro.
+Bu 44 kurumun yasal kapasitesi 38.227 mahkum.
+Müzakereler resmi olarak 31 Ocak 2003'te başladı.
+Konser günü tek sorun hava durumu değildi.
+Bunu kimi anlıyor, kimi anlamıyormuş.
+Diğer partilerse açık farkla geriden geliyor.
+Splitli yüksek atlamacı yılın sporcusu seçildi.
+Dükkânlar kapanıyor.
+İsrailli yetkililer bu konuyu düşünmeli.
+Sergi Ocak ayına kadar devam edecek.
+Seçmen katılımı Mayıs ayındakinden bile düşüktü.
+Şikayet edemem doğrusu.
+Bunların ikisi de mümkün değil.
+Papadoniou belli bir koşul önermedi.
+İftardan sonra hemen eve gidilmiyor.
+O zamandan bu yana ilerleme kaydedildi.
+Halk için asıl kriz sosyo-ekonomik.
+Şimdi sıra onlara geldi.
+Desteğin toplam değeri 5 milyon avro.
+Eşi, oğlu ve torunuysa ağır yaralandı.
+Ama artık öyle değil.
+Ancak Dodik çabalara katılmayı reddediyor.
+Etkinlikte 70'ten fazla film gösterildi.
+Fakat gösterinin yıldızı erken havlu attı.
+Katliam devam etti.
+Bu, beklemediğimiz bir dış müdahaledir.
+Böyle davrandığımız için özür dileriz.
+"Bugüne kadar neler denedin?"
+Şirket tesisi 2011 yılında açmayı planlıyor.
+İş adamı, hayatının seyahatine çıkıyor.
+Benim için anlamı büyüktür.
+Seçimlerde on aday yarışacak.
+Konu, dinleyicilerin bam teline dokundu.
+İsmin ne önemi var?
+Fakat bu sadece başlangıç.
+Olay Türkiye'de farklı tepkilere yol açtı.
+Satıcılar açıkgöz ve deneyimli.
+Bugün oluşumun bünyesinde 85 ülke yer alıyor.
+Bunlar bu yasanın düzenlemesi gereken konular.
+Ayrıldıklarında, Meyrema sadece sekiz yaşındaydı.
+Listede yer alan kişiler 12 ay süreyle izlenecek.
+Siyasi sorunları çözemeyiz.
+Ekspedisyon üç hafta sürdü.
+Bombalardan biri patlarken diğeri patlamadı.
+İlk atışı yapan Konstantinos oldu.
+Bu miktarın yaklaşık 9800 tonu ihtiyaç fazlası.
+Fakat artık isim, ikincil bir rol alıyor.
+Adil oldu mu?
+"Kurtlar Vadisi" nefreti körüklüyor mu?
+Tihiç dört yıl daha görevde kalacak.
+Ancak ülkeyi daha pek çok güçlük bekliyor.
+Yasa geriye dönük olarak uygulanacak.
+Bankadan alınacak yardım üç alanda yoğunlaşacak.
+Fakat görevinin kendisine uydurulması gerekiyor.
+Oylama Perşembe günü yapılacak.
+Bu, toplumumuzdaki durumun bir yansıması idi.
+Bu da çok daha fazla ortak çaba gerektiriyor.
+Gerçekler oldukça çatışan sinyaller vermektedir.
+Türkiye ve İsrail uzlaşabilecek mi?
+Stadyumlarda sık sık kavgalar çıkıyor.
+Bu, üçüncü kez saldırıya uğrayışım.
+Baraj sulama için gerekli suyu sağlayacak.
+Tudjman'ın mirası tartışmalı.
+Bu, bölgeyle ilgili alınan üç karardan biriydi.
+Fabrikada 350 kişi çalışacak.
+Bitola'daki bir ilkti.
+Etkinlik 8 Ağustos'ta başladı.
+Anlaşmanın ayrıntıları belirsizliğini koruyor.
+Türkiye 1960'tan bu yana üç askeri darbe gördü.
+Bu meselenin bu yıl içinde çözüleceğinden eminim.
+Çiftçiler en başta iyimserdiler.
+Bu sevkıyat da Bulgaristan'a gidiyordu.
+Hırvatistan bir ay sonra yeni ülkeyi tanıdı.
+Ancak bu durum değişti.
+Etkinliğe engelli koşucular katılacak.
+Buraya kadar her şey güzel.
+Sırp bakan Euromoney dergisi tarafından seçildi.
+Çocuklar yerel kliniklerde aşı olabilecek.
+Bilim eziyet verici olmaktan çok eğlenceliydi.
+Seçkin ödülü sel önleme projesiyle kazandı.
+Diğer ülkeler, iç ihtiyaçlara odaklanıyor.
+Ve bu, yaşanan sorunla ilgili tek örnek değil.
+Bugünse sorgu sayısı belirgin derecede azaldı.
+Bu tür bir sonuç Kosova sorununa çözüm bulunmasına yardımcı olabilir miydi?
+Bu anlaşmazlığın yakında sona ereceğini düşünüyor musunuz ve sizce müzakereler ne yönde ilerler?
+Belki olurdu.
+Aynı yıl cami de hasar görmüştü.
+Bu sefer durum çok daha farklı.
+Valovoi değişim umut ediyor.
+Bayrami şimdi hapishanede cezasını çekiyor.
+Fakat bunların çoğu gezilerini iptal ettiler.
+Bu yılki festivale 49 film katıldı.
+Mahkemenin görev süresi 2014 yılında sona eriyor.
+Ya tahmin hatalı çıkarsa?
+Fakat pek kişi de gereksiz olduğu görüşünde.
+Yeteri kadar isteklilik veya beceri yok.
+Karışımı sertleşene kadar yoğurun.
+Bu uygulamaları gerçekleştiriyoruz.
+Parlamentoya girmek istiyorsunuz.
+Bunların 32 milyonu Slovenya üzerinden geldi.
+Pek çoğu da hapse atılmıştı.
+İkincisiyse kredi toplamının yarısını karşılıyor.
+Ama onlar bunu yapmadı.
+Bu süreç nasıl gerçekleşiyor ve devlet idaresi böyle bir davranışı kabul ediyor mu?
+Kosova Cumhurbaşkanı liderlik ödülü aldı.
+Sergi 25 Mayıs'a kadar açık kalacak.
+Bu iş kolay olmayacak.
+O dönemle şimdi arasında bir fark var mı?
+İş dışında da kendini sürekli meşgul ediyor.
+Üretimin yüzde sekseni ihraç edilecek.
+Banka borcum ne diyor?
+Liderliğinizi uygulayın.
+Arnavutluk'ta turizm hâlâ emekleme döneminde.
+Görünüşe göre para sorun değil.
+Yeni ders kitapları da övgü topladı.
+Dava beş yıldan uzun sürdü.
+Aslında böyle bir şey yok.
+Buralarda nadiren fatura kesiliyor.
+Etnik ayrılıkların parçaladığı bir ülkede gerçek anlamda bir etnik çoğulluk mümkün mü?
+Kurbanlar anısına sokaklara çiçekler bırakıldı.
+Fakat Romanya'daki okullar bu değişikliği kaldırabilecek mi?
+Bulgaristan ise 42. sırada yer aldı.
+AB sonucu memnuniyetle karşıladı.
+Ülkedeki hiç kimse oylamanın sonucuna şaşırmadı.
+Bazı dış yatırımlar da zarar gördü.
+Ancak günün geri kalanında haberler iyiydi.
+Buğdayın fiyatı artmıştır.
+Söz konusu kişilerin eskiden yaşadıkları yerlerin güvenliği konusunda bize ne söyleyebilirsiniz?
+Kosova'yı ne bekliyor?
+Balkanlar'da da bu daha az geçerli değil.
+Ancak bugün daha farklı düşünüyorum.
+Gerçekten de bu süreci hızlandırmak istiyoruz.
+Bu sistem işe yarıyor.
+Ancak reformu siyasi bağlamı pek dostça olmadı.
+Taslak onay için parlamentoya gönderilecek.
+Takım şimdiden bazı hayal kırıklıkları yaşadı.
+Partiyse bu tür iddiaları reddediyor.
+Sağır son Olimpiyat şampiyonuydu.
+İnsanlar sadece basketbol konuşuyorlardı.
+Kulüplerde oynayamıyoruz.
+Yelpazenin diğer ucunda doğum oranı yer alıyor.
+Bu gece Sırbistan kutlama yapıyor.
+Söylediği şey de yanlış değil.
+Duruşmanın gelecek yıla sarkması bekleniyor.
+Şimdiyse 56 sandalyesi olacak.
+Sinema tek altenatif değil.
+Havaalanı, 1996'da sivil uçuşa açılmıştı.
+Liderler devam eden ikili meseleleri görüştüler.
+Bunun psikolojik baskısı çok büyük.
+Bence bu son derece yanlış bir kavram.
+Çabalarının karşılığını da aldılar.
+Pisari uyarıyı duymadı.
+Bu cesur iddialar doğru mu?
+Binlerce kişi de coşkuya stadın dışından katıldı.
+Bazen öykülerini fısıldadıklarını duyabilirsiniz.
+Ne iş olsa yaparım.
+Yunanistan, bazı ülkelerin heyetlerine yönelik ek tedbirler alıyor mu?
+Bu yılki festivale 25 ülkeden 85 film katıldı.
+Ancak bedel çok daha yüksek olabilir.
+Bölgesel işbirliği için iyi bir gerekçe vardır.
+Sırp yüzücü, Pazar günkü yarışmada birinci oldu.
+Söz konusu ikinci özellik ise kitlesel göç.
+"Rugovizm" nedir?
+Karar, şirketi özelleştirme planlarını bozabilir.
+Yarışmacılar aylardır şarkılarını tanıtıyorlar.
+Ülke çapındaki katılım 5 bini geçmedi.
+Zamanla, talepleri büyük miktarda nakde döndü.
+Ana yemek ya domuz ya da kuzu rostosu oluyor.
+Öfkeyi azaltmak zor olabilir.
+Ancak bu mahkeme sadece danışmanlık rolüne sahip.
+Bunun hakkında ne düşünüyorsunuz?
+Milli takımın kötü taraftarı yok.
+Bu çocukları, en öncelikli grup olarak görüyorum.
+Ancak duruşmalar henüz sona ermedi.
+Kızgın sürücüler olayı mahkemeye götürdüler.
+İki bölümlük dizinin ikinci bölümü.
+Bazı analistler böyle bir risk olduğu görüşünde.
+Kapsamlı bir rapor bu yaz hazırlanacak.
+Ancak oylama planlandığı şekilde gerçekleşecek mi?
+Tüm notlar istikrarlı görünüme sahip.
+Seçimler 17 Kasım'da yapıldı.
+Bunu derhal bir dizi tutuklama izledi.
+Son yıllarda Belgrad önemli bir gelişim geçirdi.
+İyileşmeler devam etti.
+Sergiye 13 ülkeden 43 sanatçı katılıyor.
+Yarışmaya 339 güfte katıldı.
+Bu bir kalite meselesi.
+Tabii 1990'lardan bu yana durum değişti.
+Festival Cumartesi gününe kadar devam edecek.
+Eski yasada pişman olmak yetmiyordu.
+Tutuklanan 11 kişinin sekizi Hırvat uyrukluydu.
+Hepsi de suçsuz olduğunu iddia etti.
+Priştine yönetimi tutumunu hiç de gizlemedi.
+Ödül 2 milyon avro olacak.
+Festivale 14 binden fazla seyirci geldi.
+Festivale 50 yabancı film katıldı.
+Artık iktidardaki kimseye güvenmediğini söylüyor.
+Zafer Rusya'ya karşı oynanan karşılaşmada geldi.
+Bunlar bizim hedeflerimiz.
+Kısaca anfiler ve sınıflar tekrar doldu.
+Bu katılım hangi koşullarda olacak ve ne zamana kadar devam edecek?
+İranlılar da talebe uydular.
+Ancak organize suç suçundan aklandı.
+Sonra her şey değişti.
+Olayların failleri bulunamadı.
+Yetkililer ise aksini iddia ediyor.
+Siz ne düşünüyorsunuz?
+Bazı durumlarda bu uzun bir süreç olacaktır.
+Gazete körler alfabesinde basılıyor.
+Söz konusu tarafa mensup olmaktan dolayı bir sorun yaşıyor musunuz?
+Savcılar, şaibeli nedenlerle davadan alındı.
+Ancak bu kanıtlar mahkemede engellendi.
+Şimdi onu zar zor hatırlıyor.
+Kimileri ise protestolardan etkilenmiş görünüyor.
+Bize biraz festivalin tarihçesinden ve nasıl başladığından bahseder misiniz?
+Çıkarılmayı bekleyen yalnızca bir tek yasa var.
+Bu yıl hedefler daha iddialı.
+Meclis kesintileri Ekim ayında değerlendirecek.
+Filmin galası 2011 yılında yapılacak.
+Yolunda nasıl donuk ve acı sözlerime sağır hale geldin?
+Komisyon çifte vatandaşlığı da tartışıyor.
+Maaşları düzenli olarak ödeniyor.
+Harcamalar genellikle gelirlerin üzerinde oluyor.
+Bu suçlamalara yanıtınız nedir?
+Aşağı trend bu yılın ilk üç ayında da devam etti.
+Bazı tanıklar ifade vermeyi reddetti.
+Priştine seyahat ve turizme odaklanıyor.
+Bana hiçbir yeni öneri getirilmedi.
+Ancak Hiseni suçlamaktan da geri kalmadı.
+Hüseyni ise bu düşünceye kızıyor.
+Yağmur aynı zamanda temizler.
+Peki polis reformunun gerçekleştirilmemesi kimin için faydalı olacak?
+Pukaniç hem saygın hem de tartışmalı bir isimdi.
+Resmi iade süreci birkaç hafta sürebilir.
+Bende mücadele edeceğime bu yolu seçtim.
+Şimdi ise her düzeyde tam bir dönüşüm gerekiyor.
+Hırvatistan ise Botswana ile birlikte 78. oldu.
+Ordu, amaçlanan hedeflere ulaşıldığını belirtti.
+İspanya, protokolü onaylayan 12. üye ülke oldu.
+Bu arada bahisler de yükseliyor.
+Genel süreci nasıl değerlendiriyorsunuz?
+Fakat seyirci sözleri unutmamıştı.
+Pek çok izleme kuruluşu da bunu doğruluyor.
+İhracat tamamen askıya alındı.
+Dava Ekim ayında İstanbul mahkemesinde görülecek.
+Kuruluşun geleceği ile ilgili öngörüleriniz neler?
+Resmi adaylık dönemi hafta sonu sona eriyor.
+Yazar, böyle bir zihniyetle "aldığımız madalyalar bile büyük ikramiye!" diyor.
+Görüşmelerde ekonomik işbirliği ele alındı.
+Ancak Seydiu ayrıntı vermeyi reddetti.
+Yine de bir hukuk misyonuna ihtiyaç var.
+Eski liderin cezaya itiraz etme hakkı var.
+Ayrıca basın enformasyonundan da sorumluydu.
+Ancak sürmekte olan siyasi kriz, olası ziyaretçileri caydırabilir mi?
+Mültecilerin çoğu Sırbistan'da yaşıyor.
+Nikoliç ise %47,7 oy topladı.
+Neden oy kullanayım ki?
+Soruşturmada İsveç makamları da işbirliği yaptı.
+Ancak bu kağıdın içeriği sorunlu.
+Posavina Hırvatlarının sayısı azalıyor.
+Artık sadece bir savunma kurumu var.
+Vergi toplamıyorlar.
+Şimdiye kadar fonların yaklaşık %80'i sağlandı.
+Fakat daire tek yetkili kurum değil.
+Maras finalde 15.375 puan topladı.
+Sizce bu bütçe, mali açıdan ne kadar istikrarlı?
+Bu bizim sorumluluklarımızdan biri.
+Oysa işler pek de öyle değil.
+Aşılama, olası yanıtlardan biri.
+Ben bunu ilerleme olarak görüyorum.
+"Veya büyük anne ve babalarımızın Partiye nasıl rapor verdiğini?"
+Böyle bir belgeyi bizden daha iyi kim hazırlayabilir?
+Bugün bu sektörü nasıl değerlendiriyorsunuz?
+Bu konuda başarı sağlayabildiniz mi?
+Bir sonraki ay bir anayasa kabul edildi.
+Şimdi bu önerilerin somutlaştırılması gerekiyor.
+Ancak krediyi kimin vereceği henüz belli değil.
+Ancak hükümetin rotası bunun tersini gösteriyor.
+Bajec dış yatırımın da artacağını söylüyor.
+Obrija ailesinin babası olayda hayatını kaybetti.
+Semir Osmanagiç kolay pes etmiyor.
+Bir tavayı yağ veya tereyağıyla yağlayın.
+Ölenlerin üçü Makedon vatandaşı.
+Maç 91-77'lik skorla bitti.
+Türkiye'de turizm 2007 yılında tırmanışa geçti.
+Bu, Bulgaristan için iyi bir şey değil.
+Ancak halkın bazı yorumları var.
+Hayranlar da memnun kaldılar.
+Nisan 1992 pek çok vatandaş için hâlâ canlı.
+Bu bana çok sık olmaz.
+İnsanların size güvenmelerini sağlamak için mücadele etmek zorunda kaldınız mı?
+Bugüne kadar bunu sadece dokuz ülke yaptı.
+Sizin bu konudaki kişisel ve profesyonel görüşünüz nedir?
+Bu tarihten beri bunların sekizi tutuklandı.
+Türk icadı Almanya'da üretildi.
+Kredi 13 yıl vadeye sahip.
+Romen medyası bu yeni tavrı tepkiyle karşıladı.
+Teklif süresi bir ay içinde sona erecek.
+Gazete pazarı büyük değişimler geçiriyor.
+Proje yaklaşık 600 yeni iş yaratacak.
+Savaş dönemi sona erdi ve şimdi inşa etme zamanı.
+Yine de hala kırılgan.
+Bu olay bir ilk mi?
+Hevesle "Bu yıl farklı!" dedi.
+Belediyelerin çoğu iflas bayrağını çekti.
+Orada hayat farklı.
+Ancak bütün bu para nerden gelecek?
+Kazara oylama halk arasında ihtiyata yol açtı.
+Bir vergi politikası, nasıl bir yapıda ve ne düzeyde vergi gelirleri hedeflemelidir?
+Bu sistem iç baskı ve gerginlikleri yumuşatmıştı.
+Sırbistan'da yaklaşık 350 bin Macar yaşıyor.
+Eşit konumda değilsiniz.
+O evdeyken ödüm patlardı.
+Doğrudan ya da dolaylı olarak hepimizi etkiliyor.
+Ancak Mladiç bulunamadı.
+Aynı suçlar bizim halkımıza karşı da işlenmiştir.
+Bu arada imar düzenlemeleri de hiç sıkı değil.
+Birincilik ödülü Kosovalı motorcuların oldu.
+Örgütler daveti geri çevirdiler.
+Seçimleri nasıl değerlendiriyorsunuz?
+Partiler suistimal iddialarına işaret ediyor.
+İstikrarsızlık tehlikesi söz konusu mu?
+Bu noktada bilgi paylaşımı da giderek gelişiyor.
+Olayda yaralanan olmadı.
+Diğer sandalyelerse bağımsız adayların olmuştu.
+İnsanlar bekliyor.
+Peki küreselleşmenin bu tablodaki yeri nedir?
+Etkinlik 14 Ocak'a kadar devam edecek.
+Ancak bu görüşü herkes paylaşmıyor.
+Bazılar iyi bir neden için koştular.
+Alproud yaygın bir görüşü toparlıyor.
+Bunun ne bize ne de müşterilere faydası var.
+Romanya-Rusya ilişkilerinde gerilim artıyor.
+Bu olaylar sık sık dış basında baş haber oluyor.
+Her yer Almanlar'la doluydu.
+Partinin genel başkan yardımcısı da bir kadın.
+Renovasyon çalışmaları 152 bin avro tutacak.
+Gerçekten harikaydı.
+Bilim insanı, "Bunu neden değiştirmek gerekiyor ki?" diye soruyor.
+Proje 1200 kişiye iş yaratacak.
+Dragnea'nın seçimi pek kişiye sürpriz oldu.
+Fakat bazı radikaller ve suçlular da var.
+Bu durumun pek çok açıklaması var.
+Savcılık daha sonra suçlamaları geri almıştı.
+Çok küçük düşürücü bir durumdu.
+Yaklaşık 30 aileyi alan büyük bir ahırdı.
+Taraflar ortak bir uyarı mesajı yayınladılar.
+Seçmenler yine kendisine karşı oy versinler diye mi?
+Bunu nasıl iyileştirmeye çalışıyorsunuz?
+Ancak üretim yıllık bazda %11,6 geriledi.
+Şimdi de ülkeler bu kilometre taşını kutluyorlar.
+Bu yüzden, bu ülkeler birlikte sıralanıyor.
+Efes ise yılda 4 milyon euro gelir sağlıyor.
+Sizce bu görüşmeler bir sonuca bağlanacak mı?
+Misyonlar tam olarak belirlenmedi.
+Etkinlik 28 Eylül'e kadar devam edecek.
+İki yetkili, yasadışı göç konusunda da görüştü.
+Kuruluşun %44,84'ü ise devletin kontrolünde.
+Sorunlu alanlardan birisi belge güvenliği.
+Bu büyük bir ilerleme.
+Ağları en çok kullananlar gençler.
+Son kilometre taşı ise Aralık 2004'te.
+Tam bir geçiş muhtemelen birkaç yıl sürer.
+Ancak merkez hâlâ faaliyete geçmedi.
+Davanın aylarca sürmesi bekleniyor.
+Ancak zorluklar da yok değil.
+Bu konuda neden bu kadar az şey söylendiğini açıklayabilir misiniz?
+Birliğin ülkede iki ay kalacağı bildirildi.
+Yenilgiden sonraki gün.
+Kalabalıktan birisi, "Hiçbir açıklamada bulunmayacaklar, yorum yok!" açıklamasını yaptı.
+Ley 11 Aralık'ta 2,5959'dan işlem gördü.
+Ülkelerin ortalama başarı oranlarıysa %35.
+Etkinlikte 47 ülkeden 92 kısa film gösterilecek.
+Guca, çılgınlık yapmak için geldiğiniz bir yer.
+Hıristofyas da kendi radikallerinden baskı gördü.
+Kazanan üç eseri burada sunuyoruz.
+Dinarın devaluasyonu ise bir diğer alternatif.
+Kapanma saati yaklaştığında, fiyatlar düşüyor.
+İlk hibrid taksiler Atina'da çalışmaya başladı.
+Fedailerinden birisi ise hayatını kaybetmişti.
+Elçinin ilk durağı Priştine oldu.
+Ama böyle olmadı.
+Birbiri ardına istifa ettiler.
+Bal!
+Burada arkadaşlarım, iyi adamlar var.
+Kocası Milorad da aynı fikirde.
+Bu işbirliği o günden bu yana sürekli büyüdü.
+Bu turda, en çok oyu alan aday kazanıyor.
+Kadın meclis üyelerinin sayısı da artıyor.
+Suçlamalar daha sonra düşürüldü.
+Bu haberler doğru mu?
+Bu arada asıl sorun da ortadan kalkmış değil.
+Neden olduğu umurumda değil!
+Yeni radarların çoğu Bükreş'te kullanılacak.
+Aynı kural adalet sistemi için de uygulanıyor.
+Şampiyonaya tüm dünyadan toplam 243 kişi katıldı.
+Seçimlere toplam dört ittifak katılıyor.
+Eski rejimin bir kurbanıyım.
+Katılım oranı yaklaşık %47 idi.
+Üç yarışta da ortayı vurmak bu kadar sık olmaz.
+En çok hangi alanlarda işbirliği yapıyorsunuz?
+Tahminen kaç gazeteci işten çıkarıldı?
+Bu yıl ilk defa pasif seçmen kaydı uygulandı.
+Fuara katılanlar 150 binden fazla kitap sattılar.
+Her takıma etaplardan birinde bir rakip verildi.
+Periklis Iakovakis 400m engellide iddialı.
+Hırvat borçlular, frank başına 5,8 kuna ödeyecek.
+Timofti de buna katılıyor.
+Bu, Sırbistan'da ilk defa uygulanan bir yöntem.
+Çift, anavatanlarından ayrılmayı düşünüyor.
+Oyun alanı sadece bir örnek.
+Sırp makamları mahkumun iadesini bekliyorlar.
+Ben sadece hafif yaralandım.
+Kürtçe Türkiye'de 1991 yılında yasaklanmıştı.
+Bu olay 22 Mayıs'ta gerçekleşti.
+Oyna.
+Sırp doktor yeteneğinden ötürü ödüllendirildi.
+En fazla dört tur oylama yapılabilecek.
+Ziyaretçilere rehberli gezi olanağı sunuluyor.
+Her iki toplumdan da sakin olmalarını istiyoruz.
+Film Kosova'da gösterilmedi.
+Şimdiye kadar yerine getirilen ve getirilmeyen koşullar neler?
+Smalios'un en iyi derecesi 71,87 oldu.
+Google Hırvatistan'da faaliyetlere başladı.
+Sorguya Cuma günü de devam edildi.
+Balkanlar'da değişim rüzgarları mı esiyor?
+İvica Racan, 1944-2007
+Mücadele 2-2, 2-1, 2-2 sonuçlandı.
+Davetler kesin üyelik anlamına gelmeyecek.
+Parti sadece %7 oy almıştı.
+Daha hâlâ tutuklama görmeyi bekliyoruz.
+Herşeyden önce krizi görmezden gelmeyeceğiz.
+Ülke gelecek yıl vizeden kurtulmayı umuyor.
+"Evrak işlerini halletmek iki üç ay sürerse Yunanistan'a hangi şirket gelir?"
+Festivalde 30 ülkeden toplam 60 film yer aldı.
+Cezalar 27 Eylül'de verildi.
+Sergi bu ayın sonuna kadar devam edecek.
+Karar düzenli olarak uzatıldı.
+Bu eleştiriler sizi rahatsız ediyor mu?
+Tasarının şu anki halinde 44 madde yer alıyor.
+Ardından işyeri sorunu geliyor.
+Herkesin menfaatleri gözönünde bulundurulmalı.
+Konuşma, Romenlerin çoğunu duygulandırdı.
+İkinci ankete göre, bu oran %81'den bile yüksek.
+Bulguların toplam ağırlığı dört tonu buluyor.
+Kosova ile ilişkiler tamamen farklı bir konu.
+Yanıt yalnızca zamanla verilebilir.
+Ancak toplam maliyet %50 daha yüksek olabilir.
+Proje 240 milyon avroya mal olacak.
+Maniou Kasım ayında 16 yaşına girecek.
+Ancak bu durum değişiyor.
+Bunu kendim için değil, gençler için yapıyorum.
+Onlarca ev kül oldu veya hasar gördü.
+Balkabağına yağ, şeker ve biraz da tuz ekleyin.
+Dış basın bu büyüyen olguya odaklanmaya başladı.
+Hadise yalnız değil.
+Çözümü nasıl görüyorsunuz?
+Soruşturma bir yıl kadar sürebilir.
+Bu arada yeni sorunlar da baş gösteriyor.
+Fakat emir yerine getirilmedi.
+Festival 12 Kasım'a kadar devam edecek.
+Tesise yaklaşık 60 milyon avro yatırım yapıldı.
+Öneri Macar meclisi tarafından onaylandı.
+Aynı durum diğer Balkan ülkeleri için de geçerli.
+Bundan aşağısı ise hayal kırıklığı demek olacak.
+Litvanya'da en çok konuşulan takım oldular.
+Kimse ne olduğunuzu, kim olduğunuzu umursamazdı.
+Para, hükümetin yedek fonlarından sağlanacak.
+Üçüncü şüphelinin adı açıklanmadı.
+Hırvatistan'da işsizlik azalıyor.
+Proje yaklaşık 15 bin kişiye iş sağlayacak.
+Fakat bu gerçeklerle uyuşmuyor.
+Bir sonraki adım ne olacak?
+Kosova dış yatırımı çekebilir mi?
+Samaras, anlaşmayı destekleyeceğini söyledi.
+Aylık ücretler 131 euro civarrında kaldı.
+U2 1997 yılında Saraybosna'da çaldı.
+Medya toplumlar arası diyalogu ilerletmek için ne yapabilir?
+Suda tatlısu incisi arayanlar da oluyor.
+Sırbistan 11 Mayıs'ta başkanlığı devralacak.
+Balkan medya kuruluşlarına verilen dış destek amacına ulaştı mı?
+Bükreş'e geldiğinde çocuk babasını arar.
+Romanya'nın %0,5'lik düşüş kaydetmesi bekleniyor.
+Kararı ertelemekle kazanılacak bir şey yok.
+Aranızdaki ilişkiden ve milli takımdaki genel havadan biraz bahseder misiniz?
+Temmuz'da iki büyük rock etkinliği daha var.
+Ayvazi'ye göre, bu tür sorunlar çözüldü.
+Pirin sözleri hâlâ yankılanıyor.
+Bunlar, tutukevindeki tek zavaş suç zanlıları.
+Çoğunluk bundan şüphe duyuyor.
+Duruşma, 14 Mayıs'a ertelendi.
+Final karşılaşması Ankara'da oynandı.
+Gruevski yönetimiyse bunu değiştirmeye çalışıyor.
+Düveler.
+Almanya dışişleri bakanı Ankara'yı ziyaret etti.
+Park 25 bin kişiye iş sağlayacak.
+Müslüman olmayan insanlarla bir sorunum yok.
+Makedonya son yıllarda bilime büyük önem veriyor.
+Birlik şu anda 6 bin askere sahip.
+Ancak bazıları buna katılmıyor.
+Bunun Kosova'nın tamamını etkileyebilecek bir güvenlik meselesi olarak önemi nedir?
+Üçüncü grubun lideri aynı zamanda bir amirdi.
+Bu rakam 2004'te yaklaşık 29 bin 500'e ulaştı.
+Ardından saçı kesiliyor.
+Siryopulos temerrüt çağrısında bulunuyor.
+Polis saldırganları arıyor.
+Şimdi durum farklı.
+Bu görüşmeler basına kapalı olarak yürütüldü.
+Teklif süresi 10 Şubat'ta sona eriyor.
+Çantaları taşıyamayacakları kadar ağırdı.
+Ona göre kararda siyasi amaç güdüldü.
+Geçiş ülkelerinde yaşananlar ise karışık.
+Medya, yayınlarında şiddeti azaltmalıdır.
+Bazı okullarda pilot projeler çoktan başlatıldı.
+Ülkemiz demiryollarımız ve raylarımız gibi.
+AB şimdi endişelerini dile getiriyor.
+Steiner'ın yerine bir cok kisinin adi geciyor.
+Kuzeydeki sorunların anıda çözümü yok.
+Yine de Erdoğan ödülden vazgeçmeyi reddediyor.
+Siz nasıl bir yöntem uygulayacaksınız?
+Sezaryen maliyetiyse bunun iki katından fazla.
+Ancak rapor, Marty'den istenen etkiyi sağladı.
+Kirin gerçekten soruşturma başlattıysa, bunu yapma yetkisini nereden aldı?
+Slovenya 2008 yılında Kosova'yı tanımıştı.
+Partiler gelir ve giderler.
+Maksim Cikuli de sağlık bakanlığına getiriliyor.
+Filmin Tiran'daki galası bu ay gerçekleşecek.
+Sürpriz sonuç bekleyen kişi sayısı oldukça az.
+Yazarın 70 kitabı 20'nin üzerinde dile çevrildi.
+Orenburg tesisindeki kontrol odası.
+Elimizde video kayıtları var.
+Hiçbir siyasi durum hakkında yorumumuz yoktur.
+Festival 30 Haziran'a kadar sürecek.
+Yeni süre 14 Ekim'de sona erecek.
+Sonuçsa birincilik oldu.
+Burası bir gerçek.
+Bu katılım, Makedonya'nın kara para aklama ile mücadelesine nasıl yardımcı olacak?
+Turnuvaya 21 ülkeden 150 sporcu katıldı.
+Nüfusun geri kalan kısmı ise 15 yaşın altında.
+Bu herşeyi açıklıyor.
+Peki bunlar yeterli mi?
+Etkinlik bir hafta sürecek.
+AK, projeye 1 milyon euro sağlayacak.
+Şansıma ve buradaki herkesin şansına, bu olmadı.
+Projenin bedeli 2 milyar avro olarak açıklandı.
+Yerleşim birimi derhal karantinaya alındı.
+Refah da zamanla sağlanabilir.
+Her toplumda aşırılık yanlıları vardır.
+Rusya karşıt görüş bildirdi.
+Faaliyetler burada bitmiyor.
+Ankette daha kişisel sorular da var.
+Ancak Jurciç teklifi reddetmişti.
+Fabrikanın 700 kişiye iş sağlaması bekleniyor.
+Birlikte yaşamak zor, yaşlılar huzur istiyor.
+Anayasanın da değiştirilmesi gerek.
+Birinci yarı golsüz berabere bitti.
+Makedonya ile olan ilişkileriniz ne durumda?
+Ancak herkes bu kadar hevesli değildi.
+Ülkenin hala devlet amblemi ve ulusal marşı yok.
+Bizi bilgilendirmek zorunda değiller.
+Ankete 10 bin 350 kişi katıldı.
+Bu rakam hükümeti kurmak için yeterli.
+Liderlik etme zamanınız geldi.
+Nevesinje'nin tamamı elektriksiz kaldı.
+Makedonya bu yıl 30 adet T-72 tankı aldı.
+İki ülke bloğa Ocak ayında katılacak.
+Ancak Rehn böyle bir niyeti reddetti.
+Müşteriler geçip gittiğinde iç çekiyor.
+Tüm bölge liderleri başsağlığı dilediler.
+Çinli Yibing Chen altında madalyanın sahibi oldu.
+Bu yüzden, bence duman olup gidecek! diyor.
+Akarsu iki ülke arasında sınır teşkil ediyor.
+Kosteliç'in üç Olimpiyat şampiyonluğu bulunuyor.
+Proje, inşaatın farklı safhalarında ilerliyor.
+İlk davaların Eylül ayında başlaması planlanıyor.
+Bu sınırlamalar Nisan ayında yürürlüğe girecek.
+Ülkenin geleceğiyle ilgili tahmin ve düşünceleriniz nelerdir?
+Peki bu tür iddialar hâlâ akla yatkın mı?
+Güvenilirlik ve şeffaflık olmazsa olmazlardan.
+Oylar teker teker elle sayılacak.
+Tören Saraybosna'da gerçekleşti.
+O tarihten itibaren Birliğe 10 yeni ülke katıldı.
+Seçimlerde toplam 12 aday yarıştı.
+İlk defa listeler İnternette de yayınlanıyor.
+O nedenle de aradaki köprüleri yıkmak istemiyor.
+Ancak gerekli olan siyasi irade mevcut değildi.
+Fonun şu anki değeri 50 milyon avro.
+İktidardan ayrılıyor mu?
+Seyirci her şeyi hemen tüketmek istiyordu.
+Belopeta bazı sorunlar olduğunu kabul ediyor.
+İkinci yarı daha da heyecanlı başladı.
+Hiç bir Müslüman aile bulamazsınız.
+Priştine'nin yanıtı çabuk geldi.
+Avustralya'ya 1-2 yenildik.


### PR DESCRIPTION
Here is public domain Turkish text from SETimes (South East European Times). It has 5,000 sentences with the idea of pulling the remaining 5,000 from other (less newslike) sources.