### PR TITLE
Fix typos and improve organization in iOS view controllers

### DIFF
--- a/ios/voicebank-ios-wrapper/Base.lproj/Main.storyboard
+++ b/ios/voicebank-ios-wrapper/Base.lproj/Main.storyboard
@@ -24,7 +24,7 @@
                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="iCj-1t-oGY">
                                 <rect key="frame" x="177" y="270" width="20" height="20"/>
                             </activityIndicatorView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gcR-lo-ZPX">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gcR-lo-ZPX" userLabel="Connection Status Label">
                                 <rect key="frame" x="16" y="301" width="343" height="65"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
@@ -33,7 +33,7 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="gcR-lo-ZPX" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" id="0j3-YP-zfn"/>
+                            <constraint firstItem="gcR-lo-ZPX" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" constant="-20" id="0j3-YP-zfn"/>
                             <constraint firstItem="iCj-1t-oGY" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="2a2-wJ-IOi"/>
                             <constraint firstItem="gcR-lo-ZPX" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="MSB-mA-aFd"/>
                             <constraint firstItem="gcR-lo-ZPX" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="djG-ZD-DcZ"/>

--- a/ios/voicebank-ios-wrapper/BrowserViewController.swift
+++ b/ios/voicebank-ios-wrapper/BrowserViewController.swift
@@ -2,65 +2,59 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import Foundation
 import UIKit
 import WebKit
 
-class BrowserViewController: UIViewController, WKNavigationDelegate {
+class BrowserViewController: UIViewController {
     
-    var webView: WKWebView?
-    var _url : URL?
+    private var webView: WKWebView?
+    private var _url: URL?
     @IBOutlet weak var activityIndicatorView: UIActivityIndicatorView!
-    @IBOutlet weak var plhview: UIView?
+    @IBOutlet weak var plhview: UIView!
     
     override func loadView() {
         super.loadView()
-        print("constructor")
-        webView = WKWebView(frame: self.view.frame)
+
+        webView = WKWebView(frame: view.frame)
         webView?.isHidden = true
         webView?.navigationDelegate = self
         webView?.scrollView.isScrollEnabled = true
-        self.plhview?.addSubview(webView!)
+        plhview.addSubview(webView!)
     }
     
-    public func setUrl(url: String){
+    func setUrl(url: String) {
         _url = URL(string: url)
         let request = URLRequest(url: _url!)
         webView?.load(request)
     }
-    
-    // if webview has endangered with an error , there will be go back
-    //    and reload page options
-    private func tryConnectionAgain(sender : UIAlertAction!)
-    {
-        let request = URLRequest(url: self._url!)
-        self.webView?.load(request)
+
+    fileprivate func tryConnectionAgain(sender: UIAlertAction!) {
+        let request = URLRequest(url: _url!)
+        webView?.load(request)
     }
     
-    // go main view controller (ViewController.swift)
-    private func showingFirstPage(sender : UIAlertAction!){
+    fileprivate func returnToFirstPage(sender: UIAlertAction!) {
         dismiss(animated: true, completion: nil)
     }
-    
-    func webView(_ webView: UIWebView, didFailLoadWithError error: Error)
-    {
-        // imported alert view for fail
-        let connectionAlert : UIAlertController = UIAlertController(title: "Connection", message: "Connection is Lost", preferredStyle: .alert)
+}
+
+extension BrowserViewController: WKNavigationDelegate {
+
+    func webView(_ webView: UIWebView, didFailLoadWithError error: Error) {
+        let connectionAlert = UIAlertController(title: "Connection", message: "Connection is Lost", preferredStyle: .alert)
         
         let actionForTryAgain = UIAlertAction(title: "Try Again", style: .default, handler: tryConnectionAgain)
         
-        let actionForGoBack = UIAlertAction(title: "Go Back", style: .default, handler: showingFirstPage)
+        let actionForGoBack = UIAlertAction(title: "Go Back", style: .default, handler: returnToFirstPage)
         
         connectionAlert.addAction(actionForTryAgain)
         connectionAlert.addAction(actionForGoBack)
         
-        self.present(connectionAlert, animated: true, completion: nil);
+        present(connectionAlert, animated: true, completion: nil);
     }
     
-    func webView(_ webView: WKWebView,
-                 didFinish navigation: WKNavigation!) {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         webView.isHidden = false
-        self.activityIndicatorView.isHidden = true
+        activityIndicatorView.isHidden = true
     }
-    
 }

--- a/ios/voicebank-ios-wrapper/ViewController.swift
+++ b/ios/voicebank-ios-wrapper/ViewController.swift
@@ -8,7 +8,7 @@ class ViewController: UIViewController {
     var webView: WKWebView?
     var recorder: Recorder!
     var orientation: UIInterfaceOrientationMask!
-    var browserViewController: UIViewController? = nil
+    var browserViewController: BrowserViewController?
     var timerconn: Timer!
     @IBOutlet weak var labelStatus: UILabel!
     @IBOutlet weak var activityIndicatorView: UIActivityIndicatorView!
@@ -52,7 +52,7 @@ class ViewController: UIViewController {
         recorder = Recorder()
         recorder.webView = webView!
         let mainStoryboard = UIStoryboard(name: "Main", bundle: Bundle.main)
-        browserViewController = mainStoryboard.instantiateViewController(withIdentifier: "browser")
+        browserViewController = mainStoryboard.instantiateViewController(withIdentifier: "browser") as? BrowserViewController
     }
 
     @objc private func checkConnectivity() {
@@ -108,7 +108,7 @@ extension ViewController: WKNavigationDelegate {
             print(navigationAction.request.url?.relativeString as Any)
             decisionHandler(WKNavigationActionPolicy.cancel)
             present(browserViewController!, animated: true, completion: nil)
-            (browserViewController as! BrowserViewController).setUrl(url: (navigationAction.request.url?.absoluteString)!)
+            browserViewController?.setUrl(url: (navigationAction.request.url?.absoluteString)!)
         } else {
             decisionHandler(WKNavigationActionPolicy.allow)
         }

--- a/ios/voicebank-ios-wrapper/ViewController.swift
+++ b/ios/voicebank-ios-wrapper/ViewController.swift
@@ -18,8 +18,8 @@ class ViewController: UIViewController, WKScriptMessageHandler, WKNavigationDele
         
         if !Reachability.isConnectedToNetwork(){
             self.activityIndicatorView.stopAnimating()
-            labelStatus.text = "Voice Commons needs an internet connection to function properly. Please connect to the internet and try again."
             timerconn = Timer.scheduledTimer(timeInterval: 0.4, target: self, selector: #selector(self.checkconnectivity), userInfo: nil, repeats: true)
+            labelStatus.text = "Common Voice needs an internet connection to function properly. Please connect to the Internet and try again."
         } else {
             self.loadWebView()
         }


### PR DESCRIPTION
Proposing several fixes / enhancements surrounding view controller classes of the iOS app:
- Fix incorrect access modifiers and typos in string literals
- Make code organization / formatting consistent in `ViewController.swift` and `BrowserViewController.swift`