### PR TITLE
fix quoting

### DIFF
--- a/web/src/stores/user.ts
+++ b/web/src/stores/user.ts
@@ -125,7 +125,7 @@ export const ACCENTS: any = {
     st_pierre_et_miquelon: 'Français de Saint-Pierre-et-Miquelon',
     rwanda: 'Français du Rwanda',
   },
-  ga-IE: {
+  'ga-IE': {
     mumhain: 'Gaeilge na Mumhan',
     connachta: 'Gaeilge Chonnacht',
     ulaidh: 'Gaeilge Uladh',


### PR DESCRIPTION
I  introduced an error in ecc8156f45e11a615f7f1eab3a204d1813b9f4a7; travis isn't very helpful about tracking it down, but I assume that ga-IE needs to be quoted. Creating the pull request to see if it fixes it, can't check on this machine