### PR TITLE
Fix french sentences

### DIFF
--- a/server/data/fr/ofis_publik_ar_brezhoneg.txt
+++ b/server/data/fr/ofis_publik_ar_brezhoneg.txt
@@ -32,7 +32,7 @@ il est parti.
 elle est partie.
 j'aime aussi ce livre.
 j'aime ce livre.
-la couleur qui me plait le plus est le jaune.
+la couleur qui me plaît le plus est le jaune.
 je mange souvent des pâtes.
 ces gens-là sont souvent en train de se plaindre.
 j'avais souvent froid durant l'hiver.
@@ -91,7 +91,7 @@ prénoms et nom du futur époux.
 prénoms et nom de la future épouse.
 Audit annuel des fermes pour le lait, des fromageries pour le lactosérum.
 Nous avions eu peur.
-Licencié : Personne autorisée à prendre part aux compétitions des fédérations sportives.
+Licencié : Personne autorisée à prendre part aux compétitions des fédérations sportives.
 des messieurs fort arrogants.
 approuver la proposition de bail des nouveaux bureaux de Rennes.
 la page 44.
@@ -106,11 +106,11 @@ la plus grande femme.
 Evaluation réalisée dans les classes bilingues breton- français à l’initiative de Dihun par Gilbert Dalgalian, linguiste, ancien Directeur Pédagogique de l’Alliance Française.
 Les larmes montaient aux yeux de l'enfant.
 la fille la plus courageuse.
-les chiens coivent obéir aux bergers.
+les chiens croient obéir aux bergers.
 ce château-là.
 Le chat se voyait dans le miroir.
 le professeur avait donné une mauvais note à Mark.
-les changements qui se passent concernant les classes sociales qui utilisent le breton (en lien avec le deuxièrme point).
+les changements qui se passent concernant les classes sociales qui utilisent le breton (en lien avec le deuxième point).
 c'est la première fois que j'entends cela.
 le chien était dans sa niche.
 le chien est dans sa niche.
@@ -153,16 +153,16 @@ ceux-ci.
 la République dominicaine.
 ces blancs_là.
 ceux-là.
-Les données les plus complètes dont on dispose pour la Bretagne sont celles de l’enquête Étude de l’histoire familiale menée par l’INSEE* en 1999 (ces chiffres sont analysés en détail dans ce rapport).
+Les données les plus complètes dont on dispose pour la Bretagne sont celles de l’enquête Étude de l’histoire familiale menée par l’INSEE en 1999 (ces chiffres sont analysés en détail dans ce rapport).
 Les données les plus complètes qui existent (INSEE, 1999) commencent maintenant à dater.
 c'est samedi.
 les instituteurs sont contre maintenant car l'IEN leur a dit qu'un poste d'institutrice monolingue sera retiré si la classe ouvre.
 les sportifs courraient vite.
-L’étoile la plus proche du Soleil est à 250 000 fois la distance Terre Soleil !
+L’étoile la plus proche du Soleil est à 250 000 fois la distance Terre Soleil !
 la formation de perfectionnement débutera le 2 avril 2015.
 aujourd'hui c'est dimanche.
 c'est les vacances.
-la mamam a ressenti une oposition forte quand elle a parlé à l'école, elle est prête à continuer mais à Pabu ou Ploumagoar si ça ne fonctionne pas bien.
+la maman a ressenti une opposition forte quand elle a parlé à l'école, elle est prête à continuer mais à Pabu ou Ploumagoar si ça ne fonctionne pas bien.
 les bons médecins.
 la jolie petite fille.
 les bergers doivent être obéis par les chiens.
@@ -268,18 +268,18 @@ elle jouait avec elle.
 il jouait avec moi.
 elle jouait avec moi.
 il jouait avec lui.
-ellel jouait avec lui.
+elle jouait avec lui.
 il jouait avec eux.
 elle jouait avec eux.
 il jouait avec toi.
 elle jouait avec toi.
 des joueurs de boules.
-des jouers violents.
+des jouets violents.
 Il riait en se voyant habillé comme ceci.
 Il riait en se voyant habillé comme ça.
 Il riait en se voyant…
-Je resterai ici jusquà ce que vous me disiez d'entrer.
-Je resterai ici jusquà ce que vous me disiez de venir.
+Je resterai ici jusqu'à ce que vous me disiez d'entrer.
+Je resterai ici jusqu'à ce que vous me disiez de venir.
 Ne pas aller voir le médecin.
 Restons tranquille de peur qu'il nous entende.
 quarante six.
@@ -389,7 +389,7 @@ ils aiment ta sœur.
 elles aiment ta sœur.
 on aimera ta sœur.
 ton père est grand.
-ton père n'est pa grand.
+ton père n'est pas grand.
 ton père.
 on doit lui reprocher cela.
 ta djellaba.
@@ -441,7 +441,7 @@ le marché se tient le jeudi.
 tes mains.
 les bleus sont les derniers.
 ta main.
-à l'occasion de la nouvelle année Lena Louarn, Présidente et les membres du conseil d'administration de l'établissement public Office public de la langue bretonne sont heureux de vous souahiter une très bonne année 2015.
+à l'occasion de la nouvelle année Lena Louarn, Présidente et les membres du conseil d'administration de l'établissement public Office public de la langue bretonne sont heureux de vous souhaiter une très bonne année 2015.
 tiens.
 Merci de tenir votre chien en laisse pour ne pas les déranger.
 tenez.
@@ -476,14 +476,14 @@ des yeux vifs.
 cet enfant a les yeux bleus.
 le petit garçon avait les yeux bleus.
 malgré tous les écrits que je dois lire tous les jours j'essaierai de la lire, ou bien au moins d'y jeter un regard minutieux.
-est-ce que tu as eu des nouvelles au sujet de ce nouveau décrêt ?
+est-ce que tu as eu des nouvelles au sujet de ce nouveau décret ?
 quarante chevaux bruns.
 quarante chevaux.
 quarante.
 douze maisons.
 douze.
 le 5 novembre 2007.
-à cette époque, les gens n'avaient pas beacoup de temps libre.
+à cette époque, les gens n'avaient pas beaucoup de temps libre.
 il rentrait à la maison sans se presser.
 en ce temps-là nous étions nombreux à travailler dans cette entreprise.
 en ce temps-là j'étais petit et en bonne santé.
@@ -494,7 +494,7 @@ le mardi 6 avril.
 mange.
 des mangeurs d'hommes.
 on dînait tard.
-tont frère a mangé la dernière part de gâteau.
+ton frère a mangé la dernière part de gâteau.
 mon frère a mangé mon morceau de pain.
 le petit déjeuner est terminé.
 nous mangeons des fruits.
@@ -539,8 +539,8 @@ viens vendredi.
 viens immédiatement.
 viens tout de suite.
 viens avec nous.
-suis-moi s'il te plait .
-viens avec moi s'il te plait.
+suis-moi s'il te plaît .
+viens avec moi s'il te plaît.
 viens quand tu veux.
 viens quand le temps sera venu.
 viens.
@@ -550,14 +550,14 @@ on a défendu aux voitures de passer par cette route.
 diphtérie, tétanos, poliomyélite.
 J'ouvre la barrière tous les matins.
 ouvre la porte avant de partir.
-le magazin est ouvert le lundi.
+le magasin est ouvert le lundi.
 c'est ouvert le mercredi.
 elle est ouverte aux stagiaires qui ont suivi une formation 6 mois ainsi qu'à tous ceux qui parlent breton et qui veulent améliorer leur langue.
 Digor party.
 il est sans travail.
 lundi je suis resté à la maison.
 je serai là lundi.
-la clé sera sous le paillason.
+la clé sera sous le paillasson.
 sous la mer.
 le mur avait été détruit il y a cinq ans.
 descend tout de suite du mur.
@@ -596,7 +596,7 @@ c'est la porte de la maison.
 c'est la porte de la chambre qui était resté ouverte.
 c'est la porte de la chambre que je vois là-bas.
 c'est la porte de la chambre que je vois ici.
-c'est la porte de la chambe que je vois là.
+c'est la porte de la chambre que je vois là.
 c'est la porte de la chambre.
 Dieu vous bénisse.
 Que Dieu soit loué !
@@ -617,7 +617,7 @@ il est furieux que son parti ait perdu les élections.
 les ducs de Bretagne.
 les gens sont là-bas.
 c'est là-bas.
-il es tlà-bas.
+il est là-bas.
 elle est là-bas.
 sa tête.
 son genou.
@@ -676,7 +676,7 @@ dans ma maison.
 Ils sont en train de faire des paniers.
 l'assiette est sur la table.
 le chat est en train de manger des souris.
-Le chien est en train de courrir.
+Le chien est en train de courir.
 les enfant sont en train de jouer sur la plage.
 Les enfant sont en train de jouer sur la rue.
 les enfants sont en train d'écrire une lettre.
@@ -687,7 +687,7 @@ il est en train de lire le journal.
 elle est en train de lire le journal.
 il vient juste de partir.
 elle vient juste de partir.
-Il est en train de courrir.
+Il est en train de courir.
 elle est en train d'enlever son tablier.
 nous sommes debout.
 le Combat des Trente.
@@ -744,15 +744,15 @@ ces temps-ci vous devez faire attention.
 ces temps-ci je n'ai pas beaucoup de travail.
 ces temps-ci je suis souvent fatigué.
 ces temps-ci j'ai souvent mal à la tête.
-il y avait des vaches dans ce hamps hier.
-Cette pièce contenait un coin toilette, une douche, des WC et une baignoire 
+il y avait des vaches dans ce champs hier.
+Cette pièce contenait un coin toilette, une douche, des WC et une baignoire
 il y a un tas de choses bon-marché dans ce magasin.
 les gants étaient dans la boîte.
 il neige régulièrement en Sibérie.
 Il neige où pas ?
 il neigeait.
 Echange et formation.
-En comparaison, la Lune orbite en moyenne à 390 000 km de la Terre.
+En comparaison, la Lune orbite en moyenne à 390 000 km de la Terre.
 l'heure du dîner.
 c'est l'heure du goûter.
 horaires d'ouverture : lundi, mercredi, vendredi de 14h00 à 18h30 et samedi de 9h00 à 12h00 et de 14h00 à 18h30.
@@ -777,7 +777,7 @@ Pour la première fois, de nombreuses listes, et notamment les listes principale
 Pour être efficace, cette vaccination nécessite un rappel tous les 5 ans.
 il s’agit d’un rappel puisque vous avez dû recevoir une invitation de l’ULAMIR.
 Pour en savoir plus voir Vie et mort des étoiles par Bruno Manguin et Bénédicte Saulier-Le Dréan, collection a Espace des sciences, Éditions Apogée, 2005.
-Pour que la préfecture ne viennent pas nous dire : « Ah non, maintenant vous avez transféré vote compétence, les communes ne pourront plus s’occuper de ça », parce qu’il y aussi des gens qui veulent nous embêter là-dessus.
+Pour que la préfecture ne viennent pas nous dire : « Ah non, maintenant vous avez transféré vote compétence, les communes ne pourront plus s’occuper de ça », parce qu’il y aussi des gens qui veulent nous embêter là-dessus.
 pour qu'il pêche.
 pour qu'elle pêche.
 pour que vous pêchiez.
@@ -798,7 +798,7 @@ dans ton bureau.
 dans tes mains.
 dans ta maison.
 dans ta main.
-nous avons besoin de bénévoles prêts à nous aider ou à nous proposer de nouvelles idées pour organiser des évènements de qualité.
+nous avons besoin de bénévoles prêts à nous aider ou à nous proposer de nouvelles idées pour organiser des événements de qualité.
 Fañch s'occupe des bêtes.
 C'est Fañch qui s'occupe des bêtes.
 on mange le far avec les mains.
@@ -847,7 +847,7 @@ il est capable de nous faire perdre.
 Il est capable oui ou non ?
 le roi demande que son maître de maison vienne.
 Yannig demande une réunion préparatoire et il viendra au déjeuner de travail.
-On vous demande d'être à un quart d'heure près afin de povoir prendre plus d'une personne à  la fois.
+On vous demande d'être à un quart d'heure près afin de pouvoir prendre plus d'une personne à  la fois.
 je sais.
 je sais bien.
 il le sait fort bien, j'en suis sur.
@@ -870,7 +870,7 @@ réalisée à partir de pièces de monnaie par des prisonniers de guerre frança
 on a fait un scanner et découvert une tumeur.
 elles se sont rencontrées pendant la formation longue de Roudour de 2013-2014 et ont créé à Carhaix une crèche où l'on parle breton aux enfants.
 pas un mot à ce sujet.
-pas un mot de la part du Pst de la communauté sur ses documents de communication pour la campagne éléctorale départementale en tous cas, si ce n'est un petit mot sur l'identité lié au tourisme.
+pas un mot de la part du Pst de la communauté sur ses documents de communication pour la campagne électorale départementale en tous cas, si ce n'est un petit mot sur l'identité lié au tourisme.
 faites ce que je vous dis.
 suivez ses indications.
 faites comme je vous dis.
@@ -915,10 +915,10 @@ Croyez-vous que je puisse y parvenir ?
 Surtout pas !
 et même si la lumière revenait, ce serait trop tard.
 Et pourquoi donc ?
-elle tranquilisa sa mère en lui téléphonant.
+Elle tranquillisa sa mère en lui téléphonant.
 Applaudissements sur les bancs du groupe socialiste, radical, citoyen et divers gauche et sur quelques bancs du groupe de l’Union pour un mouvement populaire.
 et je vis l'avion partir.
-Et lui de courrir à toute vitesse.
+Et lui de courir à toute vitesse.
 et d’autres employés de l’Office de la Langue Bretonne, en fonction de leur domaine d’activité.
 à moitié vivant.
 cinquante.
@@ -955,7 +955,7 @@ elle, elle lirait.
 elle, elle lira.
 elle, elle a été aimée.
 elle, elle est aimée.
-elle a l'esprit affuté.
+elle a l'esprit affûté.
 c'est elle.
 elle, elle a eu aimé.
 elle, elle a aimé.
@@ -1036,8 +1036,8 @@ eux, ils aimeront.
 elles, elles aimeront.
 eux, ils lisent.
 elles, elles lisent.
-ils, ils lûrent.
-elles, elles lûrent.
+ils, ils lurent.
+elles, elles lurent.
 eux, ils lisaient.
 elles, elles lisaient.
 eux, ils liraient.
@@ -1124,8 +1124,8 @@ des professeurs de breton.
 Des nouvelles de votre époux et du mien.
 Pour en savoir plus, voir aussi le chapitre La formation continue dans la partie L’enseignement aux adultes : le début d’un renouveau ? et le chapitre Daoulagad Breizh et le Festival de cinéma de Douarnenez dans la partie des Médias.
 tout vous est expliqué ci-dessous et les archives jointes pour répondre, allons-y !
-La plus petite quantité réalisable : 1 exemplaire.
-La plus grande quantité réalisable : 1 exemplaire.
+La plus petite quantité réalisable : 1 exemplaire.
+La plus grande quantité réalisable : 1 exemplaire.
 Il écrit tellement mal qu'on ne peut lire son écriture.
 il continuait à fumer en m'écoutant.
 un concours de haïkus sera organisé en grande pompe en 2016 .
@@ -1174,7 +1174,7 @@ il parle à son chien.
 il parlait de sa sœur partie travailler dans un autre pays.
 j'ai parlé avec le gars de la garderie (je trouvais qu'il y avait moins de familles vues).
 je lui ai parlé pour lui dire que l'école (instituteurs, parents) pouvait défendre les postes dans leur ensemble (comme cela avait été et est le cas à Bégard) plutôt que de les opposer.
-j'étais content que vous soyiez venu.
+j'étais content que vous soyez venu.
 je suis tombé en essayant de marcher sur un seul pied.
 l'oiseau est tombé de son nid.
 le moucheron est tombé dans le verre.
@@ -1192,7 +1192,7 @@ j'avais cru qu'il aurait chanté.
 j'ai cru qu'il aurait chanté.
 il pense avoir un livre sur les Vikings.
 le feu a pris dans un bâtiment à Lannion.
-cette journée a été créée pour promouvoir et célébrer la diversité culturelle et linguistique dans le monde entier et surtout les langues autochnones, les langues minoritaires et le patrimoine linguistique en danger.
+cette journée a été créée pour promouvoir et célébrer la diversité culturelle et linguistique dans le monde entier et surtout les langues autochtones, les langues minoritaires et le patrimoine linguistique en danger.
 elle avait des problèmes de mémoire depuis peu et elle somnolait à d'autres moments.
 du travail soigné.
 du bon travail.
@@ -1282,7 +1282,7 @@ si tu me dis que ça vaut la peine d'y aller j'irai.
 mes chaussettes sont sous le lit.
 mes chaussettes ne sont pas sous le lit.
 ma mère me tira de ce mauvais pas.
-Ma grand'mère a bien connu M. Gauguin, ajoute de nouveau le fermier.
+Ma grand-mère a bien connu M. Gauguin, ajoute de nouveau le fermier.
 mes mur.
 si tu n'avais pas été là je serais parti.
 si tu n'avais pas été là je partais.
@@ -1316,19 +1316,19 @@ si j'ai deux tickets, je vous en donnerai un.
 si j'avais travaillé, j'aurais de l'argent.
 si j'ai deux tickets.
 si j'avais le temps.
-la mêre de Pêr.
-la maman de Youenn (était à la réunion, enfant dans la classe d'Enora, mais je ne l'ai pas reconnue) et la mère de Liza (elle était muette, malade, elle n'est pas restée discutrer).
+la mère de Pêr.
+la maman de Youenn (était à la réunion, enfant dans la classe d'Enora, mais je ne l'ai pas reconnue) et la mère de Liza (elle était muette, malade, elle n'est pas restée discuter).
 source : ANPE – 2005.
-Source : enquête «Produit en Bretagne» 2011.
+Source : enquête «Produit en Bretagne» 2011.
 Tu as eu tort, mon fille Merlette, d'espérer ainsi ma mort.
 s'ils n'étaient pas venus l'attraper, il tombait.
 s'il n'avait pas tenu bon il se noyait.
-s'il vous plait suivez-moi.
-s'il vous plait venez avec moi.
-s'il te plait suis-moi.
-s'il te plait viens avec moi.
-s'il te plait.
-s'il vous plait.
+s'il vous plaît suivez-moi.
+s'il vous plaît venez avec moi.
+s'il te plaît suis-moi.
+s'il te plaît viens avec moi.
+s'il te plaît.
+s'il vous plaît.
 Nous n'irons pas si tu es trop fatigué.
 Nous n'irons pas si tu es trop fatiguée.
 Marie Mahieu (langue française).
@@ -1402,7 +1402,7 @@ elle viendra probablement plus tard.
 il va à Quimper.
 elle va à Quimper.
 il va à l'école.
-elle va à lécole.
+elle va à l'école.
 il s'en va.
 elle s'en va.
 Ça va bien ?
@@ -1411,8 +1411,8 @@ elle va bien.
 ils vont très bien.
 elles vont très bien.
 je vais à table.
-On fatigue à force d'entendre des bétises à longueur de journée.
-on fatigue en entendant des bétises à longueur de journée.
+On fatigue à force d'entendre des bêtises à longueur de journée.
+on fatigue en entendant des bêtises à longueur de journée.
 il va à cheval.
 elle va à cheval.
 elle va.
@@ -1446,7 +1446,7 @@ Ne faites pas cela !
 ne donne pas de nourriture aux chiens.
 ne donne pas de la nourriture au chat.
 ne soyez par sur vos gardes.
-n'oublie pas de predre rendez-vous au garage.
+n'oublie pas de prendre rendez-vous au garage.
 N'allez pas trop vite !
 ne répétez pas ce que je vous ai dit.
 Je ne connais pas ça.
@@ -1523,7 +1523,7 @@ elle ne faisait que jeter un œil.
 il ne faisait qu'observer.
 elle ne faisait qu'observer.
 Peu m'importe.
-nous ne faisons que lui obérir.
+nous ne faisons que lui obéir.
 Vas-tu te taire ?
 on n'enfonce pas les clous si fort.
 nous n'avions pas l'impression que c'était utile.
@@ -1555,7 +1555,7 @@ je n'ai pas eu le temps de regarder cela ce soir.
 je n'ai pas eu le temps de regarder ça ce soir.
 Lizig n'est pas à la maison.
 je ne suis pas d'accord avec lui.
-il n'avai tpas assez réfléchi.
+il n'avait pas assez réfléchi.
 il n'est pas facile de chercher des arguments économiques alors que l'on sait pertinemment qu'il s'agit d'un besoin social.
 le temps n'est pas beau.
 il n'est pas capable de s'en tirer.
@@ -1607,7 +1607,7 @@ Note : les dates peuvent varier d'un jour selon les années.
 on ne sait pas s'il est mort ou vivant.
 on ne sait pas s'il est mort ou bien s'il est encore vivant.
 je ne sais rien.
-je ne sais pa grand-chose.
+je ne sais pas grand-chose.
 je ne sais pas bien.
 je ne sais pas ce qu'il veut.
 la nuit du Mardi-Gras.
@@ -1635,8 +1635,8 @@ leur mur.
 leurs murs.
 ce sont les leurs.
 les leurs.
-ils sont en train de courrir.
-elles sont en train de courrir.
+ils sont en train de courir.
+elles sont en train de courir.
 Il avait appris un tas de choses en écoutant les gens.
 Herve était en train de laver la vaisselle.
 je suis en train de manger.
@@ -1661,7 +1661,7 @@ Qu'est-ce que tu es en train de faire ?
 Qu'étais-tu en train de faire ?
 je regarderai la télévision ce soir.
 à table.
-de toutes manières plus d'un ½ poste monolingue sera retiré car il est prévu une baisse (ouverture => -1 poste ou -1.5 post mono alors ? C'es pas clair).
+de toutes manières plus d'un ½ poste monolingue sera retiré car il est prévu une baisse (ouverture => -1 poste ou -1.5 post mono alors ? C'est pas clair).
 rajouter les formes dérivées pour les substantifs et les adjectifs.
 De plus, ils pourraient être perdus.
 quand je ne m'en occupe pas je ne sais pas ce qu'ils font.
@@ -1742,7 +1742,7 @@ Où suis-je ?
 Où-suis-je ?
 Où es-tu ?
 je serai long.
-il est parti pour logntemps.
+il est parti pour longtemps.
 elle est partie pour longtemps.
 il est loin.
 elle est loin.
@@ -1754,22 +1754,22 @@ téléphoner ou y aller.
 j'ai téléphoné à la maman que je n'avais pas vu, et lui ai proposé de la voir à ce moment-là, elle travaille dans la restauration et le père est conducteur de poids-lourds, ils sont débordés et peu à l'école.
 très loin.
 il est cinq heures.
-quarante cinq.
-quarante cinq petits animaux verts.
-quarante cinq petits animaux.
-quarante cinq animaux.
-vingt cinq beaux animaux.
+Quarante-cinq.
+Quarante-cinq petits animaux verts.
+Quarante-cinq petits animaux.
+Quarante-cinq animaux.
+Vingt-cinq beaux animaux.
 cinq beaux animaux.
-vingt cinq animaux.
-trente cinq éléphants noirs.
-trente cinq éléphants.
-trente cinq beaux éléphants.
-ving cinq maisons.
+Vingt-cinq animaux.
+Trente-cinq éléphants noirs.
+Trente-cinq éléphants.
+Trente-cinq beaux éléphants.
+Vingt-cinq maisons.
 cinq maisons.
-vingt cinq.
+Vingt-cinq.
 cinq.
 quinze.
-il allait se coucher quand il avait diné.
+il allait se coucher quand il avait diner.
 Comment ?
 Comment est-il ?
 Comment est-elle ?
@@ -1783,8 +1783,8 @@ Pêr Le Bihan.
 Pourquoi ?
 Pourquoi ferais-je cela ?
 Pourquoi devrais-tu mentir ?
-Pourquoi ne nous dit-il pas clairement qu'il ne veut pas vnier avec nous ?
-Pourquoi ne nous dit-elle pas clairement qu'elle ne veut pas vnier avec nous ?
+Pourquoi ne nous dit-il pas clairement qu'il ne veut pas venir avec nous ?
+Pourquoi ne nous dit-elle pas clairement qu'elle ne veut pas venir avec nous ?
 Pourquoi donc ?
 Lesquels ?
 Lesquelles ?
@@ -1824,16 +1824,16 @@ Qu'est-ce qu'on mange ce soir ?
 Qu'est-ce qu'on mange au petit-déjeuner ?
 Qu'est-ce qu'on mange ce midi ?
 Qu'est-ce qui est rouge ?
-vingt quatre jeux intéréssants.
+vingt quatre jeux intéressants.
 quatre jeux intéressants.
 vingt quatre jeux.
-quantre jeux.
+quatre jeux.
 quatre personnes.
 quatre hommes.
 quatre gars.
-quarante quatre éléphants.
-trente quatre éléphants.
-trente quatre éléphants rouges.
+Quarante-quatre éléphants.
+Trente-quatre éléphants.
+Trente-quatre éléphants rouges.
 quatre éléphants.
 quatre coups.
 trente quatre nouvelles maisons avaient été construites.
@@ -1851,7 +1851,7 @@ Qui est-il ?
 Qui est-elle ?
 Qui sont-ils ?
 Qui sont-elles ?
-Qui sait ce qu'est un ornithorinque ?
+Qui sait ce qu'est un ornithorynque ?
 Qui êtes-vous ?
 Qui suis-je ?
 Qui es-tu ?
@@ -1864,7 +1864,7 @@ il plia le bout de papier et le mit dans sa poche.
 il avait plié le bout de papier.
 il est content.
 elles est contente.
-ça lui plait.
+ça lui plaît.
 J'ai du mal à croire cette histoire.
 il a mal à la tête.
 mal de tête.
@@ -1939,7 +1939,7 @@ il faut que je travaille.
 il est nécessaire d'avoir un imperméable.
 Il faut faire croître l’intérêt des étudiants et, de manière générale, des actifs vis-à-vis de ce métier si l’on veut développer la filière et rendre les formations plus efficaces.
 donne cette lettre à la mère de Herve.
-donne un baiser à mamam.
+donne un baiser à maman.
 pierre qui roule n'amasse pas mousse.
 il a été viré.
 elle a été virée.
@@ -2009,11 +2009,11 @@ te voici.
 plus c'est loin mieux c'est.
 je me lève tous les jours à sept heures du matin.
 Malheureusement, en France (à l’inverse des autres pays européens), le recensement ne s’intéresse pas aux langues parlées par les citoyens.
-Les « ducs à cause d’elle » sont indiqués en plus clair.
+Les « ducs à cause d’elle » sont indiqués en plus clair.
 Aujourd'hui Ecole Jean Jaurès.
 l'école de Morlaix.
 J'avais frémis en le voyant.
-Gwenole Larvol m'écrit qu'il n'a pas été invité par l'Office à participer à la commision lexicographique de mathématique dont on avait parlé au conseil scientifique.
+Gwenole Larvol m'écrit qu'il n'a pas été invité par l'Office à participer à la commission lexicographique de mathématique dont on avait parlé au conseil scientifique.
 Écrire en breton.
 Écrivez-moi si vous voyez des choses à rajouter.
 Nous sommes assez fatigués.
@@ -2033,7 +2033,7 @@ C'est fatigant.
 Il est fatigant.
 Elle est fatigante.
 J'ai pensé que l'on enverrait ça par courriel avec un mot d'accompagnement en plus.
-SP à son compte, rétribuée par la mairie, compétente en kayak, premiers secours, danses à l'ancienne, diplomée pour être assistante maternelle.
+SP à son compte, rétribuée par la mairie, compétente en kayak, premiers secours, danses à l'ancienne, diplômée pour être assistante maternelle.
 notre chienne est intelligente.
 il est épouvantable d'entendre de telles choses.
 nous pouvons vous proposer des stages de toutes sortes pour les semaines et les mois à venir.
@@ -2254,7 +2254,7 @@ je vous remercie.
 je te remercie.
 merci pour tes vœux, je te souhaite une année 2015 avec des nouveaux brittophones qui germent partout.
 merci de ta réponse.
-mersi de tes réponses.
+merci de tes réponses.
 merci de votre réponse.
 merci de vos réponses.
 merci beaucoup.
@@ -2276,7 +2276,7 @@ des petites gens.
 vingt maisons.
 vingt.
 trente et un livres noirs.
-vintgt et un livres noirs.
+vingt et un livres noirs.
 un livre noir.
 trente et un livres.
 vint et un livres.
@@ -2302,7 +2302,7 @@ une statue en bois.
 un adulte.
 Une personne à la langue bien pendue.
 c'est une grosse déception qui va à l'encontre du vote fait en 2011 par le conseil communautaire qui avait voté le niveau 1 de la charte.
-Une décision qui, bien entendu, n’a jamais été prise… ni même envisagée !
+Une décision qui, bien entendu, n’a jamais été prise… ni même envisâgée !
 une gardienne d'enfants.
 une garderie d'enfants.
 Il y a là quelque chose à imaginer pour progresser : utiliser toutes les bonnes volontés pour faire avancer la langue bretonne.
@@ -2381,7 +2381,7 @@ un chien.
 un vieux truc.
 un vieux machin.
 un lave-linge bruyant.
-une petie gare.
+une petite gare.
 une professeure de français.
 une grande ville.
 trente et une chiennes.
@@ -2407,11 +2407,11 @@ une robe jaune et non rouge.
 Il s’agit là d’un obstacle majeur qui nous empêche d’avoir une connaissance suffisamment fine de l’état de la langue.
 une école de dessin.
 Un exemple quand même, celui d’Yvette Guilbert, chanteuse de cabaret qui avait en 1899 proche de sa chambre, une seule grande pièce fonctionnelle.
-une très grosse bétise.
+une très grosse bêtise.
 une poissonnerie.
 une boucherie.
 une librairie.
-un magazin de vieilleries.
+un magasin de vieilleries.
 une boulangerie.
 un voilier.
 un tout petit petit papillon.
@@ -2422,7 +2422,7 @@ Un visage rasé de près.
 une belle fleur.
 une tabatière.
 une grande bouteille.
-une boutaille de vin blanc.
+une bouteille de vin blanc.
 une bouteille de vin.
 une jupe quelconque.
 une jupe noire.
@@ -2474,11 +2474,11 @@ le temps se refroidit.
 il refroidit.
 ça se refroidit.
 Elle refroidit.
-Le cas du zoo de Pont-Scorff, défendu hier aussi par des élus, responsables économiques, hôteliers, restaurateurs, est loin d'être unique. 
+Le cas du zoo de Pont-Scorff, défendu hier aussi par des élus, responsables économiques, hôteliers, restaurateurs, est loin d'être unique.
 Zoom sur…
 Récemment.
 Récemment j'ai vu un homme.
-Ca, c'est nouveau.
+Ça, c'est nouveau.
 Ça c'est assez nouveau.
 Ça c'est assez neuf.
 Ça c'est assez récent.
@@ -2611,12 +2611,12 @@ Tu n'iras pas danser ?
 Ils ne connaissent pas la nouvelle ?
 Il ne tombera pas ?
 Ils ne seraient pas venus ?
-Ils ne se plaidront pas ? Si.
+Ils ne se plaindront pas ? Si.
 Il faisait beau hier. Oui.
 Il n'est pas venu aujourd'hui. Non.
 Quel stupide animal !
 Ce tableau représente la Sainte Vierge.
-Quel huluberlus !
+Quel hurluberlus !
 Quelles bruyantes voitures !
 Comme il est fort !
 Qu'est-ce qu'on les voit souvent !
@@ -2689,7 +2689,7 @@ Un liquide.
 L'étude des sciences.
 La pêche.
 Une étude de notaire.
-Les quatres vents.
+Les quatre vents.
 Celui-là, ce temps-là.
 Deux livres.
 Il y a une mauvaise odeur ici, il faut l'éliminer.
@@ -2703,7 +2703,7 @@ Une chanteuse.
 Un Anglais.
 Une Anglaise.
 Un protestant.
-Une brotestante.
+Une protestante.
 Le loup.
 La louve.
 Un médecin.
@@ -2745,7 +2745,7 @@ Ces châtaignes ne sont pas pourries.
 Quelques châtaignes.
 Les châtaigniers ne sont pas encore en fleur.
 Le bois de châtaignier est clair.
-Le goémon non-pourri n'est pas bon comme emgrais.
+Le goémon non-pourri n'est pas bon comme engrais.
 Ses oreilles ne sont pas sales.
 La libellule a deux paires d'ailes.
 Des paires d'yeux me regardaient.
@@ -2822,18 +2822,18 @@ La plus neuve d'entre elles.
 Le chemin de la plage.
 l'aide des pompiers.
 Les gens de la campagne.
-Un bâteau à voile.
+Un bateau à voile.
 La bonté à l'égard des pauvres
 L'amour du prochain.
 La peur des chiens.
 Les cheveux de Yann sont noirs.
-Le cœur de cette fille tréssaille.
+Le cœur de cette fille tressaille.
 J'aime bien les règles de ce jeu.
 Une machine à écrire.
 Le moment de partir.
 L'avenir.
 Un bureau.
-Le bâteau de pêche.
+Le bateau de pêche.
 Un restaurant.
 Un moment de repos.
 Un mois de travail.
@@ -2845,7 +2845,7 @@ Aucune autre maison.
 Il n'y a pas de chaises.
 Il n'y a aucune autre chaise.
 Il n'y a pas de maisons.
-Il n'y a pas d'uatre maison.
+Il n'y a pas d'autre maison.
 Si les enfants ne peuvent pas jouer.
 Si tu ne peux pas jouer.
 Si les enfants ne peuvent pas jouer il faudra trouver autre chose.
@@ -2891,8 +2891,8 @@ Mieux vaut instruction que richesse.
 Qu'est-ce que tu prendras ?
 Du thé ou du café ?
 Il y a de la sauce à rajouter.
-J'aime bien les crèpes.
-J'aime courrir.
+J'aime bien les crêpes.
+J'aime courir.
 Il aime lire.
 Elle aime lire.
 Y aura-t-il de la neige à Noël ?
@@ -2956,7 +2956,7 @@ Monsieur Louarn.
 Madame la directrice, venez vite.
 Bonjour monsieur Le Goff.
 Au revoir madame Louarn.
-Docteur Keraotred, écoutez-moi s'il vous plait.
+Docteur Keraotred, écoutez-moi s'il vous plaît.
 Les Trégorois sont moqueurs.
 Tous les Irlandais.
 Ces Écossais portaient des kilts.
@@ -2987,7 +2987,7 @@ Le Grand chariot.
 La ville du Faou.
 L'Union des Enseignants de Breton.
 L'UGB s'était réunie la semaine dernière.
-Il est bien pauvre, sa paye n'atteint même pas le smic.
+Il est bien pauvre, sa paye n'atteint même pas le SMIC.
 Une trentaine de moules.
 Une trentaine de personnes.
 Dix soldats étaient en train de tirer environ.
@@ -2995,7 +2995,7 @@ Une dizaine de soldats étaient en train de tirer.
 Une paire de lunettes fines sur le nez.
 Des yeux emplis d'amour me regardaient.
 Mourir de froid.
-Trésaillir de joie.
+Tressaillir de joie.
 Rougir de honte.
 L'odeur de roussi
 Une odeur de roussi
@@ -3028,7 +3028,7 @@ Ils ne l'avaient pas écouté.
 Elles ne l'avaient pas écouté.
 D'ici à demain nous les aurons informés.
 D'ici à demain nous les aurons informées.
-Ils se méfiaent comme toi et moi.
+Ils se méfiaient comme toi et moi.
 Il y avait eu une dispute entre lui et sa femme.
 Iras-tu, toi, au cinéma après dîner ?
 On ne vous verra pas, vous, vous occuper des enfants.
@@ -3223,7 +3223,7 @@ Votre idée.
 Leur idée.
 Cela m'a été dit par un de ses frères.
 Son prix est à 100 euros.
-Son toît est rouge.
+Son toit est rouge.
 Ses chambres sont vastes.
 Et son jardin bien entretenu.
 Prends les trois feuilles qui sont sur la table.
@@ -3326,7 +3326,7 @@ Une heure après minuit.
 Une heure du matin.
 Deux heures après minuit.
 Deux heures du matin.
-Le vote du douze spetembre.
+Le vote du douze septembre.
 On prélèvera l'argent de votre compte le quinze du mois.
 Le combien sommes-nous ?
 Le premier mai.
@@ -3387,7 +3387,7 @@ Une telle.
 Et patati et patata.
 Un tas de livres.
 Une marée humaine.
-Un certains nombre d'huluberlus.
+Un certains nombre d'hurluberlus.
 Tout le monde sait ça.
 Dans chaque commune il y a une mairie.
 Tous ceux qui étaient là-bas ce jour-là virent son frère.
@@ -3398,7 +3398,7 @@ Tu as perdu tout ton argent ?
 Tout Rennes est content du résultat du match.
 Le pays tout entier avait été pillé.
 Tout ce monde-ci.
-J'ai envie de voir ce mone magnifique en entier.
+J'ai envie de voir ce monde magnifique en entier.
 Ce ne sont que des mensonges !
 Rien que des idioties !
 Nous étions allés en ville, nous tous.
@@ -3422,7 +3422,7 @@ Tout le monde est bien habillé ce soir.
 Ils ont chacun un chapeau.
 Les enfants ont tous eu une part de gâteau.
 Vous prendrez tous un café ?
-On meur donnera trois livres à chacun.
+On donnera trois livres à chacun.
 Les invités ont eu chacun leur tasse de café.
 Nous, nous avons fait chacun notre travail.
 Après le jeu, il ne leur en restait qu'un seul à chacun.
@@ -3481,7 +3481,7 @@ Beaucoup ont crié de peur.
 Beaucoup de renards étaient venus manger les poules du paysan.
 La majorité du travail a été faite.
 J'ai suffisamment d'or.
-Ils avaient eu suffissament de chagrin.
+Ils avaient eu suffisamment de chagrin.
 J'ai assez d'or.
 Ils avaient eu assez de chagrin.
 Nous n'aurons pas assez de temps pour aller voir ta sœur.
@@ -3525,7 +3525,7 @@ Maintenant nous somme peu de monde.
 J'ai quelques livres qui traitent de l'informatique.
 J'aime l'informatique.
 Il n'est pas compétent en informatique.
-Les quelques rares nouvelles qu'elle m'avait envoyées n'ataient pas très bonnes.
+Les quelques rares nouvelles qu'elle m'avait envoyées n'étaient pas très bonnes.
 Ils vivent de peu.
 Peu sont venus manger ce soir.
 Il y a beaucoup de nourriture sur la table.
@@ -3534,7 +3534,7 @@ Peu de gens ne sont pas vêtu de rouge.
 Quelques choses n'avaient pas été faites.
 Peu ne rient pas.
 J'ai trop peu d'argent pour acheter une maison.
-J'ai trop peu d'argent pour acheter ur c'harr.
+J'ai trop peu d'argent pour acheter un char.
 J'ai bien peu confiance en lui.
 Il est vraiment préoccupé.
 C'est vraiment beau.
@@ -3659,7 +3659,7 @@ Comprendre la vie des gens.
 Il ne comprend pas la vie des gens.
 Développer les compétences humaines.
 Développer les compétences des gens.
-Acheter le terrioire commun.
+Acheter le territoire commun.
 Diffuser à tous.
 Diffuser aux personnes qui ont participé.
 Quel jour téléphonera-t-il donc ?
@@ -3690,7 +3690,7 @@ Je ne trouve aucune graine dans ce champ.
 Là-bas, aucun arbre ne pousse.
 Bien qu'il eût fait une grave erreur, il s'en retourna sans aucune honte.
 On peut courir à n'importe quelle période de l'année.
-Voici une œuvre qui me plait plus qu'aucune autre.
+Voici une œuvre qui me plaît plus qu'aucune autre.
 J'achèterai une autre maison quand j'aurai de l'argent.
 Ton autre manteau est dans le couloir.
 Quand viendront les autres personnes ?
@@ -3734,7 +3734,7 @@ Diffuser la bonne nouvelle aux gens.
 Si le vent faiblit.
 Si la force me manque.
 Si tout le monde se met ensemble pour danser on y arrivera.
-Si les gens s'ennuient ils peuvent toujours éteindre la téle et aller se promener.
+Si les gens s'ennuient ils peuvent toujours éteindre la télé et aller se promener.
 Je ne suis pas sûr d'avoir éteint la télé avant de sortir.
 Je ne suis pas sûr d'avoir éteint la lumière avant de sortir.
 Si le jardin de Douarnenez avait été nettoyé le site aurait été mieux conservé.
@@ -3812,7 +3812,7 @@ Ce genre de choses ne se vend pas bien.
 J'aimerais bien avoir une maison telle que celle-là.
 J'aimerais bien avoir un travail tel que celui-là.
 Un grand garçon.
-La petie cuillère.
+La petite cuillère.
 De petites voitures rouges.
 De jolis petits boutons ronds rouges.
 Une bien mauvaise nouvelle.
@@ -3839,8 +3839,8 @@ Peu de chose.
 C'est un homme porté à dire la vérité.
 Un gars qui ne ressemble pas à son père.
 Une bouteille pleine d'eau.
-Cet homme, porté à dire la vérité, me plait.
-Cet écrivain, connu pour ses pièves ed théâtre, a également écrit un roman.
+Cet homme, porté à dire la vérité, me plaît.
+Cet écrivain, connu pour ses pièces de théâtre, a également écrit un roman.
 Il fait beau.
 Le beau temps.
 Ses cheveux sont noirs, longs et brillants.
@@ -3883,9 +3883,9 @@ C'est un homme plutôt grand.
 Le tas sera un peu plus grand.
 J'ai beaucoup de mal à me lever.
 J'ai une grande douleur au bras.
-J'ai beaucoup de mal à coire qu'il a été enlevé.
+J'ai beaucoup de mal à croire qu'il a été enlevé.
 J'ai une douleur au bras.
-J'ai du mal à coire ce que tu m'expliques.
+J'ai du mal à croire ce que tu m'expliques.
 Les trous sont nombreux par ici.
 Les gens ne sont pas nombreux.
 Les gens sont peu nombreux.
@@ -3896,8 +3896,8 @@ De 845 à 978
 Il faut que tu mettes ça en place.
 Tu doit mettre ça en place.
 Il s'occupe d'une grande charge.
-Cet endroit me plait.
-Cet endroit me plait, qu'on y vende des maisons ou non.
+Cet endroit me plaît.
+Cet endroit me plaît, qu'on y vende des maisons ou non.
 Je vais directement à la maison.
 Il ira directement à la maison.
 Deux points d'avance.
@@ -3966,7 +3966,7 @@ Une quarantaine de personnes.
 Une vingtaine de joueurs.
 Une trentaine d'étudiants.
 Une cinquantaine de policiers.
-Une quinzaine d'huluberlus.
+Une quinzaine d'hurluberlus.
 Les choses ont été grandement facilitées.
 Trois point d'avance.
 Il faut apporter du changement.
@@ -3975,7 +3975,7 @@ Un grand changement.
 Il y a eu de grands changement.
 Il apprend bien.
 Elle apprend bien.
-Tu apprens bien tes leçons.
+Tu apprends bien tes leçons.
 On fait durer les choses.
 On fait attendre les gens.
 On fait attendre les gens longtemps.
@@ -4052,7 +4052,7 @@ Vraiment mauvais.
 Assez fatigué.
 C'est vivant que le renard avait été attrapé.
 On mange le far froid ou tiède.
-Il avit appris beaucoup de chansons étant jeune.
+Il avait appris beaucoup de chansons étant jeune.
 Blanc comme neige.
 Noir comme dans un four.
 Brièvement.
@@ -4110,7 +4110,7 @@ On a apporté des changements au texte.
 On a apporté de grands changements au texte.
 Depuis longtemps les maires doivent faire attention à ça.
 Ce livre te plaira.
-Ces évènements leur plaisaient.
+Ces événements leur plaisaient.
 L'orage est à son maximum.
 La radio est au maximum.
 Quelle jolie maison !
@@ -4251,7 +4251,7 @@ Quand ton père achète-il le journal ?
 Qu'achète ton père tous les jours ?
 Où ton père achète le journal ?
 Que fait ton père tous les jours.
-Faire des crèpes.
+Faire des crêpes.
 Se peigner les cheveux.
 Bien jouer.
 Il joue bien.
@@ -4262,7 +4262,7 @@ Achète le journal tous les jours.
 Regardez ce qu'il est en train de montrer.
 Tiens donc !
 Si !
-On n'aua pas le temps d'y aller ? Si !
+On n'aura pas le temps d'y aller ? Si !
 Que si !
 Voilà qui est bien!
 Voilà qui est vrai !
@@ -4336,12 +4336,12 @@ Elle qui devait être ici depuis un quart d'heure…
 Moi qui suit de devenu vieux…
 Ronan, qui était malade, était resté à la maison également.
 Une lettre qui est joliment écrite.
-J'irai demander à quelqu'un qui connait la route.
+J'irai demander à quelqu'un qui connaît la route.
 La porte que vous être en train de peindre.
 L'homme avec qui j'étais en train de parler est mon voisin.
 Dites-moi quel est ce médicament dont on parle tellement.
 Les gens avec qui j'aime bien être sont des gens sans façons.
-Cet homme-là, qui avait vécu dans les pays lontains, savait un tas de choses.
+Cet homme-là, qui avait vécu dans les pays lointains, savait un tas de choses.
 Mon père, qui venait de perdre son travail, préféra changer de profession.
 L'oiseau qui ne chante plus.
 Les choses que je n'aime plus.
@@ -4414,8 +4414,8 @@ Il était plus vieux que je ne le croyait.
 Moi, je cherche alors que toi tu ne le fais pas.
 Je vais manger car j'ai faim.
 C'est joli mais c'est trop cher.
-Ce n'était pas quelqu'un de très instruit mais il s'avait bien s'exprimer.
-Ce n'était pas quelqu'un de très instruit sauf qu'il s'avait bien s'exprimer.
+Ce n'était pas quelqu'un de très instruit mais il savait bien s'exprimer.
+Ce n'était pas quelqu'un de très instruit sauf qu'il savait bien s'exprimer.
 J'allais à l'école en bus et je devais me lever tôt.
 Arrête tout de suite où je le dirai à mon père.
 Elle ira.
@@ -4451,7 +4451,7 @@ Environ 300 kilomètres.
 Environ 8 heures de voyage avec la route.
 En face de la poste.
 Quand il sera arrivé nous irons tous dehors.
-L'agriculture est la principale occupation des gens la-bàs.
+L'agriculture est la principale occupation des gens là-bas.
 Tout.
 Tout est bon.
 Ils sont tous bons.
@@ -4487,7 +4487,7 @@ Vous avez peur ?
 Tu as peur ?
 Êtes-vous allergique à quelque chose ?
 Êtes-vous Américain ?
-Vous êtes faché contre moi ?
+Vous êtes fâché contre moi ?
 Êtes-vous réveillé ?
 Es-tu réveillé ?
 Connaissez-vous cela ?
@@ -4553,7 +4553,7 @@ Soyez poli ou vous entendrez parler de moi.
 Grand / Petit.
 Dieu vous pardonne.
 Fermer la porte à clef.
-Emmenez-moi ma chemise s'il vous plait.
+Emmenez-moi ma chemise s'il vous plaît.
 Emmenez-les ici.
 Les affaires sont bonnes.
 Téléphonez-moi.
@@ -4564,25 +4564,25 @@ Je peux me connecter à Internet ici ?
 Je peux me connecter au réseau ici ?
 Je peux emprunter un peu d'argent ?
 Je peux venir avec mon ami ?
-Est-ce que je peux avoir un verre d'eau s'il vous plait ?
-Est-ce que je peux avoir une facture s'il vous plait ?
-Est-ce que je peux avoir la note s'il vous plait ?
+Est-ce que je peux avoir un verre d'eau s'il vous plaît ?
+Est-ce que je peux avoir une facture s'il vous plaît ?
+Est-ce que je peux avoir la note s'il vous plaît ?
 Un peu d'aide ?
 Je peux vous aider ?
 Je peux mettre un rendez-vous pour mercredi ?
-Puis-je voir votre passeport s'il vous plait ?
+Puis-je voir votre passeport s'il vous plaît ?
 Je peux prendre un message ?
 Est-ce que je peux l'essayer ?
 Je peux utiliser votre téléphone ?
 Il peut être meilleur marché ?
-Est-ce que nous pouvons avoir la carte s'il vous plait ?
-Nous pouvons avoir un peu plus de pain s'il vous plait ?
-Est-ce que nous pouvons avoir un peu plus de pain s'il vous plait ?
-Pouvons-nous avoir un peu plus de pain s'il vous plait ?
+Est-ce que nous pouvons avoir la carte s'il vous plaît ?
+Nous pouvons avoir un peu plus de pain s'il vous plaît ?
+Est-ce que nous pouvons avoir un peu plus de pain s'il vous plaît ?
+Pouvons-nous avoir un peu plus de pain s'il vous plaît ?
 Nous pouvons nous asseoir par là ?
 Pouvez-vous retéléphoner plus tard ?
 Pouvez-vous me retéléphoner plus tard ?
-Pouvez-vous porter ça pour moi s'il vous plait.
+Pouvez-vous porter ça pour moi s'il vous plaît.
 Pouvez-vous me rendre un petit service ?
 Pouvez-vous arranger ça ?
 Vous pouvez me donner un exemple ?
@@ -4590,10 +4590,10 @@ Pouvez-vous m'aider ?
 Vous pouvez tenir ça pour moi ?
 Vous pouvez redire ça ?
 Vous pouvez nous recommander un bon restaurant ?
-Vous pouvez redire ça s'il vous plait ?
-Vous pouvez le redire s'il vous plait ?
+Vous pouvez redire ça s'il vous plaît ?
+Vous pouvez le redire s'il vous plaît ?
 Vous pouvez me montrer ?
-Vous pouvez parler plus fort  s'il vous plait ?
+Vous pouvez parler plus fort  s'il vous plaît ?
 Vous pouvez parler doucement ?
 Vous savez nager ?
 Pouvez-vous lancer ça dehors pour moi ?
@@ -4622,7 +4622,7 @@ Vous étiez venu avec votre famille ?
 Vous avez eu mon mail ?
 Vous avez eu mon courrier ?
 Vous étiez arrivé à temps ?
-Vous étiez au brureau hier ?
+Vous étiez au bureau hier ?
 Ça vous a plu ici ?
 Vous avez fermé la porte à clef ?
 Vous avez ouvert la porte ?
@@ -4635,7 +4635,7 @@ Vous avez pris votre médicament ?
 Vous avez tapé la lettre ?
 Vous avez compris cette leçon ?
 Votre femme aime-t-elle la Californie ?
-Votre femme se plait en Californie ?
+Votre femme se plaît en Californie ?
 Faites vos devoirs.
 Nous aimons l'école ?
 Vous acceptez les dollars USA ?
@@ -4644,7 +4644,7 @@ Vous allez mieux ?
 Vous allez souvent en Floride ?
 Vous avez un amoureux ?
 Vous avez une amoureuse ?
-Vous avez ur crayon gris ?
+Vous avez un crayon gris ?
 Vous avez un problème ?
 Vous avez une piscine ?
 Vous avez rendez-vous ?
@@ -4654,7 +4654,7 @@ Vous avez du café ?
 Vous avez de l'argent ?
 Vous avez des crayons gris ?
 Il y a des places vacantes ?
-Vous avez quleque chose ?
+Vous avez quelque chose ?
 Vous avez quelque chose de meilleur marché ?
 Vous avez assez d'argent sur vous ?
 Vous avez le numéro du taxi ?
@@ -4677,10 +4677,10 @@ Est-ce que vous savez qui elle est ?
 Savez-vous où est-ce qu'il y a un magasin qui vend des serviettes ?
 Vous savez où est-ce qu'il y a un magasin qui vend des serviettes ?
 Vous vous plaisez ici ?
-Ça vous plait ?
-Le livre vous plait ?
+Ça vous plaît ?
+Le livre vous plaît ?
 Vous aimez regarder la télévision ?
-Votre directeur vous plait ?
+Votre directeur vous plaît ?
 Vos collaborateurs vous plaisent ?
 Vous avez besoin de quelque chose d'autre ?
 Vous avez besoin de quelque chose ?
@@ -4702,17 +4702,17 @@ Et vous pensez qu'il va pleuvoir demain ?
 C'est possible, vous pensez ?
 Et vous pensez être une personne intelligente ?
 Vous serez de retour pour 11h30, vous pensez ?
-Vous conprenez ?
+Vous comprenez ?
 Vous voulez que je vienne vous prendre ?
 Vous voulez venir avec moi ?
 Vous voulez aller au cinéma ?
 Vous voulez y aller avec moi ?
 Quelqu'un sait l'anglais ici ?
 Quelqu'un sait l'allemand ici ?
-Il se plait à l'école ?
-L'école lui plait ?
+Il se plaît à l'école ?
+L'école lui plaît ?
 Il ouvre la porte ?
-Il neige souvent pendant l'hiver au Masschussets ?
+Il neige souvent pendant l'hiver au Massachusetts ?
 Cette route va à Auray ?
 Cette route va à Nantes ?
 Cette route va à New York ?
@@ -4738,7 +4738,7 @@ Ne laissez pas la parte ouverte.
 Ne me faites pas me mettre en colère.
 Ne faites pas de bruit.
 Il ne faut pas faire de bruit.
-Pas un mo sur ça.
+Pas un mot sur ça.
 Pas un mot là-dessus.
 Ne déménagez pas avec eux.
 Ne bougez pas avec eux.
@@ -4775,7 +4775,7 @@ Excusez-moi, qu'avez-vous dit ?
 Excusez-moi
 Date de fin.
 Extra.
-Remplissez-le s'il vous plait.
+Remplissez-le s'il vous plaît.
 Bien.
 Excellent.
 En très bonne santé.
@@ -4808,7 +4808,7 @@ Bonjour !
 Bonne nuit et dormez bien !
 Bien/ mal/ entre les deux.
 Bien/ entre les deux.
-Bon anniverssaire !
+Bon anniversaire !
 Bonne année !
 Est-ce que votre frère a déjà été en Californie ?
 Bon voyage.
@@ -4841,7 +4841,7 @@ Ellen ne ressemble pas à une infirmière.
 Il a une belle voiture.
 Est-ce qu'il a quelques lettres pour votre père ?
 C'est un affairiste.
-C'est ur gars rigolo.
+C'est un gars rigolo.
 Il est ingénieur en informatique chez WIPRO.
 C'est Andrew.
 Il s'appelle Andrew.
@@ -4849,22 +4849,22 @@ Il réussit bien.
 Il va bien.
 Il est en classe avec moi.
 C'est un de mes collaborateurs.
-C'est mon frère ainé.
+C'est mon frère aîné.
 C'est mon père.
-C'est pmon grand-père.
+C'est mon grand-père.
 C'est mon voisin.
 Il est en train d'ouvrir la porte…
 Il travaille comme ingénieur en informatique chez WIPRO.
 Il travaille chez MSN - USA.
 Il est venu faire un tour seulement.
-Ça lui plait énormément.
+Ça lui plaît énormément.
 Il aime bien le jus mais il n'aime pas le lait.
 Il habite à Paris en France.
 Nous avons besoin de quelques nouveaux vêtements.
 Il ne me donne jamais rien.
 Il ouvre la porte.
 La porte ouvre.
-Il dit que c'est ul lieu agréable.
+Il dit que c'est un lieu agréable.
 Il dit que vous aimez regardez des films.
 Il étudie à l'université de Boston.
 Il pense que nous ne voulons y aller.
@@ -4898,7 +4898,7 @@ Il travaille d'arrache-pied.
 Alors ! Mon gars !
 Alors ! Comment est-ce que vous pouvez me parlez comme ça ?
 Salut !
-Salut ! Mme Smith est là, s'il vous plait ?
+Salut ! Mme Smith est là, s'il vous plaît ?
 Cachez le quelque part.
 Sa famille vient demain.
 Sa chambre est très petite.
@@ -4954,7 +4954,7 @@ Combien de temps resterez-vous en Californie ?
 Combien de temps allez-vous rester là ?
 Combien de temps allez-vous rester ?
 Combien de temps ça prend en voiture ?
-Combien de temps pour aller en Georgie ?
+Combien de temps pour aller en Géorgie ?
 Combien de temps avez-vous été ici ?
 Combien de temps avez-vous été en Amérique ?
 Combien de temps avez-vous habité ici ?
@@ -4999,10 +4999,10 @@ Comment est-ce que vous réussirez ?
 Comment sont les affaires ?
 Comment ça va avec le travail ?
 Dépêchez-vous !
-Je suis diplomé de B.E.
+Je suis diplômé de B.E.
 Je suis une fille.
 Moi, je suis une fille.
-Je suis diplomé en ingénierie.
+Je suis diplômé en ingénierie.
 Je suis femme au foyer.
 Je suis originaire de Washington.
 Je fais une thèse de médecine.
@@ -5040,7 +5040,7 @@ J'habite à Londres.
 Je suis certain que ce n'était pas de voter faute et tout le monde le sait.
 Je vous suis très reconnaissant.
 Je suis très satisfait.
-Je suis extrèmement satistfait.
+Je suis extrêmement satisfait.
 Je suis très strict.
 Je travaille comme agent de publicité.
 Je travaille chez Google.
@@ -5120,7 +5120,7 @@ J'ai beaucoup de riz.
 J'ai beaucoup de choses à manger.
 J'ai beaucoup de choses à faire.
 J'ai une paire de tasses de thé.
-J'ai une paire de siceaux.
+J'ai une paire de ciseaux.
 J'ai une paire de chaussures.
 J'ai une paire de chaussons.
 J'ai un crayon et deux livres.
@@ -5133,14 +5133,14 @@ J'ai un sac de riz.
 J'ai été travailler, je n'ai pas ouvert.
 Je n'ai plus de patience.
 J'en ai fini avec ma M.S.
-J'ai fait mon B.S en ingiénierie.
+J'ai fait mon B.S en ingénierie.
 J'ai des problèmes de cœur.
 J'ai des problèmes de foie.
 J'ai de l'argent.
 Je ne me souviens de rien.
 Je n'ai pas le temps de vous voir.
 J'en ai un dans ma voiture.
-Il ne me reste que quelques secondes pour vous rappeller que votre travail sur ces leçons n'est pas terminé, loin de là.
+Il ne me reste que quelques secondes pour vous rappeler que votre travail sur ces leçons n'est pas terminé, loin de là.
 J'ai ouvert, je n'ai pas ouvert. Est-ce que vous avez ouvert ?
 J'ai mal au bras.
 J'ai mal à la gorge.
@@ -5170,7 +5170,7 @@ J'ai lu les titres rapidement.
 Je sais.
 Je m'en vais à 9h15.
 J'aime l'anglais.
-Ça me plait.
+Ça me plaît.
 J'aime ça.
 J'aime la nourriture italienne.
 J'aime regarder la télévision.
@@ -5236,7 +5236,7 @@ Je reviens tout de suite.
 Je viendrai vous chercher.
 Je n'oublierai jamais le temps que vous m'avez consacré pour m'aider.
 Je n'ouvrirai pas la porte.
-J'ouvrrai la porte. Je devrais ouvrir la porte.
+J'ouvrirai la porte. Je devrais ouvrir la porte.
 J'ouvrirai, je n'ouvrirai pas, est-ce que vous ouvrirez, qu'est-ce que vous ferez.
 Je t'y emmènerai un jour.
 J'aimerais en avoir une.
@@ -5256,14 +5256,14 @@ Je suis prêt à déjeuner.
 Tu me plais beaucoup comme ami.
 J'aimerais avoir un plan de ville.
 Je voudrais une chambre non fumeur.
-Je voudrais avoir une chambre avec deux lits s'il vous plait
+Je voudrais avoir une chambre avec deux lits s'il vous plaît
 Je voudrais avoir une chambre.
 Je voudrais avoir une chambre seule.
 J'aimerais avoir une table près de la fenêtre.
-J'aimerais aussi avoir un verre d'eau, s'il vous plait.
-Je voudrais avoir le numéro de l'hôtel Hilton, s'il vous plait.
-Je voudrais acheter une bouteille d'eau s'il vous plait.
-Je voudais acheter une carte de téléphone.
+J'aimerais aussi avoir un verre d'eau, s'il vous plaît.
+Je voudrais avoir le numéro de l'hôtel Hilton, s'il vous plaît.
+Je voudrais acheter une bouteille d'eau s'il vous plaît.
+Je voudrais acheter une carte de téléphone.
 Je voudrais acheter quelque chose.
 Je voudrais téléphoner aux États-Unis.
 Je voudrais manger au restaurant de la 5è rue.
@@ -5277,18 +5277,18 @@ Je veux réserver une place.
 Je veux louer une voiture.
 J'aimerais envoyer un fax.
 Je veux envoyer ça en Amérique.
-J'aimerais parler à M. Smith s'il vous plait.
+J'aimerais parler à M. Smith s'il vous plaît.
 J'aimerais utiliser l'Internet.
 J'aimerais aller en Espagne un jour.
-Si ça te plait je peux acheter plus.
+Si ça te plaît je peux acheter plus.
 Si vous avez besoin d'être aidé, dites le moi.
 Je rappellerai plus tard.
 Je vous téléphonerai vendredi.
 Je vous téléphonerai quand je partirai.
 Je reviendrai plus tard.
 Je vous téléphonerai.
-Je prendrai une tasse de thé s'il vous plait.
-Je prendrai un verre d'eau s'il vous plait.
+Je prendrai une tasse de thé s'il vous plaît.
+Je prendrai un verre d'eau s'il vous plaît.
 Je prendrai la même chose.
 Je paierai mon dîner.
 Je paierai les tickets.
@@ -5313,7 +5313,7 @@ Je suis Américain.
 Je m'ennuie.
 Je suis en train de nettoyer ma chambre.
 J'ai froid.
-Je viens dout de suite.
+Je viens tout de suite.
 Je viens vous prendre.
 Je suis bien, et vous ?
 Je suis bien, merci !
@@ -5348,7 +5348,7 @@ Je suis en train d'écouter. (téléphone).
 Je suis prêt.
 Je suis mon propre employé.
 Excusez-moi (si vous n'entendez pas quelque chose).
-Je suis désolé, il est epuisé.
+Je suis désolé, il est épuisé.
 Excusez-moi.
 Je suis certain.
 J'ai beaucoup de travail.
@@ -5373,7 +5373,7 @@ Il apprend l'anglais ?
 Il est en train de payer les frais ?
 Il est en train de courir ?
 Il est en train de prendre votre téléphone portable ?
-C'est votre entraineur ?
+C'est votre entraîneur ?
 C'est un parent à vous ?
 C'est fermé ?
 Il fait froid dehors ?
@@ -5391,7 +5391,7 @@ C'est vrai ?
 Ça vaut la peine ?
 C'est la première fois que vous venez à Chennai ?
 John est là ?
-John est là s'il vous plait ?
+John est là s'il vous plaît ?
 Mala est en train de raconter une histoire ?
 Maran est en train de prendre votre crayon ?
 M. Smith est américain ?
@@ -5475,7 +5475,7 @@ C'est un régal !
 C'est loin d'ici.
 C'est marrant.
 Il fait chaud aujourd'hui.
-Il ca neiger aujourd'hui.
+Il va neiger aujourd'hui.
 Il est 11 heures et demi.
 C'est ici.
 Il est chaud.
@@ -5495,7 +5495,7 @@ C'est bon.
 Il est dans la 7è rue.
 C'est par ici.
 Il pleut.
-C'est brulant.
+C'est brûlant.
 Il fait extrêmement chaud.
 Il est plus court que 3 miles.
 Il est censé pleuvoir demain.
@@ -5529,7 +5529,7 @@ Allons jeter un œil.
 Allons.
 Nous nous verrons en face de l'hôtel.
 Parlons anglais.
-Répartons les choses.
+Répartissons les choses.
 Vivre c'est plus que souffrir.
 Fermez la porte.
 Fermez !
@@ -5585,9 +5585,9 @@ Mon fils.
 J'ai mis ma montre.
 À côté de la banque.
 Il ne marque pas.
-La pochaine fois.
+La prochaine fois.
 Dans une semaine mon cousin de Bombay viendra.
-C'est ur plaisir de faire connaissance avec vous.
+C'est un plaisir de faire connaissance avec vous.
 C'est un plaisir de faire votre connaissance.
 Pas de problème !
 Pas de problème.
@@ -5623,8 +5623,8 @@ Bien, déballe les choses.
 Au second étage.
 L'un est fort, l'autre est faible.
 Un comme ça.
-Un petit moment s'il vous plait.
-Un billet pour New York s'il vous plait.
+Un petit moment s'il vous plaît.
+Un billet pour New York s'il vous plaît.
 Un aller ou un voyage aller-retour ?
 Un, deux, trois.
 Ouvrez la porte.
@@ -5642,9 +5642,9 @@ Par là.
 Payez la note.
 Les gens parlent tamoul.
 Ramassez vos vêtements.
-Appelez-moi s'il vous plait
-Téléphonez-moi s'il vous plait.
-Entrez s'il vous plait.
+Appelez-moi s'il vous plaît
+Téléphonez-moi s'il vous plaît.
+Entrez s'il vous plaît.
 Contez ça pour moi.
 Comptez ça pour moi.
 Remplissez ce formulaire.
@@ -5653,12 +5653,12 @@ Parlez en anglais s'il vous plait.
 Parlez plus lentement s'il vous plait.
 Emmenez-moi à l'aéroport.
 Emmenez-moi à cette adresse.
-Enlevez-vos chaussures s'il vous plait.
+Enlevez-vos chaussures s'il vous plaît.
 Dites-lui que John a téléphoné.
-Dites-moi s'il vous plait.
-Attendez-moi s'il vous plait.
-Écrivez-ça s'il vous plait.
-S'il vous plait.
+Dites-moi s'il vous plaît.
+Attendez-moi s'il vous plaît.
+Écrivez-ça s'il vous plaît.
+S'il vous plaît.
 Assez bien.
 Mettez votre chemise.
 Qu'il pleuve ou qu'il fasse soleil, je serai là pour vous.
@@ -5690,9 +5690,9 @@ Elle veut savoir quand viendrez-vous.
 C'est une experte.
 Elle s'appelle Barbara.
 Il viendra avec moi demain.
-Il est plus agé que moi.
+Il est plus âgé que moi.
 C'est plus vieux que moi.
-Elle est plus agée que moi.
+Elle est plus âgée que moi.
 C'est joli.
 Elle s'appelle Sandra.
 Je dois attendre ?
@@ -5744,7 +5744,7 @@ Je vous remercie beaucoup.
 Merci.
 Merci d'avoir appelé.
 Merci pour tout.
-Merci de voter aide.
+Merci de votre aide.
 Cette voiture est pareille que la mienne.
 Cette voiture est identique à la mienne.
 Cette voiture est la même que la mienne.
@@ -5817,10 +5817,10 @@ Il y a quelques livres sur la table.
 Il y a deux crayons dans ma boîte.
 Il y a.
 Il y a eu un accident de voiture.
-Il y a un livre sutr la table.
+Il y a un livre sur la table.
 Il y a un puits mais l'eau est saumâtre.
 Chaque problème a toujours sa solution.
-Ce n'est pas la peine d'être préocuppé.
+Ce n'est pas la peine d'être préoccupé.
 Il n'y a aucun problème d'eau.
 Il n'y a aucun livre sur la table.
 Il y a de l'eau en quantité.
@@ -5846,7 +5846,7 @@ Eux, ils sont connus.
 Le bonus sera donné la semaine prochaine.
 Ils vident la maison le mois prochain.
 Ils sont très connus.
-Ils sont extrèmement connus.
+Ils sont extrêmement connus.
 Ils sont super connus.
 Ils sont arrivés hier.
 Ça coûte 26 dollars par jour.
@@ -5902,7 +5902,7 @@ Réveille-la.
 Réveille-le.
 Nous sommes connus.
 Nous, nous sommes connus.
-Nous vivont au Wisconsin.
+Nous vivons au Wisconsin.
 Nous sommes six personnes à la maison. Mon père, ma mère, mes deux sœurs et un frère en plus de moi-même.
 Nous sommes six personnes.
 Nous sommes deux frères et une sœur à la maison.
@@ -5910,7 +5910,7 @@ Nous pouvons manger de la nourriture de Chine ou d'Italie.
 Nous avons une voiture.
 Nous avons deux fils et une fille.
 Nous avons deux garçons et une fille.
-Ça nous plait énormément.
+Ça nous plaît énormément.
 Bienvenue (pour saluer quelqu'un)
 Deux verres d'eau s'il vous plait.
 Nous sommes de Californie.
@@ -6195,7 +6195,7 @@ Lequel veux-tu ?
 Lequel voulez-vous ?
 Lequel est le meilleur marché ?
 Lequel est le meilleur ?
-Quel chlin devrais-je prendre ?
+Quel chemin devrais-je prendre ?
 À quelle école va-t-il ?
 T'es qui ?
 Tu es qui ?
@@ -6228,7 +6228,7 @@ Pourquoi me le demandez-vous ?
 Pourquoi s'emporter sans raison ?
 Pourquoi êtes-vous en retard ?
 Pourquoi êtes-vous en train de rire ?
-Pourquoi êtes-vous en train d'hurler comme ça ?
+Pourquoi êtes-vous en train de hurler comme ça ?
 Pourquoi est-ce que vous me regardez comme ça ?
 Pourquoi me dites-vous tout ça ?
 Pourquoi n'y allez-vous pas ?
@@ -6246,24 +6246,24 @@ Pourquoi ne m'avez-vous pas informé ?
 Pourquoi portez-vous toujours des chemises bleues ?
 Pourquoi êtes-vous gêné ?
 Pourquoi avoir peur quand je suis avec vous ?
-Pouquoi avoir peur puisque je suis là ?
+Pourquoi avoir peur puisque je suis là ?
 Pourquoi est-ce ennuyeux ?
 Pourquoi le train est-il en retard ?
 Pourquoi pas ?
 Est-ce qu'il va pleuvoir aujourd'hui ?
 Y aura-t-il une fête d'anniversaire à la maison ?
 Viendront-ils jusqu'ici ?
-Appelez-moi un taxi s'il vous plait.
-Passez-moi une serviette s'il vous plait.
+Appelez-moi un taxi s'il vous plaît.
+Passez-moi une serviette s'il vous plaît.
 Ouvrirez-vous la porte ?
-Passez-moi le sel s'il vous plait.
+Passez-moi le sel s'il vous plaît.
 Vous le mettrez  dans la voiture pour moi ?
 Vous me le rappellerez ?
 Vous me raccompagnerez chez moi ?
 Avec qui était-elle venu ?
 Qui l'accompagnait ?
 Qui vous accompagnait ?
-Pouvez-vous lui dire de me rappeler s'il vous plait ?
+Pouvez-vous lui dire de me rappeler s'il vous plaît ?
 Pouvez-vous lui demander de venir ici ?
 Prendrez-vous un verre d'eau.
 Prendrez-vous du café ou du thé ?
@@ -6276,8 +6276,8 @@ Que diriez-vous de dîner avec moi ?
 Vous voulez louer un film ?
 Vous voulez regarder la télévision ?
 Vous aurez de l'eau ou du café ?
-Pouvez-vous prendre un message s'il vous plait ?
-Notez par écrit, s'il vous plait.
+Pouvez-vous prendre un message s'il vous plaît ?
+Notez par écrit, s'il vous plaît.
 Oui, tout à fait.
 Oui.
 Oui. J'en ai.
@@ -6293,14 +6293,14 @@ Vous êtes la bienvenue.
 Vous avez un très belle voiture.
 Vous m'avez beaucoup aidé.
 Attendez ici.
-Cela vous plait ?
+Cela vous plaît ?
 Vous ressemblez à ma sœur.
 Vous avez l'air fatigué.
 Vous parlez breton couramment.
 Vous parlez anglais couramment.
 Vos enfants sont bien élevés.
 Votre fille.
-Votre prénom, s'il vous plait ?
+Votre prénom, s'il vous plaît ?
 Votre maison est très agréable.
 Toutes vos affaires sont ici.
 Vous êtes beau.

--- a/server/data/fr/ofis_publik_ar_brezhoneg.txt
+++ b/server/data/fr/ofis_publik_ar_brezhoneg.txt
@@ -1,1153 +1,1167 @@
-Ah ! Tu es étais là ?
-De nombreux autres autocollants existent : salle de réunion, salle d’attente, tirez / poussez...
+Ah ! Tu étais là ?
+De nombreux autres autocollants existent : salle de réunion, salle d’attente, tirez-poussez...
 Il est crucial de réussir dans ce domaine sans attendre.
 Cordialement.
 De la Cornouaille au Goëlo.
 De tout cœur.
 La séance du trente.
 Depuis que je suis de nouveau en bonne santé.
-Depuis qu'il est de retour.
-Depuis des mois j'ai informé Yann-Vari, et je lui ai dit de rester attentif.
-Mince, tu nous as percé à jour Jañ-Do !
-À tire d'aile.
-Relancer Yann pour la séance de Dalgalian s'il ne m'informe pas.
+Depuis qu’il est de retour.
+Depuis des mois j’ai informé Yann-Vari, et je lui ai dit de rester attentif.
+Mince, tu nous as percé à jour Jañ-Do !
+À tire d’aile.
+Relancer Yann pour la séance de Dalgalian s’il ne m’informe pas.
 Je reprends vendredi matin normalement.
-Ils sont d'accord avec nous.
-D'accord, s'il y a du monde qui vient.
+Ils sont d’accord avec nous.
+D’accord, s’il y a du monde qui vient.
 Tu es contre eux.
 Tu es contre elles.
-C'était plus facile que je ne le pensais.
-Il est allé skier et il s'est cassé la jambe.
+C’était plus facile que je ne le pensais.
+Il est allé skier et il s’est cassé la jambe.
 Vous vous étiez levé de table.
 Vous vous étiez levés de table.
-J'étais passé par là pour qu'il ne me voit pas.
-il est parti de travers.
-c'est les Kurdes qui ont gagné à Kobané.
-les Kurdes ont été victorieux à Kobané.
-c'est le gars de Carhaix qui a gagné.
-le gars de Carhaix a été victorieux.
-elle est partie.
-il est parti en mer.
-il est parti.
-elle est partie.
-j'aime aussi ce livre.
-j'aime ce livre.
-la couleur qui me plaît le plus est le jaune.
-je mange souvent des pâtes.
-ces gens-là sont souvent en train de se plaindre.
-j'avais souvent froid durant l'hiver.
+J’étais passé par là pour qu’il ne me voit pas.
+Il est parti de travers.
+C’est les Kurdes qui ont gagné à Kobané.
+Les Kurdes ont été victorieux à Kobané.
+C’est le gars de Carhaix qui a gagné.
+Le gars de Carhaix a été victorieux.
+Elles sont parties.
+Il est parti en mer.
+Il est parti.
+Elle est partie.
+J’aime aussi ce livre.
+J’aime ce livre.
+La couleur qui me plait le plus est le jaune.
+Je mange souvent des pâtes.
+Ces gens-là sont souvent en train de se plaindre.
+J’avais souvent froid durant l’hiver.
 Il venait souvent me voir.
-il est là le lundi.
-ici on parle breton.
-ils sont ici.
-elles sont ici.
-c'est ici.
-il est ici.
-elle est ici.
+Il est là le lundi.
+Ici on parle breton.
+Ils sont ici.
+Elles sont ici.
+C’est ici.
+Il est ici.
+Elle est ici.
 Je suis ici.
 Tu es ici.
-il fait chaud.
-il fait froid.
-le temps est froid.
-le temps passé.
+Il fait chaud.
+Il fait froid.
+Le temps est froid.
+Le temps passé.
 On entend le vent.
-C'est le vent qu'on entend.
-le jour était long et le temps beau.
-le texte qui explique ce qu'est le CS et quel est sa mission.
-la petite tigresse.
-les deux vieilles femmes minces.
-cela me fait peur.
-la dix-huitième.
-les gens maudits.
-les petites gens.
+C’est le vent qu’on entend.
+Le jour était long et le temps beau.
+Le texte qui explique ce qu’est le CS et quelle est sa mission.
+La petite tigresse.
+Les deux vieilles femmes minces.
+Cela me fait peur.
+La dix-huitième.
+Les gens maudits.
+Les petites gens.
 Ces gens-là aiment les animaux.
-l'une et l'autre.
-l'un et l'autre.
-l'une ou l'autre.
-l'un ou l'autre.
-la forte.
-le blanc.
-le fort.
-le bon.
-le jaune.
-le rouge.
-la rouge.
-la bonne.
-la jaune.
-tout le monde.
-le ciel était sombre.
-le ciel est bleu.
-Le  document téléchargeable n’est pas traduit.
-le petit tigre.
-les qui vont en empirant me font peur.
-les choses vont en empirant.
+L’une et l’autre.
+L’un et l’autre.
+L’une ou l’autre.
+L’un ou l’autre.
+La forte.
+Le blanc.
+Le fort.
+Le bon.
+Le jaune.
+Le rouge.
+La rouge.
+La bonne.
+La jaune.
+Tout le monde.
+Le ciel était sombre.
+Le ciel est bleu.
+Le document téléchargeable n’est pas traduit.
+Le petit tigre.
+Les choses qui vont en empirant me font peur.
+Les choses vont en empirant.
 Les trois quarts des élèves bilingues de CM2 continuent à pratiquer la langue bretonne à l’âge adulte.
-la dix-huitième porte.
-le dix-huitième.
+La dix-huitième porte.
+Le dix-huitième.
 Youenn est très angoissé évidemment.
-c'est Annaig.
-Il avait été question de plusieurs dates mais aucune n'avait été confirmée en fin de compte, je relance Mael ou je vois tout d'abord avec Gwennael ?
-prénoms et nom du futur époux.
-prénoms et nom de la future épouse.
+C’est Annaig.
+Il avait été question de plusieurs dates mais aucune n’avait été confirmée en fin de compte.
+Je relance Mael ou je vois tout d’abord avec Gwennael ?
+Prénoms et nom du futur époux.
+Prénoms et nom de la future épouse.
 Audit annuel des fermes pour le lait, des fromageries pour le lactosérum.
 Nous avions eu peur.
-Licencié : Personne autorisée à prendre part aux compétitions des fédérations sportives.
-des messieurs fort arrogants.
-approuver la proposition de bail des nouveaux bureaux de Rennes.
-la page 44.
-la page quarante quatre.
-les petits garçons.
-les grands garçons.
-la quatrième.
-le loup et les trois petits cochons.
-ces chaussures ne sont pas confortables.
-le plus grand.
-la plus grande femme.
-Evaluation réalisée dans les classes bilingues breton- français à l’initiative de Dihun par Gilbert Dalgalian, linguiste, ancien Directeur Pédagogique de l’Alliance Française.
-Les larmes montaient aux yeux de l'enfant.
-la fille la plus courageuse.
-les chiens croient obéir aux bergers.
-ce château-là.
+Licencié : Personne autorisée à prendre part aux compétitions des fédérations sportives.
+Des messieurs fort arrogants.
+Approuver la proposition de bail des nouveaux bureaux de Rennes.
+La page quarante-quatre.
+Les petits garçons.
+Les grands garçons.
+La quatrième.
+Le loup et les trois petits cochons.
+Ces chaussures ne sont pas confortables.
+Le plus grand.
+La plus grande femme.
+Évaluation réalisée dans les classes bilingues breton-français à l’initiative de Dihun.
+Par Gilbert Dalgalian, linguiste, ancien Directeur Pédagogique de l’Alliance Française.
+Les larmes montaient aux yeux de l’enfant.
+La fille la plus courageuse.
+Les chiens croient obéir aux bergers.
+Ce château-là.
 Le chat se voyait dans le miroir.
-le professeur avait donné une mauvais note à Mark.
-les changements qui se passent concernant les classes sociales qui utilisent le breton (en lien avec le deuxième point).
-c'est la première fois que j'entends cela.
-le chien était dans sa niche.
-le chien est dans sa niche.
-le chien, quand il verra un vélo, le poursuivra en aboyant.
-les joueurs de boules.
-cette chaise n'est pas confortable.
-la plus courageuse.
-la leçon trois.
-Cette pluie tombe dru.
-les bonnes femmes médecins.
-les grandes filles.
-la connaissance.
-les pages 44 et 58.
-les pages trente trois et vingt deux.
-l'objectif était d'y aller le mercredi matin quand les familles ont un peu plus de temps censément.
-l'homme a une casquette blanche.
-la quatrième page.
-il était arrivé le cinquième.
-elle était arrivée la cinquième.
-ce qui montre qu'il sera quand même un peu plus facile de travailler avec le nouveau directeur.
-cette fille avait le cœur tendre.
-il faut arroser ces plantes.
-les malades.
-les forts.
-les fortes.
-ceux malades avec le mal de mer.
-les rouges.
-les bons et les mauvais.
-les bonnes et les mauvaises.
-les bons.
-les bonnes.
-les jaunes.
-les rouillés.
-les noirs.
-les noires.
-ceux-là là-bas.
-j'aime beaucoup ceux-ci, ceux-là par contre pas du tout.
-ces jaunes-ci.
-ceux-ci.
-la République dominicaine.
-ces blancs_là.
-ceux-là.
-Les données les plus complètes dont on dispose pour la Bretagne sont celles de l’enquête Étude de l’histoire familiale menée par l’INSEE en 1999 (ces chiffres sont analysés en détail dans ce rapport).
-Les données les plus complètes qui existent (INSEE, 1999) commencent maintenant à dater.
-c'est samedi.
-les instituteurs sont contre maintenant car l'IEN leur a dit qu'un poste d'institutrice monolingue sera retiré si la classe ouvre.
-les sportifs courraient vite.
-L’étoile la plus proche du Soleil est à 250 000 fois la distance Terre Soleil !
-la formation de perfectionnement débutera le 2 avril 2015.
-aujourd'hui c'est dimanche.
-c'est les vacances.
-la maman a ressenti une opposition forte quand elle a parlé à l'école, elle est prête à continuer mais à Pabu ou Ploumagoar si ça ne fonctionne pas bien.
-les bons médecins.
-la jolie petite fille.
-les bergers doivent être obéis par les chiens.
-la plus grande.
-les enfants ne jouaient pas avec le chien.
-les bons petits enfants.
-la Vierge Marie.
+Le professeur avait donné une mauvaise note à Mark.
+Les changements qui se passent concernant les classes sociales qui utilisent le breton.
+En lien avec le deuxième point.
+C’est la première fois que j’entends cela.
+Le chien était dans sa niche.
+Le chien est dans sa niche.
+Le chien, quand il verra un vélo, le poursuivra en aboyant.
+Les joueurs de boules.
+Cette chaise n’est pas confortable.
+La plus courageuse.
+La leçon trois.
+Cette pluie tombe drue.
+Les bonnes femmes médecins.
+Les grandes filles.
+La connaissance.
+Les pages quarante-quatre et cinquante-huit.
+Les pages trente-trois et vingt-deux.
+L’objectif était d’y aller le mercredi matin quand les familles ont un peu plus de temps censément.
+L’homme a une casquette blanche.
+La quatrième page.
+Il était arrivé le cinquième.
+Elle était arrivée la cinquième.
+Ce qui montre qu’il sera quand même un peu plus facile de travailler avec le nouveau directeur.
+Cette fille avait le cœur tendre.
+Il faut arroser ces plantes.
+Les malades.
+Les forts.
+Les fortes.
+Ceux malades avec le mal de mer.
+Les rouges.
+Les bons et les mauvais.
+Les bonnes et les mauvaises.
+Les bons.
+Les bonnes.
+Les jaunes.
+Les rouillés.
+Les noirs.
+Les noires.
+Ceux-là là-bas.
+J’aime beaucoup ceux-ci, ceux-là par contre pas du tout.
+Ces jaunes-ci.
+Ceux-ci.
+La République dominicaine.
+Ces blancs-là.
+Ceux-là.
+Les données les plus complètes dont on dispose pour la Bretagne sont celles de l’enquête.
+Étude de l’histoire familiale menée par l’INSEE en mille neuf cent quatre-vingt-dix-neuf.
+Ces chiffres sont analysés en détail dans ce rapport.
+Les données les plus complètes qui existent commencent maintenant à dater.
+C’est samedi.
+Les instituteurs sont contre maintenant car l’IEN leur a dit qu’un poste d’institutrice monolingue sera retiré si la classe ouvre.
+Les sportifs courraient vite.
+L’étoile la plus proche du Soleil est à deux-cents-cinquante mille fois la distance Terre Soleil !
+La formation de perfectionnement débutera le deux avril deux mille quinze.
+Aujourd’hui c’est dimanche.
+C’est les vacances.
+La maman a ressenti une opposition forte quand elle a parlé à l’école.
+Elle est prête à continuer, mais à Pabu ou Ploumagoar, si ça ne fonctionne pas bien.
+Les bons médecins.
+La jolie petite fille.
+Les bergers doivent être obéis par les chiens.
+La plus grande.
+Les enfants ne jouaient pas avec le chien.
+Les bons petits enfants.
+La Vierge Marie.
 Interdit de fumer.
-ne viens pas ici.
-ne venez pas ici.
-il est interdit de venir par ici.
-il ne faudrait pas.
-ne pas traverser la route.
-Avant quelle date faut-il envoyer la lettre ?
-avant tu venais plus souvent manger avec nous.
-demain il pleuvra.
-demain je laverai le linge.
-il y a du vent.
-c'est assez.
-assez.
+Ne viens pas ici.
+Ne venez pas ici.
+Il est interdit de venir par ici.
+Il ne faudrait pas.
+Ne pas traverser la route.
+Avant quelle date faut-il envoyer la lettre ?
+Avant tu venais plus souvent manger avec nous.
+Demain il pleuvra.
+Demain je laverai le linge.
+Il y a du vent.
+C’est assez.
+Assez.
 Il était ici.
 Elle était ici.
-J'étais ici.
-c'est bien là le problème.
-il est là.
-elle est là.
-c'est là.
-Patatras ! La vaisselle par terre !
-avenue du Général de Gaulle - 02.97.60.72.94.
-on mange du pain au petit-déjeuner.
-il achète du pain frais tous les matins.
-elle achète du pain frais tous les matins.
-on mangue du vieux pain au petit-déjeuner.
-tu joues tous les jours.
-je lis tous les jours.
+J’étais ici.
+C’est bien là le problème.
+Il est là.
+Elle est là.
+C’est là.
+Patatras ! La vaisselle par terre !
+Avenue du Général de Gaulle.
+Zéro deux quatre-vingt-dix-sept soixante soixante-douze quatre-vingt-quatorze.
+On mange du pain au petit-déjeuner.
+Il achète du pain frais tous les matins.
+Elle achète du pain frais tous les matins.
+On mangue du vieux pain au petit-déjeuner.
+Tu joues tous les jours.
+Je lis tous les jours.
 Je mange du pain tous les jours.
-nous mangeons des fruits tous les jours.
-il attend tous les jours à la gare.
-il attend tous les jours.
-ils jouaient aux cartes tous les jours.
-J'ai le temps de téléphoner tous les jours.
-je vais travailler tous les jours.
-tous les matins il était le dernier à arriver à l'école.
-tous les matins elle était la dernière à arriver à l'école.
-tous les matins nous prenions notre petit-déjeuner à table.
-tous les matins il allait tôt à l'école.
-tous les matins il allait en retard à l'école.
-tous les matins il allait à l'école.
-je l'ai connue.
+Nous mangeons des fruits tous les jours.
+Il attend tous les jours à la gare.
+Il attend tous les jours.
+Ils jouaient aux cartes tous les jours.
+J’ai le temps de téléphoner tous les jours.
+Je vais travailler tous les jours.
+Tous les matins il était le dernier à arriver à l’école.
+Tous les matins elle était la dernière à arriver à l’école.
+Tous les matins nous prenions notre petit-déjeuner à table.
+Tous les matins il allait tôt à l’école.
+Tous les matins il allait en retard à l’école.
+Tous les matins il allait à l’école.
+Je l’ai connue.
 Elle est allée chercher son sac.
-nous avons eu beaucoup de choses sans avoir demandé.
-il s'est noyé en mer.
-Le breton est vivant dans ces structures, on l'y entend et des actions de formation y ont été proposées.
-je serai donc à la réunion avec la mairie de Carhaix.
+Nous avons eu beaucoup de choses sans avoir demandé.
+Il s’est noyé en mer.
+Le breton est vivant dans ces structures, on l’y entend et des actions de formation y ont été proposées.
+Je serai donc à la réunion avec la mairie de Carhaix.
 Il sera avec nous demain.
-elle sera avec nous demain.
-j'ai bien une nouvelle maison.
-ayez vos papiers sur vous.
-Je n'avais jamais entendu pareille chose.
-heureuse année à tous.
-bonne année à vous.
-bonne année à toi.
-bonne année.
-il avait été contusionné en se bagarrant avec d'autres enfants.
-regroupe tout dans un tableau comme d'habitude, ce sera plus facile pour y voir clair.
-le conseil scientifique avait été réuni.
-c'est assez grand.
-il est assez grand.
-elle est assez grande.
-assez grand.
-très grands.
-très grandes.
-leurs patates sont sacrément grosses.
-le temps était beau.
-le bras de Morwena.
-j'irai manger tout à l'heure.
-tout à l'heure nous aurons un rendez-vous avec elles.
-maintenant il pêche.
-maintenant elle pêche.
-maintenant je pêche.
-maintenant on pêche.
-maintenant tu pêches.
-maintenant vous pêchez.
-maintenant nous pêchons.
-maintenant ils pêchent.
-maintenant elles pêchent.
+Elle sera avec nous demain.
+J’ai bien une nouvelle maison.
+Ayez vos papiers sur vous.
+Je n’avais jamais entendu pareille chose.
+Heureuse année à tous.
+Bonne année à vous.
+Bonne année à toi.
+Bonne année.
+Il avait été contusionné en se bagarrant avec d’autres enfants.
+Regroupe tout dans un tableau comme d’habitude, ce sera plus facile pour y voir clair.
+Le conseil scientifique avait été réuni.
+C’est assez grand.
+Il est assez grand.
+Elle est assez grande.
+Assez grand.
+Très grands.
+Très grandes.
+Leurs patates sont sacrément grosses.
+Le temps était beau.
+Le bras de Morwena.
+J’irai manger tout à l’heure.
+Tout à l’heure nous aurons un rendez-vous avec elles.
+Maintenant il pêche.
+Maintenant elle pêche.
+Maintenant je pêche.
+Maintenant on pêche.
+Maintenant tu pêches.
+Maintenant vous pêchez.
+Maintenant nous pêchons.
+Maintenant ils pêchent.
+Maintenant elles pêchent.
 Maintenant je le vois.
-maintenant c'est bien.
-maintenant c'est bon.
-il fume.
-elle fume.
-c'est préoccupant, on a découvert le cancer dans le cerveau de sa femme.
-les chiens du professeur Aouregan avaient été achetés à Châteauneuf.
-j'aimerais avoir un rendez-vous avec toi pour plusieurs projets.
-j'avais envie de vous parler.
-je veux que vous chantiez.
-il voulait que je chantasse.
-Nous avons envie d'y aller.
-il jouait avec vous.
-elle jouait avec vous.
-il jouait avec elle.
-elle jouait avec elle.
-il jouait avec moi.
-elle jouait avec moi.
-il jouait avec lui.
-elle jouait avec lui.
-il jouait avec eux.
-elle jouait avec eux.
-il jouait avec toi.
-elle jouait avec toi.
-des joueurs de boules.
-des jouets violents.
+Maintenant c’est bien.
+Maintenant c’est bon.
+Les sportifs couraient vite.
+Il fume.
+Elle fume.
+C’est préoccupant, on a découvert le cancer dans le cerveau de sa femme.
+Les chiens du professeur Aouregan avaient été achetés à Châteauneuf.
+J’aimerais avoir un rendez-vous avec toi pour plusieurs projets.
+J’avais envie de vous parler.
+Je veux que vous chantiez.
+Il voulait que je chantasse.
+Nous avons envie d’y aller.
+Il jouait avec vous.
+Elle jouait avec vous.
+Il jouait avec elle.
+Elle jouait avec elle.
+Il jouait avec moi.
+Elle jouait avec moi.
+Il jouait avec lui.
+Elle jouait avec lui.
+Il jouait avec eux.
+Elle jouait avec eux.
+Il jouait avec toi.
+Elle jouait avec toi.
+Des joueurs de boules.
+Des joueurs violents.
 Il riait en se voyant habillé comme ceci.
 Il riait en se voyant habillé comme ça.
-Il riait en se voyant…
-Je resterai ici jusqu'à ce que vous me disiez d'entrer.
-Je resterai ici jusqu'à ce que vous me disiez de venir.
+Il riait en se voyant.
+Je resterai ici jusqu’à ce que vous me disiez d’entrer.
+Je resterai ici jusqu’à ce que vous me disiez de venir.
 Ne pas aller voir le médecin.
-Restons tranquille de peur qu'il nous entende.
-quarante six.
-trente six.
-six chaises laides.
-vingt six chaises jaunes laides.
-six chaises jaunes laides.
-vingt six petites chaises jaunes.
-six petites chaises jaunes.
-vingt six chaises jaunes.
-six chaises jaunes.
-vingt six petites chaises.
-six petites chaises.
-six chaises.
-quarante six oiseaux.
-six maisons.
-vingt six.
-six.
-seize maisons.
-seize.
-vous, vous aimez.
-vous, vous aimiez.
-vous, vous aimerez.
-Vous pensez que c'est sa sœur ?
-vous, vous lisez.
-vous, vous lûtes.
-vous, vous lisiez.
-vous, vous liriez.
-vous, vous lirez.
-vous devriez avoir honte.
-vous, vous avez été aimé.
-vous, vous êtes aimé.
-vous, vous êtes aimés.
-c'est vous.
-vous, vous avez eu aimé.
-vous, vous avez aimé.
-il siffle en travaillant.
-tu trouves le temps long.
-Où vont-ils ?
-Où vont-elles ?
-Où allions-nous ?
-Où voulais-tu que nous allions ?
-Où voulais-tu que l'on aille ?
-en cinquième.
-ta tête.
-tes têtes.
-A quelle heure vient-il ?
-A quelle heure vient-elle ?
-À quelle heure est la séance ?
-A quelle heure doit-il venir ?
-A quelle heure doit-elle venir ?
-A quoi ça sert d'attendre plus longtemps ?
-A quoi ça sert de les écouter ?
-en quatrième.
-A qui doit-on écrire ?
-A qui donneras-tu ton cadeau ?
-C'est à qui de jouer ?
-C'est à qui ?
-A qui est ce manteau ?
-ton genou.
-il aime ta sœur.
-elle aime ta sœur.
-ta sœur aime.
-j'aime ta sœur.
-il aima ta sœur.
-il aimait ta sœur.
-elle aimait ta sœur.
-vous aimiez ta sœur.
-on aimait ta sœur.
-nous aimions ta sœur.
-j'aimais ta sœur.
-ils aimaient ta sœur.
-elles aimaient ta sœur.
-on aime ta sœur.
-tu aimais ta sœur.
-tu aimes ta sœur.
-il aimerait ta sœur.
-elle aimerait da sœur.
-ta sœur aimerait.
-vous aimeriez ta sœur.
-on aimerait ta sœur.
-nous aimerions ta sœur.
-j'aimerais ta sœur.
-ils aimeraient ta sœur.
-elles aimeraient ta sœur.
-tu aimerais ta sœur.
-tu aimeras ta sœur.
-nous aimerons ta sœur.
-j'aimerai ta sœur.
-ils aimeront ta sœur.
-elles aimeront ta sœur.
-j'aimai ta sœur.
-vous aimez ta sœur.
-elle aimerait ta sœur.
-vous aimâtes ta sœur.
-on aima ta sœur.
-nous aimâmes ta sœur.
-ils aimèrent ta sœur.
-elles aimèrent da sœur.
-tu aimas ta sœur.
-il aimera ta sœur.
-elle aimera ta sœur.
-ta sœur aimera.
-vous aimerez ta sœur.
-nous aimons ta sœur.
-ils aiment ta sœur.
-elles aiment ta sœur.
-on aimera ta sœur.
-ton père est grand.
-ton père n'est pas grand.
-ton père.
-on doit lui reprocher cela.
-ta djellaba.
-en troisième.
-c'est à toi de jouer.
-c'est ton tour.
-vous êtes second.
-en second.
-à huit heures je suis rentré à la maison.
-tes chaises sont grandes.
-tes chaises ne sont pas grandes.
-ta chambre.
-tout d'abord je souhaite te remercier.
-en premier lieu je souhaite te remercier.
-tout d'abord il faudra voir qui participera à l'expérience.
-nous sommes les premiers.
-en premier.
-je suis à la maison le midi.
-suite à notre discussion de décembre à Carhaix, je vous envoi les notes que j'avais recueillies au sujet du complément d'objet direct.
-c'est le tien.
-c'est la tienne.
-le tien est ici.
-la tienne est ici.
-le tien.
-la tienne.
-tes oiseaux sont grands.
-tes oiseaux ne sont pas grands.
-c'est ouvert le lundi.
-tes lunettes.
-le soir nous entendions les grenouilles croasser.
-c'est les tiens.
-c'est les tiennes.
-ta paire de lunettes.
-ta paire de chaussures.
-les tiens.
-les tiennes.
-c'est fermé le dimanche.
-le dimanche matin nous nous promenons à la campagne.
-le dimanche matin nous allons nous promener à la campagne.
-ta mère est grande.
-ta mère n'est pas grande.
-tes murs.
-tes frères.
-ton frère.
-j'irai à Guingamp demain.
-c'est à vendre.
-ton vin.
-le marché se tient le jeudi.
-tes mains.
-les bleus sont les derniers.
-ta main.
-à l'occasion de la nouvelle année Lena Louarn, Présidente et les membres du conseil d'administration de l'établissement public Office public de la langue bretonne sont heureux de vous souhaiter une très bonne année 2015.
-tiens.
+Restons tranquille de peur qu’il nous entende.
+Quarante-six.
+Trente-six.
+Six chaises laides.
+Vingt-six chaises jaunes laides.
+Six chaises jaunes laides.
+Vingt-six petites chaises jaunes.
+Six petites chaises jaunes.
+Vingt-six chaises jaunes.
+Six chaises jaunes.
+Six chaises.
+Quarante-six oiseaux.
+Six maisons.
+Vingt-six.
+Six.
+Seize maisons.
+Seize.
+Vous, vous aimez.
+Vous, vous aimiez.
+Vous, vous aimerez.
+Vous pensez que c’est sa sœur ?
+Vous, vous lisez.
+Vous, vous lûtes.
+Vous, vous lisiez.
+Vous, vous liriez.
+Vous, vous lirez.
+Vous devriez avoir honte.
+Vous, vous avez été aimé.
+Vous, vous êtes aimé.
+Vous, vous êtes aimés.
+C’est vous.
+Vous, vous avez aimé.
+Il siffle en travaillant.
+Tu trouves le temps long.
+Où vont-ils ?
+Où vont-elles ?
+Où allions-nous ?
+Où voulais-tu que nous allions ?
+Où voulais-tu que l’on aille ?
+En cinquième.
+Ta tête.
+Tes têtes.
+À quelle heure vient-il ?
+À quelle heure vient-elle ?
+À quelle heure est la séance ?
+À quelle heure doit-il venir ?
+À quelle heure doit-elle venir ?
+À quoi ça sert d’attendre plus longtemps ?
+À quoi ça sert de les écouter ?
+En quatrième.
+À qui doit-on écrire ?
+À qui donneras-tu ton cadeau ?
+C’est à qui de jouer ?
+C’est à qui ?
+À qui est ce manteau ?
+Ton genou.
+Il aime ta sœur.
+Elle aime ta sœur.
+Ta sœur aime.
+J’aime ta sœur.
+Il aima ta sœur.
+Il aimait ta sœur.
+Elle aimait ta sœur.
+Vous aimiez ta sœur.
+On aimait ta sœur.
+Nous aimions ta sœur.
+J’aimais ta sœur.
+Ils aimaient ta sœur.
+Elles aimaient ta sœur.
+On aime ta sœur.
+Tu aimais ta sœur.
+Tu aimes ta sœur.
+Il aimerait ta sœur.
+Elle aimerait ta sœur.
+Ta sœur aimerait.
+Vous aimeriez ta sœur.
+On aimerait ta sœur.
+Nous aimerions ta sœur.
+J’aimerais ta sœur.
+Ils aimeraient ta sœur.
+Elles aimeraient ta sœur.
+Tu aimerais ta sœur.
+Tu aimeras ta sœur.
+Nous aimerons ta sœur.
+J’aimerai ta sœur.
+Ils aimeront ta sœur.
+Elles aimeront ta sœur.
+J’aimai ta sœur.
+Vous aimez ta sœur.
+Vous aimâtes ta sœur.
+On aima ta sœur.
+Nous aimâmes ta sœur.
+Ils aimèrent ta sœur.
+Elles aimèrent ta sœur.
+Tu aimas ta sœur.
+Il aimera ta sœur.
+Elle aimera ta sœur.
+Ta sœur aimera.
+Vous aimerez ta sœur.
+Nous aimons ta sœur.
+Ils aiment ta sœur.
+Elles aiment ta sœur.
+On aimera ta sœur.
+Ton père est grand.
+Ton père n’est pas grand.
+Ton père.
+On doit lui reprocher cela.
+Ta djellaba.
+En troisième.
+C’est à toi de jouer.
+C’est ton tour.
+Vous êtes second.
+En second.
+À huit heures je suis rentré à la maison.
+Tes chaises sont grandes.
+Tes chaises ne sont pas grandes.
+Ta chambre.
+Tout d’abord je souhaite te remercier.
+En premier lieu je souhaite te remercier.
+Tout d’abord il faudra voir qui participera à l’expérience.
+Nous sommes les premiers.
+En premier.
+Je suis à la maison le midi.
+Suite à notre discussion de décembre à Carhaix.
+Je vous envoie les notes que j’avais recueillies au sujet du complément d’objet direct.
+C’est le tien.
+C’est la tienne.
+Le tien est ici.
+La tienne est ici.
+Le tien.
+La tienne.
+Tes oiseaux sont grands.
+Tes oiseaux ne sont pas grands.
+C’est ouvert le lundi.
+Tes lunettes.
+Le soir nous entendions les grenouilles croasser.
+C’est les tiens.
+C’est les tiennes.
+Ta paire de lunettes.
+Ta paire de chaussures.
+Les tiens.
+Les tiennes.
+C’est fermé le dimanche.
+Le dimanche matin nous nous promenons à la campagne.
+Le dimanche matin nous allons nous promener à la campagne.
+Ta mère est grande.
+Ta mère n’est pas grande.
+Tes murs.
+Tes frères.
+Ton frère.
+J’irai à Guingamp demain.
+C’est à vendre.
+Ton vin.
+Le marché se tient le jeudi.
+Tes mains.
+Les bleus sont les derniers.
+Ta main.
+À l’occasion de la nouvelle année Lena Louarn, Présidente, est heureuse de vous souhaiter une très bonne année 2015.
+Les membres du conseil d’administration de l’office public de la langue bretonne.
+Tiens.
 Merci de tenir votre chien en laisse pour ne pas les déranger.
-tenez.
-à mon frère.
-à ma mère.
-à mon père.
-à Madame Calvez.
-Tu danses ?
-deux petits gars.
-trente deux gars.
-deux gars.
-deux coups.
-trente deux maisons blanches.
-vingt deux maisons blanches.
-deux maisons blanches.
-trente deux maisons.
-vingt deux maisons.
-deux maisons.
-quarante deux.
-trente deux.
-vingt deux grands éléphants.
-deux grands éléphants.
-vingt deux éléphants noirs.
-deux éléphants noirs.
-quarante deux éléphants.
-deux éléphants.
-deux tsars.
-ce sont deux frères.
-deux.
-deux par deux.
-des yeux vifs.
-cet enfant a les yeux bleus.
-le petit garçon avait les yeux bleus.
-malgré tous les écrits que je dois lire tous les jours j'essaierai de la lire, ou bien au moins d'y jeter un regard minutieux.
-est-ce que tu as eu des nouvelles au sujet de ce nouveau décret ?
-quarante chevaux bruns.
-quarante chevaux.
-quarante.
-douze maisons.
-douze.
-le 5 novembre 2007.
-à cette époque, les gens n'avaient pas beaucoup de temps libre.
-il rentrait à la maison sans se presser.
-en ce temps-là nous étions nombreux à travailler dans cette entreprise.
-en ce temps-là j'étais petit et en bonne santé.
-le mardi 6 avril.
-à ta mère.
-à ton frère.
-à ton père.
-mange.
-des mangeurs d'hommes.
-on dînait tard.
-ton frère a mangé la dernière part de gâteau.
-mon frère a mangé mon morceau de pain.
-le petit déjeuner est terminé.
-nous mangeons des fruits.
-nous avons mangé des fruits.
-le chat mange des souris.
-hier c'était jeudi.
-hier il pêchait.
-hier elle pêchait.
-hier vous pêchiez.
-hier on pêchait.
-hier nous pêchions.
-hier je pêchais.
-hier ils pêchaient.
-hier elles pêchaient.
-hier tu pêchais.
-apporte en deux ou trois.
-un jour ou l'autre.
-dix maisons.
-dix.
-bonjour les amis.
-bonjour.
-bonjour à tous.
-personne.
-allons ensemble.
-il était en train de laver les vitres des fenêtres avant-hier.
-les Beatles étaient venus chanter.
+Tenez.
+À mon frère.
+À ma mère.
+À mon père.
+À Madame Calvez.
+Tu danses ?
+Deux petits gars.
+Trente-deux gars.
+Deux gars.
+Deux coups.
+Trente-deux maisons blanches.
+Vingt-deux maisons blanches.
+Deux maisons blanches.
+Trente-deux maisons.
+Vingt-deux maisons.
+Deux maisons.
+Quarante-deux.
+Trente-deux.
+Vingt-deux grands éléphants.
+Deux grands éléphants.
+Vingt-deux éléphants noirs.
+Deux éléphants noirs.
+Quarante-deux éléphants.
+Deux éléphants.
+Deux tsars.
+Ce sont deux frères.
+Deux.
+Deux par deux.
+Des yeux vifs.
+Cet enfant a les yeux bleus.
+Le petit garçon avait les yeux bleus.
+Malgré tous les écrits que je dois lire tous les jours j’essaierai de la lire, ou bien au moins d’y jeter un regard minutieux.
+Est-ce que tu as eu des nouvelles au sujet de ce nouveau décret ?
+Quarante chevaux bruns.
+Quarante chevaux.
+Quarante.
+Douze maisons.
+Douze.
+Le cinq novembre deux mille sept.
+À cette époque, les gens n’avaient pas beaucoup de temps libre.
+Il rentrait à la maison sans se presser.
+En ce temps-là nous étions nombreux à travailler dans cette entreprise.
+En ce temps-là j’étais petit et en bonne santé.
+Le mardi six avril.
+À ta mère.
+À ton frère.
+À ton père.
+Mange.
+Des mangeurs d’hommes.
+On dînait tard.
+Ton frère a mangé la dernière part de gâteau.
+Mon frère a mangé mon morceau de pain.
+Le petit déjeuner est terminé.
+Nous mangeons des fruits.
+Nous avons mangé des fruits.
+Le chat mange des souris.
+Hier c’était jeudi.
+Hier il pêchait.
+Hier elle pêchait.
+Hier vous pêchiez.
+Hier on pêchait.
+Hier nous pêchions.
+Hier je pêchais.
+Hier ils pêchaient.
+Hier elles pêchaient.
+Hier tu pêchais.
+Apportes-en deux ou trois.
+Un jour ou l’autre.
+Dix maisons.
+Dix.
+Bonjour les amis.
+Bonjour.
+Bonjour à tous.
+Personne.
+Allons ensemble.
+Il était en train de laver les vitres des fenêtres avant-hier.
+Les Beatles étaient venus chanter.
 Il était venu sans avoir été invité.
 Il était venu sans être invité.
 Maodez était venu nous donner un coup de main.
-Vous étiez là également ?
-il a grandi.
-elle a grandi.
-il est venu.
-elle est venue.
-suivez-moi s'il vous plait.
-venez avec moi s'il vous plait .
-venez à table.
-venez quand vous voulez.
-venez.
-viens écouter.
-viens vendredi.
-viens immédiatement.
-viens tout de suite.
-viens avec nous.
-suis-moi s'il te plaît .
-viens avec moi s'il te plaît.
-viens quand tu veux.
-viens quand le temps sera venu.
-viens.
-depuis des mois j'ai informé Yann-Vari, et je lui ai dit de rester attentif.
-il est interdit de fumer.
-on a défendu aux voitures de passer par cette route.
-diphtérie, tétanos, poliomyélite.
-J'ouvre la barrière tous les matins.
-ouvre la porte avant de partir.
-le magasin est ouvert le lundi.
-c'est ouvert le mercredi.
-elle est ouverte aux stagiaires qui ont suivi une formation 6 mois ainsi qu'à tous ceux qui parlent breton et qui veulent améliorer leur langue.
+Vous étiez là également ?
+Il a grandi.
+Elle a grandi.
+Il est venu.
+Elle est venue.
+Suivez-moi s’il vous plait.
+Venez avec moi s’il vous plait .
+Venez à table.
+Venez quand vous voulez.
+Venez.
+Viens écouter.
+Viens vendredi.
+Viens immédiatement.
+Viens tout de suite.
+Viens avec nous.
+Suis-moi s’il te plait .
+Viens avec moi s’il te plait.
+Viens quand tu veux.
+Viens quand le temps sera venu.
+Viens.
+Il est interdit de fumer.
+On a défendu aux voitures de passer par cette route.
+Diphtérie, tétanos, poliomyélite.
+J’ouvre la barrière tous les matins.
+Ouvre la porte avant de partir.
+Le magasin est ouvert le lundi.
+C’est ouvert le mercredi.
+Elle est ouverte aux stagiaires qui ont suivi une formation de 6 mois.
+Ainsi qu’à tous ceux qui parlent breton et qui veulent améliorer leur langue.
 Digor party.
-il est sans travail.
-lundi je suis resté à la maison.
-je serai là lundi.
-la clé sera sous le paillasson.
-sous la mer.
-le mur avait été détruit il y a cinq ans.
-descend tout de suite du mur.
-il m'a descendu mon livre.
-il est descendu par les escaliers.
-nous leur avons montré le chemin.
-ses parents sont séparés l'un de l'autre.
-ses parents sont séparés.
-ils sont séparés maintenant.
-il en aura dépensé de l'argent.
-deux petites filles.
-deux filles.
-vingt deux tables noires.
-deux tables noires.
-vingt deux grandes tables.
-deux grandes tables.
-vingt deux tables.
-deux tables.
-deux gares.
-deux ou trois fois.
-deux petites oreilles.
-quarante deux femmes.
-trente deux femmes.
-deux blondes.
-vingt deux.
-elle a des jambes maigres.
-de petites oreilles.
-Je faisais attention qu'il ne tombe pas.
-à ce propos.
-à ce sujet.
+Il est sans travail.
+Lundi je suis resté à la maison.
+Je serai là lundi.
+La clé sera sous le paillasson.
+Sous la mer.
+Le mur avait été détruit il y a cinq ans.
+Descends tout de suite du mur.
+Il m’a descendu mon livre.
+Il est descendu par les escaliers.
+Nous leur avons montré le chemin.
+Ses parents sont séparés l’un de l’autre.
+Ses parents sont séparés.
+Ils sont séparés maintenant.
+Il en aura dépensé de l’argent.
+Deux petites filles.
+Deux filles.
+Vingt-deux tables noires.
+Deux tables noires.
+Vingt-deux grandes tables.
+Deux grandes tables.
+Vingt-deux tables.
+Deux tables.
+Deux gares.
+Deux ou trois fois.
+Deux petites oreilles.
+Quarante-deux femmes.
+Trente-deux femmes.
+Deux blondes.
+Vingt-deux.
+Elle a des jambes maigres.
+De petites oreilles.
+Je faisais attention qu’il ne tombe pas.
+À ce propos.
+À ce sujet.
 Je vous verrai plus tard.
 Celui qui ne sait pas lire est inculte.
-tu viendras quand tu voudras.
-je viendrai lundi.
-c'est la porte de la maison.
-c'est la porte de la chambre qui était resté ouverte.
-c'est la porte de la chambre que je vois là-bas.
-c'est la porte de la chambre que je vois ici.
-c'est la porte de la chambre que je vois là.
-c'est la porte de la chambre.
+Tu viendras quand tu voudras.
+Je viendrai lundi.
+C’est la porte de la maison.
+C’est la porte de la chambre qui était restée ouverte.
+C’est la porte de la chambre que je vois là-bas.
+C’est la porte de la chambre que je vois ici.
+C’est la porte de la chambre que je vois là.
+C’est la porte de la chambre.
 Dieu vous bénisse.
-Que Dieu soit loué !
-il boit de l'eau.
-leurs cartes sont déchirées.
-par la grande route.
-par la porte.
-Par où es-tu venu ?
-Par où es-tu venue ?
-de ta faute.
-de sa faute.
-de votre faute.
-de notre faute.
-c'est en travaillant dur qu'il a réussi.
-de ma faute.
-de leur faute.
-il est furieux que son parti ait perdu les élections.
-les ducs de Bretagne.
-les gens sont là-bas.
-c'est là-bas.
-il est là-bas.
-elle est là-bas.
-sa tête.
-son genou.
-son père.
-nous sommes en relation.
-En vérité, l’Île-de-France est riche de nombreux brittophones et sympathisants ; l’identité bretonne s’y affiche de plus en plus et de nombreux acteurs économiques bretons de premiers plans y travaillent.
-sa chambre.
-c'est le sien qui est ici.
-c'est la sienne qui est ici.
-c'est le sien.
-c'est la sienne.
-le sien est ici.
-la sienne est ici.
-le sien.
-la sienne.
-à Quimper.
-nous étions en train d'aller.
-12 % des enfants de la commune de Plouvien sont scolarisés dans la filière bilingue.
-c'est les siens.
-c'est les siennes.
-les siens.
-les siennes.
-il habite à Rennes.
-elle habite à Rennes.
-tu es dans la maison du loup.
-sa mère.
-ses murs.
-ses frères.
-son frère.
-son vin.
-ses mains.
-sa main.
-je mange des céréales au petit déjeuner.
-le soleil était en train de briller.
-l'effet de l'emploi de la langue par les collectivités sur la manière dont les brittophones voient leur langue, ainsi que sur les Bretons qui ne savent pas le breton.
-quarante huit.
-trente huit.
-quarante huit tasses.
-vingt huit maisons.
-huit maisons.
-vingt huit.
-huit.
-nous restons lire tant qu'il y a de la lumière.
+Que Dieu soit loué !
+Il boit de l’eau.
+Leurs cartes sont déchirées.
+Par la grande route.
+Par la porte.
+Par où es-tu venu ?
+Par où es-tu venue ?
+De ta faute.
+De sa faute.
+De votre faute.
+De notre faute.
+C’est en travaillant dur qu’il a réussi.
+De ma faute.
+De leur faute.
+Il est furieux que son parti ait perdu les élections.
+Les ducs de Bretagne.
+Les gens sont là-bas.
+C’est là-bas.
+Il est là-bas.
+Elle est là-bas.
+Sa tête.
+Son genou.
+Son père.
+Nous sommes en relation.
+En vérité, l’Île-de-France est riche de nombreux brittophones et sympathisants.
+L’identité bretonne s’y affiche de plus en plus et de nombreux acteurs économiques bretons de premiers plans y travaillent.
+Sa chambre.
+C’est le sien qui est ici.
+C’est la sienne qui est ici.
+C’est le sien.
+C’est la sienne.
+Le sien est ici.
+La sienne est ici.
+Le sien.
+La sienne.
+À Quimper.
+Nous étions en train d’aller.
+Douze pourcents des enfants de la commune de Plouvien sont scolarisés dans la filière bilingue.
+C’est les siens.
+C’est les siennes.
+Les siens.
+Les siennes.
+Il habite à Rennes.
+Elle habite à Rennes.
+Tu es dans la maison du loup.
+Sa mère.
+Ses murs.
+Ses frères.
+Son frère.
+Son vin.
+Ses mains.
+Sa main.
+Je mange des céréales au petit déjeuner.
+Le soleil était en train de briller.
+L’effet de l’emploi de la langue par les collectivités sur la manière dont les brittophones voient leur langue.
+Ainsi que sur les Bretons qui ne savent pas le breton.
+Quarante-huit.
+Trente-huit.
+Quarante-huit tasses.
+Vingt-huit maisons.
+Huit maisons.
+Vingt-huit.
+Huit.
+Nous restons lire tant qu’il y a de la lumière.
 Ces éléments sont en la possession de l’Office de la Langue Bretonne.
-dans mon bureau.
-dans ma chambre.
-mes affaires sont dans ma caisse.
-dans mes mains.
-dans ma main.
-dans ma tête.
-à ma place.
-dans mon genou.
-dans mon vin.
-dans mes murs.
-dans ma maison.
+Dans mon bureau.
+Dans ma chambre.
+Mes affaires sont dans ma caisse.
+Dans mes mains.
+Dans ma main.
+Dans ma tête.
+À ma place.
+Dans mon genou.
+Dans mon vin.
+Dans mes murs.
+Dans ma maison.
 Ils sont en train de faire des paniers.
-l'assiette est sur la table.
-le chat est en train de manger des souris.
+L’assiette est sur la table.
+Le chat est en train de manger des souris.
 Le chien est en train de courir.
-les enfant sont en train de jouer sur la plage.
-Les enfant sont en train de jouer sur la rue.
-les enfants sont en train d'écrire une lettre.
-il est debout.
-elle est debout.
-mon père est en train de cirer ses chaussures.
-il est en train de lire le journal.
-elle est en train de lire le journal.
-il vient juste de partir.
-elle vient juste de partir.
+Les enfant sont en train de jouer sur la plage.
+Les enfant sont en train de jouer dans la rue.
+Les enfants sont en train d’écrire une lettre.
+Il est debout.
+Elle est debout.
+Mon père est en train de cirer ses chaussures.
+Il est en train de lire le journal.
+Elle est en train de lire le journal.
+Il vient juste de partir.
+Elle vient juste de partir.
 Il est en train de courir.
-elle est en train d'enlever son tablier.
-nous sommes debout.
-le Combat des Trente.
-réunion publique au sujet de l'ouverture de la filière bilingue du collège privé Saint Gildas, à Auray.
-lui, il boit de l'eau.
-lui, il aime.
-lui, il aimait.
-lui, il aimera.
-lui, il lit.
-lui, il lut.
-lui, il lisait.
-lui, il lirait.
-lui, il lira.
-lui, il a été aimé.
-lui, il est aimé.
-c'est fille-là s'en était bien tirée.
-il s'est retiré.
-elle s'est retirée.
-il s'en est tiré.
-il s'est retiré dans sa chambre.
-elle s'est retirée dans sa chambre.
-elle s'en est tirée.
-se battre.
-s'aimer.
-les gens sont arrivés ici.
-les gens sont arrivés.
-le gars est arrivé.
-la fille est arrivée.
-il est arrivé.
-elles est arrivée.
-c'est arrivé.
-se prendre.
-se nourrir.
-je me voyais dans l'eau.
-se voir.
-lui, il a eu aimé.
-lui, il a aimé.
-c'est lui.
-cette nuit-là précisément il avait quitté la maison.
-cette nuit-là précisément elle avait quitté la maison.
-c'est précisément cette nuit-là  qu'il avait quitté la maison.
-c'est précisément cette nuit-là qu'elle avait quitté la maison.
-A l'OLB, nous avons besoin d'argent pour progresser.
-il a réussi en travaillant dur.
-en voyant que la nuit était noire ils étaient revenus sur leurs pas.
+Elle est en train d’enlever son tablier.
+Nous sommes debout.
+Le Combat des Trente.
+Réunion publique au sujet de l’ouverture de la filière bilingue du collège privé Saint Gildas, à Auray.
+Lui, il boit de l’eau.
+Lui, il aime.
+Lui, il aimait.
+Lui, il aimera.
+Lui, il lit.
+Lui, il lut.
+Lui, il lisait.
+Lui, il lirait.
+Lui, il lira.
+Lui, il a été aimé.
+Lui, il est aimé.
+Cette fille-là s’en était bien tirée.
+Il s’est retiré.
+Elle s’est retirée.
+Il s’en est tiré.
+Il s’est retiré dans sa chambre.
+Elle s’est retirée dans sa chambre.
+Elle s’en est tirée.
+Se battre.
+S’aimer.
+Les gens sont arrivés ici.
+Les gens sont arrivés.
+Le gars est arrivé.
+La fille est arrivée.
+Il est arrivé.
+Elle est arrivée.
+C’est arrivé.
+Se prendre.
+Se nourrir.
+Je me voyais dans l’eau.
+Se voir.
+Lui, il eut aimé.
+Lui, il a aimé.
+C’est lui.
+Cette nuit-là précisément il avait quitté la maison.
+Cette nuit-là précisément elle avait quitté la maison.
+C’est précisément cette nuit-là qu’il avait quitté la maison.
+C’est précisément cette nuit-là qu’elle avait quitté la maison.
+À l’OLB, nous avons besoin d’argent pour progresser.
+Il a réussi en travaillant dur.
+En voyant que la nuit était noire ils étaient revenus sur leurs pas.
 Après-midi jeux sous le chapiteau.
-l'île de Bréhat.
-là, il y a du monde.
-j'arrangerai le grenier pendant l'été.
-il y aura également de quoi apprendre le breton pendant l'été : nous organiserons 8 stages.
-dans cette guerre il y a l'Angleterre et l'Espagne.
-à la maison il y a trois téléviseurs.
-ces temps-ci vous devez faire attention.
-ces temps-ci je n'ai pas beaucoup de travail.
-ces temps-ci je suis souvent fatigué.
-ces temps-ci j'ai souvent mal à la tête.
-il y avait des vaches dans ce champs hier.
-Cette pièce contenait un coin toilette, une douche, des WC et une baignoire
-il y a un tas de choses bon-marché dans ce magasin.
-les gants étaient dans la boîte.
-il neige régulièrement en Sibérie.
-Il neige où pas ?
-il neigeait.
-Echange et formation.
-En comparaison, la Lune orbite en moyenne à 390 000 km de la Terre.
-l'heure du dîner.
-c'est l'heure du goûter.
-horaires d'ouverture : lundi, mercredi, vendredi de 14h00 à 18h30 et samedi de 9h00 à 12h00 et de 14h00 à 18h30.
-D'où sont-ils originaire ceux-là ?
-D'où vient-elle ?
-D'où es-tu ?
-De quelle couleur ?
-De quelle couleur il est ?
-De quelle couleur elle est ?
-De quoi est-il question ?
-De quoi parle-t-on ?
-Bois !
-il boit trop d'eau avant d'aller dormir.
-elle boit trop d'eau avant d'aller dormir.
-les choses sont ainsi.
-c'est comme ça.
-il a bu autrefois.
+L’île de Bréhat.
+Là, il y a du monde.
+J’arrangerai le grenier pendant l’été.
+Il y aura également de quoi apprendre le breton pendant l’été : nous organiserons huit stages.
+Dans cette guerre il y a l’Angleterre et l’Espagne.
+À la maison il y a trois téléviseurs.
+Ces temps-ci vous devez faire attention.
+Ces temps-ci je n’ai pas beaucoup de travail.
+Ces temps-ci je suis souvent fatigué.
+Ces temps-ci j’ai souvent mal à la tête.
+Il y avait des vaches dans ce champ hier.
+Cette pièce contenait un coin toilette, une douche, des WC et une baignoire.
+Il y a un tas de choses bon-marché dans ce magasin.
+Les gants étaient dans la boîte.
+Il neige régulièrement en Sibérie.
+Il neige où pas ?
+Il neigeait.
+Échange et formation.
+En comparaison, la Lune orbite en moyenne à trois cents quatre-vingt-dix mille kilomètres de la Terre.
+L’heure du dîner.
+C’est l’heure du goûter.
+Horaires d’ouverture : lundi, mercredi, vendredi de quatorze heures à dix-huit heures trente.
+Et samedi de neuf heures à midi et de quatorze heures à dix-huit heures trente.
+D’où sont-ils originaires ceux-là ?
+D’où vient-elle ?
+D’où es-tu ?
+De quelle couleur ?
+De quelle couleur il est ?
+De quelle couleur elle est ?
+De quoi est-il question ?
+De quoi parle-t-on ?
+Bois !
+Il boit trop d’eau avant d’aller dormir.
+Elle boit trop d’eau avant d’aller dormir.
+Les choses sont ainsi.
+C’est comme ça.
+Il a bu autrefois.
 Des remarques au sujet des baisses qui ne sont pas justifiées car elles sont petites et importantes pour ceux qui les reçoivent.
 Ce conteneur est réservé uniquement aux ordures ménagères.
-pour la thèse, c'est noté dans mon agenda.
-Pour la première fois, de nombreuses listes, et notamment les listes principales (PS, UMP), avaient placé des mentions en langue bretonne dans leurs programmes politiques.
-Pour être efficace, cette vaccination nécessite un rappel tous les 5 ans.
-il s’agit d’un rappel puisque vous avez dû recevoir une invitation de l’ULAMIR.
-Pour en savoir plus voir Vie et mort des étoiles par Bruno Manguin et Bénédicte Saulier-Le Dréan, collection a Espace des sciences, Éditions Apogée, 2005.
-Pour que la préfecture ne viennent pas nous dire : « Ah non, maintenant vous avez transféré vote compétence, les communes ne pourront plus s’occuper de ça », parce qu’il y aussi des gens qui veulent nous embêter là-dessus.
-pour qu'il pêche.
-pour qu'elle pêche.
-pour que vous pêchiez.
-pour qu'on pêche.
-pour que nous pêchions.
-pour que je pêche.
-pour qu'ils pêchent.
-pour qu'elles pêchent.
-pour que tu pêches.
-dans ta chambre.
-dans ton genou.
-dans ton vin.
-dans tes murs.
-dans ta tête.
-dans tes têtes.
-à ta place.
-dans ton bureau.
-dans tes mains.
-dans ta maison.
-dans ta main.
-nous avons besoin de bénévoles prêts à nous aider ou à nous proposer de nouvelles idées pour organiser des événements de qualité.
-Fañch s'occupe des bêtes.
-C'est Fañch qui s'occupe des bêtes.
-on mange le far avec les mains.
-ils veulent.
-elles veulent.
-ma mère veut que j'aille faire les commissions avec elle.
-vous voulez.
-elle veut.
-je veux.
-tu veux.
-le fest-noz de soutien du 7 mars sera totalement organisé par des stagiaires qui suivent la formation longue de Skol an Emsav, pour soutenir l'association.
-le gars est très vexé à ce qu'il parait.
+Pour la thèse, c’est noté dans mon agenda.
+Pour la première fois, de nombreuses listes avaient placé des mentions en langue bretonne dans leurs programmes politiques.
+Et notamment les listes principales : PS, UMP.
+Pour être efficace, cette vaccination nécessite un rappel tous les cinq ans.
+Il s’agit d’un rappel puisque vous avez dû recevoir une invitation de l’ULAMIR.
+Pour en savoir plus voir Vie et mort des étoiles par Bruno Manguin et Bénédicte Saulier-Le Dréan.
+Collection Espace des sciences, Éditions Apogée, deux mille cinq.
+Pour que la préfecture ne viennent pas nous dire ça, parce qu’il y aussi des gens qui veulent nous embêter là-dessus.
+Ah non, maintenant vous avez transféré vote compétence, les communes ne pourront plus s’occuper de ça.
+Pour qu’il pêche.
+Pour qu’elle pêche.
+Pour que vous pêchiez.
+Pour qu’on pêche.
+Pour que nous pêchions.
+Pour que je pêche.
+Pour qu’ils pêchent.
+Pour qu’elles pêchent.
+Pour que tu pêches.
+Dans ta chambre.
+Dans ton genou.
+Dans ton vin.
+Dans tes murs.
+Dans ta tête.
+Dans tes têtes.
+À ta place.
+Dans ton bureau.
+Dans tes mains.
+Dans ta maison.
+Dans ta main.
+Nous avons besoin de bénévoles prêts à nous aider ou à nous proposer de nouvelles idées pour organiser des évènements de qualité.
+Fañch s’occupe des bêtes.
+C’est Fañch qui s’occupe des bêtes.
+On mange le far avec les mains.
+Ils veulent.
+Elles veulent.
+Ma mère veut que j’aille faire les commissions avec elle.
+Vous voulez.
+Elle veut.
+Je veux.
+Tu veux.
+Le fest-noz de soutien du sept mars sera totalement organisé par des stagiaires qui suivent la formation longue de Skol an Emsav, pour soutenir l’association.
+Le gars est très vexé à ce qu’il parait.
 Ces trois dernières sont des fontaines souterraines.
-il était furieux parce que vous souriiez à chaque fois qu'il expliquait quelque chose.
-j'ai eu Fulup au téléphone.
-vous pouvez croire ce que je vous dit.
-nous pourrons parler de ça demain.
+Il était furieux parce que vous souriiez à chaque fois qu’il expliquait quelque chose.
+J’ai eu Fulup au téléphone.
+Vous pouvez croire ce que je vous dit.
+Nous pourrons parler de ça demain.
 On peut laisser des pièces au pot.
-tu pourras apporter le tableau que nous avions fait sur ton ordinateur avant la réunion.
-vous pouvez croire.
-il jouait avec nous.
-elle jouait avec nous.
-je me retrouve avec 45 adresses.
-la clé est avec sa sœur.
-Pourvu qu'ils ne viennent pas !
-Pourvu qu'elles ne viennent pas !
-Pourvu qu'il ne vienne pas !
-Pourvu qu'elle ne vienne pas !
-pourvu qu'il n'aille pas répéter cela.
-en y allant  doucement, tu ne sera pas entendu.
-nous pêchions avec des filets.
-j'entourai la bonne réponse avec un crayon rouge.
-elle jouait avec lui.
-il a raison.
-C'est Gauguin qui a fait celui-là...
-bleu clair.
-il pleut maintenant.
-il pleut.
-il pleuvait.
-il pleut à verse.
-c'est mouillé.
-Je ne l'entends plus.
-complètement trempé.
+Tu pourras apporter le tableau que nous avions fait sur ton ordinateur avant la réunion.
+Vous pouvez croire.
+Il jouait avec nous.
+Elle jouait avec nous.
+Je me retrouve avec quarante-cinq adresses.
+La clé est avec sa sœur.
+Pourvu qu’ils ne viennent pas !
+Pourvu qu’elles ne viennent pas !
+Pourvu qu’il ne vienne pas !
+Pourvu qu’elle ne vienne pas !
+Pourvu qu’il n’aille pas répéter cela.
+En y allant doucement, tu ne seras pas entendu.
+Nous pêchions avec des filets.
+J’entourai la bonne réponse avec un crayon rouge.
+Il a raison.
+C’est Gauguin qui a fait celui-là.
+Bleu clair.
+Il pleut maintenant.
+Il pleut.
+Il pleuvait.
+Il pleut à verse.
+C’est mouillé.
+Je ne l’entends plus.
+Complètement trempé.
 Il était capable de se passer de manger pendant trois jours entier.
-il est capable de nous faire perdre.
-Il est capable oui ou non ?
-le roi demande que son maître de maison vienne.
+Il est capable de nous faire perdre.
+Il est capable, oui ou non ?
+Le roi demande que son maître de maison vienne.
 Yannig demande une réunion préparatoire et il viendra au déjeuner de travail.
-On vous demande d'être à un quart d'heure près afin de pouvoir prendre plus d'une personne à  la fois.
-je sais.
-je sais bien.
-il le sait fort bien, j'en suis sur.
-il le sait fort bien, j'en suis sure.
-elle le sait fort bien, j'en suis sur.
-elle le sait fort bien, j'en suis sure.
-je le sais pertinemment.
-je le sais parfaitement.
+On vous demande d’être à un quart d’heure près afin de pouvoir prendre plus d’une personne à la fois.
+Je sais.
+Je sais bien.
+Il le sait fort bien, j’en suis sûr.
+Il le sait fort bien, j’en suis sure.
+Elle le sait fort bien, j’en suis sûr.
+Elle le sait fort bien, j’en suis sure.
+Je le sais pertinemment.
+Je le sais parfaitement.
 Je sais qui je suis.
-Vous savez ce qui lui est arrivé ?
-je ne sais que trop bien.
-je sais bien ce que je dis.
-fais ce que je te dis.
-suis ses indications.
-fais comme je te dis.
-suis ce qui est marqué sur le cahier.
-tais-toi.
-fais.
-réalisée à partir de pièces de monnaie par des prisonniers de guerre français.
-on a fait un scanner et découvert une tumeur.
-elles se sont rencontrées pendant la formation longue de Roudour de 2013-2014 et ont créé à Carhaix une crèche où l'on parle breton aux enfants.
-pas un mot à ce sujet.
-pas un mot de la part du Pst de la communauté sur ses documents de communication pour la campagne électorale départementale en tous cas, si ce n'est un petit mot sur l'identité lié au tourisme.
-faites ce que je vous dis.
-suivez ses indications.
-faites comme je vous dis.
-Faites en sorte que la route de soit pas bloquée.
-suivez mes indications.
-taisez-vous.
-avec.
-Cf. Musée départemental Breton à Quimper.
-je me suis lavé les mains.
-On se lave les mains avant d'aller à table.
-le café est vraiment très chaud.
-autrefois je pêchai.
-autrefois il pêcha.
-autrefois elle pêcha.
-autrefois vous pêchâtes.
-autrefois on pêcha.
-autrefois nous pêchâmes.
-autrefois ils pêchèrent.
-autrefois elles pêchèrent.
-autrefois tu pêchas.
-je le verrai mercredi prochain.
-voir la rubrique démarches administratives.
-voir la rubrique urbanisme.
-voir la rubrique culture.
-voir la rubrique santé/social.
-on verra ça plus tard.
-on verra.
-j'ai vu le chien en traversant la route.
-j'ai vu le chien traversant la route.
-Voir note de transcription des noms p. 145 en bas à droite.
-mieux vaut deux blessés qu'un tué.
-je préfère voir mes enfants morts.
-il préfère partir.
-de vrais Bretons.
-Est-ce qu'elle aurait été réunie sans eux ?
-Les mots qui restaient en suspens auraient-ils été choisis par d'autres personnes ?
-Et il viendra ?
-Et elle viendra ?
-Et ça viendra ?
-Savez-vous ce qui lui est arrivé ?
-Croyez-vous que je puisse y parvenir ?
-Surtout pas !
-et même si la lumière revenait, ce serait trop tard.
-Et pourquoi donc ?
+Vous savez ce qui lui est arrivé ?
+Je ne sais que trop bien.
+Je sais bien ce que je dis.
+Fais ce que je te dis.
+Suis ses indications.
+Fais comme je te dis.
+Suis ce qui est marqué sur le cahier.
+Tais-toi.
+Fais.
+Réalisée à partir de pièces de monnaie par des prisonniers de guerre français.
+On a fait un scanner et découvert une tumeur.
+Elles se sont rencontrées pendant la formation longue de Roudour de deux mille treize deux mille quatorze.
+Elles ont créé à Carhaix une crèche où l’on parle breton aux enfants.
+Pas un mot à ce sujet.
+Pas un mot de la part du Président de la communauté sur ses documents de communication pour la campagne électorale départementale, en tous cas.
+Si ce n’est un petit mot sur l’identité lié au tourisme.
+Faites ce que je vous dis.
+Suivez ses indications.
+Faites comme je vous dis.
+Faites en sorte que la route ne soit pas bloquée.
+Suivez mes indications.
+Taisez-vous.
+Avec.
+Confer Musée départemental Breton à Quimper.
+Je me suis lavé les mains.
+On se lave les mains avant d’aller à table.
+Le café est vraiment très chaud.
+Autrefois je pêchai.
+Autrefois il pêcha.
+Autrefois elle pêcha.
+Autrefois vous pêchâtes.
+Autrefois on pêcha.
+Autrefois nous pêchâmes.
+Autrefois ils pêchèrent.
+Autrefois elles pêchèrent.
+Autrefois tu pêchas.
+Je le verrai mercredi prochain.
+Voir la rubrique démarches administratives.
+Voir la rubrique urbanisme.
+Voir la rubrique culture.
+Voir la rubrique santé, social.
+On verra ça plus tard.
+On verra.
+J’ai vu le chien en traversant la route.
+J’ai vu le chien traversant la route.
+Voir note de transcription des noms page cent quarante-cinq en bas à droite.
+Mieux vaut deux blessés qu’un tué.
+Je préfère voir mes enfants morts.
+Il préfère partir.
+De vrais Bretons.
+Est-ce qu’elle aurait été réunie sans eux ?
+Les mots qui restaient en suspens auraient-ils été choisis par d’autres personnes ?
+Et il viendra ?
+Et elle viendra ?
+Et ça viendra ?
+Savez-vous ce qui lui est arrivé ?
+Croyez-vous que je puisse y parvenir ?
+Surtout pas !
+Et même si la lumière revenait, ce serait trop tard.
+Et pourquoi donc ?
 Elle tranquillisa sa mère en lui téléphonant.
-Applaudissements sur les bancs du groupe socialiste, radical, citoyen et divers gauche et sur quelques bancs du groupe de l’Union pour un mouvement populaire.
-et je vis l'avion partir.
+Applaudissements sur les bancs du groupe socialiste, radical, citoyen et divers gauche.
+Et sur quelques bancs du groupe de l’Union pour un mouvement populaire.
+Et je vis l’avion partir.
 Et lui de courir à toute vitesse.
-et d’autres employés de l’Office de la Langue Bretonne, en fonction de leur domaine d’activité.
-à moitié vivant.
-cinquante.
-vous pouvez les aider à votre tour en participant à la campagne Ulule qu'ils ont mis sur pied.
-sa calculette à elle.
-son mur.
-elle est seule.
-ce maigre-ci.
-c'est celui-ci que j'aime le moins.
-c'est lui que j'aime le moins.
-c'est celui-ci que j'aime le plus.
-c'est lui que j'aime le plus.
-c'est celui-ci le tien.
-c'est celui-ci le mien.
-ce maigre là-bas.
-ce mince là-bas.
-celui-là là-bas.
-celui-là il en a de la chance.
-celui-là il a une fille et trois fils.
-c'est celui-là que j'aime le moins.
-c'est celui-là que j'aime le plus.
-c'est celui-là le tien.
-c'est celui-là le mien.
-Celui-là n'a pas toujours été là, poursuivit-il.
-ce petit-là.
-Herve s'occupe du jardin.
-elle, elle aime.
-elle, elle aimait.
-elle, elle aimera.
-elle, elle lit.
-elle, elle lut.
-elle, elle lisait.
-elle, elle lirait.
-elle, elle lira.
-elle, elle a été aimée.
-elle, elle est aimée.
-elle a l'esprit affûté.
-c'est elle.
-elle, elle a eu aimé.
-elle, elle a aimé.
-la route était longue.
-la route est longue.
-aujourd'hui c'est lundi.
-aujourd'hui c'est mardi.
-il fait froid aujourd'hui.
-c'est le vôtre.
-c'est la vôtre.
-le vôtre.
-la vôtre.
-votre chambre.
-vos chambres.
-votre genou.
-votre vin.
-votre mur.
-vos murs.
-Je vous prie de m'excuser.
-Ils vous prient d'aller les voir.
-Elles vous prient d'aller les voir.
-votre tête.
-vos têtes.
-ayez pitié.
-vos frères.
-votre frère.
-ce sont les vôtres.
-les vôtres.
-votre père.
-vos pères.
-vos mains.
-votre main.
-celle-ci qui est agréable.
-c'est celle-ci que j'aime le moins.
-c'est elle que j'aime le moins.
-c'est celle-ci que j'aime le plus.
-c'est elle que j'aime le plus.
-c'est celle-ci la tienne.
-c'est celle-ci la mienne.
-nos frères.
-notre frère.
-notre chambre.
-notre chat.
-nos mains.
-notre main.
-notre tête.
-nos têtes.
-notre genou.
-notre vin.
-c'est le nôtre.
-c'est la nôtre.
-le nôtre.
-la nôtre.
-notre mur.
-nos murs.
-c'est les nôtres.
-les nôtres.
-notre père.
-nos pères.
-cette noire là-bas.
-celle-là là-bas.
-c'est celle-là la tienne.
-c'est celle-là la mienne.
-celle-là elle en a de la chance.
-celle-là elle a une fille et trois fils.
-cette visible-là.
-notre bureau.
-nos bureaux.
-vous êtes tous les deux en vacances.
-N.-D. de Bonne Nouvelle.
-l'église de Brasparts.
-il utilisait le breton régulièrement.
-eux, ils aiment.
-elles, elles aiment.
-eux, ils aimaient.
-elles, elles aimaient.
-eux, ils aimeront.
-elles, elles aimeront.
-eux, ils lisent.
-elles, elles lisent.
-ils, ils lurent.
-elles, elles lurent.
-eux, ils lisaient.
-elles, elles lisaient.
-eux, ils liraient.
-elles, elles liraient.
-eux, ils liront.
-elles, elles liront.
-eux, ils ont été aimé.
-elles, elles ont été aimées.
-eux, ils sont aimés.
-elles, elles sont aimées.
-c'est eux.
-c'est elles.
-eux, ils ont eu aimé.
-elles, elles ont eu aimé.
-eux, ils ont aimé.
-elles, elles ont aimé.
-sous-rubrique : les délibérations du Conseil communautaire.
+Et d’autres employés de l’Office de la Langue Bretonne, en fonction de leur domaine d’activité.
+À moitié vivant.
+Cinquante.
+Vous pouvez les aider à votre tour en participant à la campagne Ulule qu’ils ont mis sur pied.
+Sa calculette à elle.
+Son mur.
+Elle est seule.
+Ce maigre-ci.
+C’est celui-ci que j’aime le moins.
+C’est lui que j’aime le moins.
+C’est celui-ci que j’aime le plus.
+C’est lui que j’aime le plus.
+C’est celui-ci le tien.
+C’est celui-ci le mien.
+Ce maigre là-bas.
+Ce mince là-bas.
+Celui-là là-bas.
+Celui-là il en a de la chance.
+Celui-là il a une fille et trois fils.
+C’est celui-là que j’aime le moins.
+C’est celui-là que j’aime le plus.
+C’est celui-là le tien.
+C’est celui-là le mien.
+Celui-là n’a pas toujours été là, poursuivit-il.
+Ce petit-là.
+Hervé s’occupe du jardin.
+Elle, elle aime.
+Elle, elle aimait.
+Elle, elle aimera.
+Elle, elle lit.
+Elle, elle lut.
+Elle, elle lisait.
+Elle, elle lirait.
+Elle, elle lira.
+Elle, elle a été aimée.
+Elle, elle est aimée.
+Elle a l’esprit affuté.
+C’est elle.
+Elle, elle eut aimé.
+Elle, elle a aimé.
+L’un ou l’autre.
+L’une ou l’autre.
+La route était longue.
+La route est longue.
+Aujourd’hui c’est lundi.
+Aujourd’hui c’est mardi.
+Il fait froid aujourd’hui.
+C’est le vôtre.
+C’est la vôtre.
+Le vôtre.
+La vôtre.
+Votre chambre.
+Vos chambres.
+Votre genou.
+Votre vin.
+Votre mur.
+Vos murs.
+Je vous prie de m’excuser.
+Ils vous prient d’aller les voir.
+Elles vous prient d’aller les voir.
+Votre tête.
+Vos têtes.
+Ayez pitié.
+Vos frères.
+Votre frère.
+Ce sont les vôtres.
+Les vôtres.
+Votre père.
+Vos pères.
+Vos mains.
+Votre main.
+Celle-ci qui est agréable.
+C’est celle-ci que j’aime le moins.
+C’est elle que j’aime le moins.
+C’est celle-ci que j’aime le plus.
+C’est elle que j’aime le plus.
+C’est celle-ci la tienne.
+C’est celle-ci la mienne.
+Nos frères.
+Notre frère.
+Notre chambre.
+Notre chat.
+Nos mains.
+Notre main.
+Notre tête.
+Nos têtes.
+Notre genou.
+Notre vin.
+C’est le nôtre.
+C’est la nôtre.
+Le nôtre.
+La nôtre.
+Notre mur.
+Nos murs.
+C’est les nôtres.
+Les nôtres.
+Notre père.
+Nos pères.
+Cette noire là-bas.
+Celle-là là-bas.
+C’est celle-là la tienne.
+C’est celle-là la mienne.
+Celle-là elle en a de la chance.
+Celle-là elle a une fille et trois fils.
+Cette visible-là.
+Notre bureau.
+Nos bureaux.
+Vous êtes tous les deux en vacances.
+Notre-Dame de Bonne Nouvelle.
+L’église de Brasparts.
+Il utilisait le breton régulièrement.
+Eux, ils aiment.
+Elles, elles aiment.
+Eux, ils aimaient.
+Elles, elles aimaient.
+Eux, ils aimeront.
+Elles, elles aimeront.
+Eux, ils lisent.
+Elles, elles lisent.
+Eux, ils lurent.
+Elles, elles lurent.
+Eux, ils lisaient.
+Elles, elles lisaient.
+Eux, ils liraient.
+Elles, elles liraient.
+Eux, ils liront.
+Elles, elles liront.
+Eux, ils ont été aimé.
+Elles, elles ont été aimées.
+C’est eux.
+C’est elles.
+Eux, ils eurent aimé.
+Elles, elles eurent aimé.
+Eux, ils ont aimé.
+Elles, elles ont aimé.
+Sous-rubrique : les délibérations du Conseil communautaire.
 Sous-titré en français.
-allez.
-Italie : photos obligatoires également pour les moins de 7 ans.
-Je n'aurais jamais cru que c'était vrai.
-vas-t'en.
-va.
-bon courage à vous tous.
-bon courage à tous.
-le coq chante tous les matins.
+Allez.
+Italie : photos obligatoires également pour les moins de sept ans.
+Je n’aurais jamais cru que c’était vrai.
+Vas-t’en.
+Va.
+Bon courage à vous tous.
+Bon courage à tous.
+Le coq chante tous les matins.
 Canton de Carhaix-Plouguer.
-qu'il aime.
-qu'elle aime.
-qu'ils aiment.
-il aimera ma mère.
-elle aimera ma mère.
-j'aime mon pays.
-j'ai eu aimé.
-j'ai aimé.
-il a eu aimé.
-il a aimé.
-il a été aimé.
-elle a été aimée.
-il est aimé.
-elle est aimée.
-on a été aimé.
-on est aimé.
-on a eu aimé.
-on a aimé.
-tu as eu aimé.
-tu as aimé.
-elle a eu aimé.
-elle a aimé.
-vous avez eu aimé.
-vous avez aimé.
-nous avons eu aimé.
-nous avons aimé.
-ils ont été aimé.
-elles ont été aimé.
-ils sont aimés.
-elles sont aimées.
-ils ont eu aimé.
-elles ont eu aimé.
-ils ont aimé.
-elles ont aimé.
-vous avez été aimé.
-vous êtes aimé.
-vous êtes aimés.
-nous avons été aimé.
-nous sommes aimés.
-j'ai été aimé.
-je suis aimé.
-tu as été aimé.
-tu es aimé.
-aimes.
-aimez.
-aimons.
-il aimera ma mère quand il l'aura vue.
-il aimera ma mère quand elle l'aura vue.
-ils aiment leurs parents.
-sors le chien.
-envoyer une lettre à Beethoven.
-il sera amené directement à Pontchaillou demain.
+Qu’il aime.
+Qu’elle aime.
+Qu’ils aiment.
+Il aimera ma mère.
+Elle aimera ma mère.
+J’aime mon pays.
+J’eus aimé.
+J’ai aimé.
+Il eut aimé.
+Il a été aimé.
+Elle a été aimée.
+Il est aimé.
+Elle est aimée.
+On a été aimé.
+On est aimé.
+On a aimé.
+Tu eus aimé.
+Tu as aimé.
+Elle eut aimé.
+Elle a aimé.
+Vous avez aimé.
+Nous avons aimé.
+Ils ont été aimés.
+Elles ont été aimées.
+Ils sont aimés.
+Elles sont aimées.
+J’eus aimé.
+Ils eurent aimé.
+Elles eurent aimé.
+Il a aimé.
+Ils ont aimé.
+Elles ont aimé.
+Vous avez été aimés.
+Vous êtes aimé.
+Vous êtes aimés.
+Nous avons été aimés.
+Nous sommes aimés.
+J’ai été aimé.
+Je suis aimé.
+Tu as été aimé.
+Tu es aimé.
+Vous eûtes aimé.
+Aime.
+Aimez.
+Aimons.
+Il aimera ma mère quand il l’aura vue.
+Il aimera ma mère quand elle l’aura vu.
+Ils aiment leurs parents.
+Sors le chien.
+Envoyer une lettre à Beethoven.
+Il sera amené directement à Pontchaillou demain.
 Emmenez-la avec vous à la maison.
-La Catalogne un pays voiles ouvertes.
-tu trouveras ci-joint plusieurs éléments qui pourraient composer l'envoi d'information au sujet du conseil.
-des professeurs de breton.
+La Catalogne : un pays à voiles ouvertes.
+Tu trouves le temps long.
+Tu trouveras ci-joint plusieurs éléments qui pourraient composer l’envoi d’information au sujet du conseil.
+Des professeurs de breton.
 Des nouvelles de votre époux et du mien.
-Pour en savoir plus, voir aussi le chapitre La formation continue dans la partie L’enseignement aux adultes : le début d’un renouveau ? et le chapitre Daoulagad Breizh et le Festival de cinéma de Douarnenez dans la partie des Médias.
-tout vous est expliqué ci-dessous et les archives jointes pour répondre, allons-y !
-La plus petite quantité réalisable : 1 exemplaire.
-La plus grande quantité réalisable : 1 exemplaire.
-Il écrit tellement mal qu'on ne peut lire son écriture.
-il continuait à fumer en m'écoutant.
-un concours de haïkus sera organisé en grande pompe en 2016 .
-concours Prix de la Jeunesse, des enfants, et prix de bandes-dessinées en breton.
-ça coûte cher.
-C'était cher.
-ça vous a coûté cher.
-ça nous a coûté cher.
-ça lui a coûté cher.
-ça lui a couté cher.
-ça leur a coûté cher.
-ça m'a coûté cher.
-ça t'as coûté cher.
-ça a coûté cher.
-Kerlouan, Fonce Devant Toujours.
-marche.
-ils avaient marché longtemps avant d'atteindre la capitale.
-elles avaient marché longtemps avant d'atteindre la capitale.
-allez-vous en.
-des cérémonies de célébration vous seront proposées tout au long de l'année.
-allez-vous en d'ici.
-des sculpteurs de bois.
+Pour en savoir plus, voir aussi le chapitre suivant.
+La formation continue dans la partie L’enseignement aux adultes : le début d’un renouveau ?
+Et le chapitre Daoulagad Breizh et le Festival de cinéma de Douarnenez dans la partie des Médias.
+Tout vous est expliqué ci-dessous et les archives jointes pour répondre, allons-y !
+La plus petite quantité réalisable : 1 exemplaire.
+La plus grande quantité réalisable : 1 exemplaire.
+Il écrit tellement mal qu’on ne peut lire son écriture.
+Il continuait à fumer en m’écoutant.
+Un concours de haïkus sera organisé en grande pompe en deux mille seize.
+Concours Prix de la Jeunesse, des enfants, et prix de bandes-dessinées en breton.
+Ça coûte cher.
+C’était cher.
+Ça vous a coûté cher.
+Ça nous a coûté cher.
+Ça lui a coûté cher.
+Ça leur a coûté cher.
+Ça m’a coûté cher.
+Ça t’as coûté cher.
+Ça a coûté cher.
+Kerlouan, fonce devant toujours.
+Marche.
+Ils avaient marché longtemps avant d’atteindre la capitale.
+Elles avaient marché longtemps avant d’atteindre la capitale.
+Allez-vous-en.
+Des cérémonies de célébration vous seront proposées tout au long de l’année.
+Allez-vous-en d’ici.
+Des sculpteurs de bois.
 Yann-Vari est malade, il ne pourra pas travailler demain.
 Il est malade.
 Elle est malade.
@@ -1157,863 +1171,888 @@ Elles sont malades.
 Vous êtes malades.
 Vous êtes malade.
 Nous sommes malades.
-je suis malade comme un chien, je ne fais que dormir pour ainsi dire.
+Je suis malade comme un chien, je ne fais que dormir pour ainsi dire.
 Je suis malade.
 Tu es malade.
-J'ai essayé de marquer sur une feuille quelques arguments pour défendre le dossier de la synthèse vocale pour le breton, en pensant les expédier aux gars de la Région.
-il se plaint toujours.
-vous vous plaigniez tous les matins.
-On l'aurait entendu se plaindre.
-on a entendu une info étonnante.
-je l'ai entendu chanter d'une voix enrouée.
-Cliquez sur l'un des services pour obtenir l'information détaillée.
+J’ai essayé de marquer sur une feuille quelques arguments pour défendre le dossier de la synthèse vocale pour le breton.
+En pensant les expédier aux gars de la Région.
+Il se plaint toujours.
+Vous vous plaigniez tous les matins.
+On l’aurait entendu se plaindre.
+On a entendu une info étonnante.
+Je l’ai entendu chanter d’une voix enrouée.
+Cliquez sur l’un des services pour obtenir l’information détaillée.
 Je perdais mon temps à chercher.
-j'ai perdu l'adresse mail d'Olier.
-j'ai perdu ma chaussure.
-il parle à son chien.
-il parlait de sa sœur partie travailler dans un autre pays.
-j'ai parlé avec le gars de la garderie (je trouvais qu'il y avait moins de familles vues).
-je lui ai parlé pour lui dire que l'école (instituteurs, parents) pouvait défendre les postes dans leur ensemble (comme cela avait été et est le cas à Bégard) plutôt que de les opposer.
-j'étais content que vous soyez venu.
-je suis tombé en essayant de marcher sur un seul pied.
-l'oiseau est tombé de son nid.
-le moucheron est tombé dans le verre.
-il est tombé en faisant du vélo.
-un moucheron est tombé dans le verre.
-je suis tombé dans les escaliers.
-Cependant, ce nombre se stabilise depuis 2004.
-il avait bien dormi pendant la nuit.
-il dort.
-elle dort.
+J’ai perdu l’adresse mail d’Olier.
+J’ai perdu ma chaussure.
+Il parle à son chien.
+Il parlait de sa sœur partie travailler dans un autre pays.
+J’ai parlé avec le gars de la garderie.
+Je trouvais qu’il y avait moins de familles vues.
+Je lui ai parlé pour lui dire que l’école pouvait défendre les postes dans leur ensemble plutôt que de les opposer.
+Comme cela avait été et est le cas à Bégard.
+J’étais content que vous soyez venu.
+Je suis tombé en essayant de marcher sur un seul pied.
+L’oiseau est tombé de son nid.
+Le moucheron est tombé dans le verre.
+Il est tombé en faisant du vélo.
+Un moucheron est tombé dans le verre.
+Je suis tombé dans les escaliers.
+Cependant, ce nombre se stabilise depuis deux mille quatre.
+Il avait bien dormi pendant la nuit.
+Il dort.
+Elle dort.
 Est-ce que ça lui coûte de l’argent ?
-coûte que coûte.
-C'est vieux ou neuf ?
-j'avais cru qu'il aurait chanté.
-j'ai cru qu'il aurait chanté.
-il pense avoir un livre sur les Vikings.
-le feu a pris dans un bâtiment à Lannion.
-cette journée a été créée pour promouvoir et célébrer la diversité culturelle et linguistique dans le monde entier et surtout les langues autochtones, les langues minoritaires et le patrimoine linguistique en danger.
-elle avait des problèmes de mémoire depuis peu et elle somnolait à d'autres moments.
-du travail soigné.
-du bon travail.
-il y a du travail.
-il y a du boulot.
-il travaille mal.
-elle travaille mal.
-il travaille bien.
-elle travaille bien.
+Coûte que coûte.
+C’est vieux ou neuf ?
+J’avais cru qu’il aurait chanté.
+J’ai cru qu’il aurait chanté.
+Il pense avoir un livre sur les Vikings.
+Le feu a pris dans un bâtiment à Lannion.
+Cette journée a été créée pour promouvoir et célébrer la diversité culturelle et linguistique dans le monde entier.
+Et surtout les langues autochtones, les langues minoritaires et le patrimoine linguistique en danger.
+Elle avait des problèmes de mémoire depuis peu et elle somnolait à d’autres moments.
+Du travail soigné.
+Du bon travail.
+Il y a du travail.
+Il y a du boulot.
+Il travaille mal.
+Elle travaille mal.
 Il travaille bien.
 Elle travaille bien.
-Est-ce qu'il travaille bien?
-Est-ce qu'elle travaille bien ?
+Est-ce qu’il travaille bien ?
+Est-ce qu’elle travaille bien ?
 Nous devons travailler.
 Travailler ou jouer, il faut savoir.
-Au travail maintenant !
-voler est mal.
-on mettra soit du bois soit de la pierre.
-il a mis ses chaussures à l'envers.
-elle a mis ses chaussures à l'envers.
-inscrivez-vous ci-dessous pour participer.
-on nous a retiré ce pourcentage d'argent pour les autres missions.
-on nous a retiré un pourcentage d'argent pour les autres missions.
-il a sauté par-dessus la barrière.
-nous sommes heureux de vous souhaiter nos meilleurs vœux pour 2015.
-je te dis de venir.
-dites quelque chose.
-dis-le à Monsieur Kerbrad.
+Au travail maintenant !
+Voler est mal.
+On mettra soit du bois soit de la pierre.
+Il a mis ses chaussures à l’envers.
+Elle a mis ses chaussures à l’envers.
+Inscrivez-vous ci-dessous pour participer.
+On nous a retiré ce pourcentage d’argent pour les autres missions.
+On nous a retiré un pourcentage d’argent pour les autres missions.
+Il a sauté par-dessus la barrière.
+Nous sommes heureux de vous souhaiter nos meilleurs vœux pour deux mille quinze.
+Je te dis de venir.
+Dites quelque chose.
+Dis-le à Monsieur Kerbrad.
 Dis-leur de ne pas faire de bruit.
-dis-moi si tu vois des choses à rajouter (ou à retirer).
-on nous avait dit que vous ne pourriez pas venir.
-on m'avait dit que nous ne pouviez pas venir.
-il a dit qu'il fera tout son possible pour finir le dossier.
-il m'avait dit cela en riant.
-on m'a dit d'aller à l'école.
-il lit.
-elle lit.
-je lis.
-moi, je lis.
-nous lisons.
-nous, nous lisons.
-ils lisent.
-elles lisent.
-tu lis.
-toi, tu lis.
-vous lisez.
-lire la rubrique éducation/formation.
-bonne lecture.
-elle avait lu un conte à son enfant pour qu'il dorme.
+Dis-moi si tu vois des choses à rajouter ou à retirer.
+On nous avait dit que vous ne pourriez pas venir.
+On m’avait dit que vous ne pouviez pas venir.
+Il a dit qu’il fera tout son possible pour finir le dossier.
+Il m’avait dit cela en riant.
+On m’a dit d’aller à l’école.
+Il lit.
+Elle lit.
+Lui, il lit.
+Je lis.
+Moi, je lis.
+Nous lisons.
+Nous, nous lisons.
+Ils lisent.
+Elles lisent.
+Tu lis.
+Toi, tu lis.
+Vous lisez.
+Lire la rubrique éducation-formation.
+Bonne lecture.
+Elle avait lu un conte à son enfant pour qu’il dorme.
 Ouvrage en français avec une partie en breton non traduite en français.
-Laisse ta voiture ici à condition qu'elle ne soit pas sur le passage.
-Parascolaire : En dehors de l'école.
-il sait très bien mentir.
-elle sait très bien mentir.
+Laisse ta voiture ici à condition qu’elle ne soit pas sur le passage.
+Parascolaire : en dehors de l’école.
+Il sait très bien mentir.
+Elle sait très bien mentir.
 Des animaux aux larges cornes.
 Des animaux cornus.
-Londres est la capitale de l'Angleterre.
-le pays avait été englouti par la mer.
-il est sale.
-elle est sale.
-c'est sale.
-Lundi 15 avril 1985.
-Lundi 1er décembre 2008.
-Lundi 20 juillet 1981.
-lundi de Pâques.
-Mon œil !
-mon frère est déjà arrivé.
-mon frère n'est pas encore arrivé.
-mon frère.
-si je peux téléphoner je lui dirai tout de suite.
-si l'étudiante pouvait s'occuper de l'un ou l'autre de ces thèmes-là cela nous serait utile.
-si nous pouvions envoyer les choses aux gens aujourd'hui ce serait une bonne chose.
-si nous pouvions envoyer les choses aux gens aujourd'hui ce serait bien.
-ma chambre.
-mes mains.
-ma main.
-ma tête.
-mon genou.
-mon vin.
-c'est le mien.
-c'est la mienne.
-le mien.
-la mienne.
-si les gens voulaient bien écouter.
-si je travaillais, j'aurais de l'argent.
-si tu me dis que ça vaut la peine d'y aller j'irai.
-mes chaussettes sont sous le lit.
-mes chaussettes ne sont pas sous le lit.
-ma mère me tira de ce mauvais pas.
-Ma grand-mère a bien connu M. Gauguin, ajoute de nouveau le fermier.
-mes mur.
-si tu n'avais pas été là je serais parti.
-si tu n'avais pas été là je partais.
-si je n'y arrive pas je serai mal.
-s'il pêchait.
-si elle pêchait.
-si vous pêchiez.
-si on pêchait.
-si nous pêchions.
-si je pêchais.
-s'ils pêchaient.
-si elles pêchaient.
-si tu pêchais.
-c'est les miens.
-c'est les miennes.
-ma paire de lunettes.
-ma paire de chaussures.
-les miens.
-les miennes.
-s'il vient ou s'il ne vient pas.
-si elle vient ou si elle ne vient pas.
-si tu étais un oiseau.
-si je voyais mon frère aujourd'hui, je lui dirais.
-mont père.
-c'est à moi de jouer.
-c'est mon tour.
-bon, c'est agréable de voir qu'il a été plus efficace que moi puisque j'avais été renvoyé sans ménagement par monsieur le maire qui pensait que c'était à cause de l'ancienne politique que l'ancien maire avait été viré.
+Londres est la capitale de l’Angleterre.
+Le pays avait été englouti par la mer.
+Il est sale.
+Elle est sale.
+C’est sale.
+Lundi quinze avril dix-neuf cent quatre-vingt-cinq.
+Lundi premier décembre deux mille huit.
+Lundi vingt juillet dix-neuf cent octante et un.
+Lundi de Pâques.
+Mon œil !
+Mon frère est déjà arrivé.
+Mon frère n’est pas encore arrivé.
+Mon frère.
+Si je peux téléphoner je lui dirai tout de suite.
+Si l’étudiante pouvait s’occuper de l’un ou l’autre de ces thèmes-là cela nous serait utile.
+Si nous pouvions envoyer les choses aux gens aujourd’hui ce serait une bonne chose.
+Si nous pouvions envoyer les choses aux gens aujourd’hui ce serait bien.
+Ma chambre.
+Mes mains.
+Ma main.
+Ma tête.
+Mon genou.
+Mon vin.
+C’est le mien.
+C’est la mienne.
+Le mien.
+La mienne.
+Si les gens voulaient bien écouter.
+Si je travaillais, j’aurais de l’argent.
+Si tu me dis que ça vaut la peine d’y aller j’irai.
+Mes chaussettes sont sous le lit.
+Mes chaussettes ne sont pas sous le lit.
+Ma mère me tira de ce mauvais pas.
+Ma grand’mère a bien connu Monsieur Gauguin, ajoute de nouveau le fermier.
+Mes murs.
+Si tu n’avais pas été là je serais parti.
+Si tu n’avais pas été là je partais.
+Si je n’y arrive pas je serai mal.
+S’il pêchait.
+Si elle pêchait.
+Si vous pêchiez.
+Si on pêchait.
+Si nous pêchions.
+Si je pêchais.
+S’ils pêchaient.
+Si elles pêchaient.
+Si tu pêchais.
+C’est les miens.
+C’est les miennes.
+Ma paire de lunettes.
+Ma paire de chaussures.
+Les miens.
+Les miennes.
+S’il vient ou s’il ne vient pas.
+Si elle vient ou si elle ne vient pas.
+Si tu étais un oiseau.
+Si je voyais mon frère aujourd’hui, je lui dirais.
+Mon père.
+C’est à moi de jouer.
+C’est mon tour.
+Bon, c’est agréable de voir qu’il a été plus efficace que moi puisque j’avais été renvoyé sans ménagement.
+Par Monsieur le Maire qui pensait que c’était à cause de l’ancienne politique que l’ancien maire avait été viré.
 Maiwenn et Enogad sont heureux de vous inviter.
-seules des personnes majeures peuvent être admises.
-si j'ai deux tickets, je vous en donnerai un.
-si j'avais travaillé, j'aurais de l'argent.
-si j'ai deux tickets.
-si j'avais le temps.
-la mère de Pêr.
-la maman de Youenn (était à la réunion, enfant dans la classe d'Enora, mais je ne l'ai pas reconnue) et la mère de Liza (elle était muette, malade, elle n'est pas restée discuter).
-source : ANPE – 2005.
-Source : enquête «Produit en Bretagne» 2011.
-Tu as eu tort, mon fille Merlette, d'espérer ainsi ma mort.
-s'ils n'étaient pas venus l'attraper, il tombait.
-s'il n'avait pas tenu bon il se noyait.
-s'il vous plaît suivez-moi.
-s'il vous plaît venez avec moi.
-s'il te plaît suis-moi.
-s'il te plaît viens avec moi.
-s'il te plaît.
-s'il vous plaît.
-Nous n'irons pas si tu es trop fatigué.
-Nous n'irons pas si tu es trop fatiguée.
-Marie Mahieu (langue française).
-une mauvais note avait été donnée à Mark par le professeur.
-peut-être pourrais-tu jeter un œil sur les propositions que j'ai faite pour la revue de la mairie  de Plouzane.
-peut-être pourrais-tu lui transmettre mon courriel.
-peut-être que ça vaut la peine.
-Peut-être viendra-t-il qui sait ?
-Peut-être viendra-t-elle qui sait ?
-peut-être qu'on aura le temps de parler de ça au moment de midi.
-peut-être que le temps sera beau demain.
-peut-être que ça a déjà été fait.
-peut-être qu'il a grandi pendant la nuit.
-peut-être qu'elle a grandi pendant la nuit.
-peut-être que j'irai.
-de violents matelots ivres.
-c'est assez bien.
-c'est assez bon.
-ce serait bien.
-il est bien.
-elle est bien.
-c'est bien maintenant.
-c'est bon maintenant.
-c'est bien comme ça.
-c'est bon comme ça.
+Seules des personnes majeures peuvent être admises.
+Si j’ai deux tickets, je vous en donnerai un.
+Si j’avais travaillé, j’aurais de l’argent.
+Si j’ai deux tickets.
+Si j’avais le temps.
+La mère de Pêr.
+La maman de Youenn était à la réunion, enfant dans la classe d’Enora, mais je ne l’ai pas reconnue.
+Et la mère de Liza était muette, malade, elle n’est pas restée discuter.
+Source : ANPE, deux mille cinq.
+Source : enquête « Produit en Bretagne » deux mille onze.
+Tu as eu tort, ma fille Merlette, d’espérer ainsi ma mort.
+S’ils n’étaient pas venus l’attraper, il tombait.
+S’il n’avait pas tenu bon il se noyait.
+S’il vous plait suivez-moi.
+S’il vous plait venez avec moi.
+S’il te plait suis-moi.
+S’il te plait viens avec moi.
+S’il te plait.
+S’il vous plait.
+Nous n’irons pas si tu es trop fatigué.
+Nous n’irons pas si tu es trop fatiguée.
+Marie Mahieu, langue française.
+Une mauvaise note avait été donnée à Mark par le professeur.
+Peut-être pourrais-tu jeter un œil sur les propositions que j’ai faite pour la revue de la mairie de Plouzane.
+Peut-être pourrais-tu lui transmettre mon courriel.
+Peut-être que ça vaut la peine.
+Peut-être viendra-t-il qui sait ?
+Peut-être viendra-t-elle qui sait ?
+Peut-être qu’on aura le temps de parler de ça au moment de midi.
+Peut-être que le temps sera beau demain.
+Peut-être que ça a déjà été fait.
+Peut-être qu’il a grandi pendant la nuit.
+Peut-être qu’elle a grandi pendant la nuit.
+Peut-être que j’irai.
+De violents matelots ivres.
+C’est assez bien.
+C’est assez bon.
+Ce serait bien.
+Il est bien.
+Elle est bien.
+C’est bien maintenant.
+C’est bon maintenant.
+C’est bien comme ça.
+C’est bon comme ça.
 En conséquence, il est bon de savoir que l’Observatoire établit régulièrement des études thématiques qu’il est possible de télécharger sur le site.
-c'est bien.
-c'est bon.
-c'est très bien.
-c'est très bon.
-très bien.
-excellent.
-parfait.
-moi, j'aime.
-moi, j'aimais.
-j'aimerais avoir une voiture.
-moi, j'aimerai.
-moi, j'entoure.
-moi, j'entourais.
-moi, j'entourerai.
-moi, je lus.
-moi, je lisais.
-moi, je lirai.
-moi, j'écris bien.
-moi, j'écris.
-moi, j'ai été aimé.
-je suis venu te voir.
-je suis venu vous voir.
-moi, je suis aimé.
-moi, j'ai eu aimé.
-moi, j'ai aimé.
-je te réveillerai demain à six heures.
-je te réveillerai demain à 6 heures.
-moi ça m'est égal.
-c'est moi.
-articles L.310-2, L.310-5, R.310-8, R.310-9 et R310-19 du code de commerce et articles R.321-1 et R.321-9 du code pénal.
-Si j'avais eu des plumes, deux ailes bleues.
-Mercredi 16 avril 2008.
-des petites filles.
-le pluriel de fille c'est filles.
-mais il est bon de savoir qu'il n'y a plus un sou pour 2015 puisque nous avons dû baisser une part des subventions pour la seconde année.
-mais, Kobané est libérée et tu ne m'as pas dit.
-mais, Kobané est libérée et vous ne m'avez pas dit.
+C’est bien.
+C’est bon.
+C’est très bien.
+C’est très bon.
+Très bien.
+Excellent.
+Parfait.
+Moi, j’aime.
+Moi, j’aimais.
+J’aimerais avoir une voiture.
+Moi, j’aimerai.
+Moi, j’entoure.
+Moi, j’entourais.
+Moi, j’entourerai.
+Moi, je lus.
+Moi, je lisais.
+Moi, je lirai.
+Moi, j’écris bien.
+Moi, j’écris.
+Moi, j’ai été aimé.
+Je suis venu te voir.
+Je suis venu vous voir.
+Moi, je suis aimé.
+Moi, j’eus aimé.
+Moi, j’ai aimé.
+Je te réveillerai demain à six heures.
+Moi ça m’est égal.
+C’est moi.
+Articles L. trois cent dix deux, L. trois cent dix cinq, R. trois cent dix huit, R. trois cent dix neuf et R trois cent dix dix-neuf du code de commerce.
+Et articles R. trois cent vingt-et-un un et R. trois cent vingt-et-un neuf du code pénal.
+Si j’avais eu des plumes, deux ailes bleues.
+Mercredi seize avril deux mille huit.
+Des petites filles.
+Le pluriel de fille c’est filles.
+Mais il est bon de savoir qu’il n’y a plus un sou pour deux mille quinze puisque nous avons dû baisser une part des subventions pour la seconde année.
+Mais, Kobané est libérée et tu ne m’as pas dit.
+Mais, Kobané est libérée et vous ne m’avez pas dit.
 Mardi 25 novembre 1986.
 Empêche-les de sortir.
 Il faisait attention à ne pas rire.
-conserver et valoriser le patrimoine linguistique oral ou écrit.
-si les poules avaient des dents.
-il viendra probablement plus tard.
-elle viendra probablement plus tard.
-il va à Quimper.
-elle va à Quimper.
-il va à l'école.
-elle va à l'école.
-il s'en va.
-elle s'en va.
-Ça va bien ?
-il va bien.
-elle va bien.
-ils vont très bien.
-elles vont très bien.
-je vais à table.
-On fatigue à force d'entendre des bêtises à longueur de journée.
-on fatigue en entendant des bêtises à longueur de journée.
-il va à cheval.
-elle va à cheval.
-elle va.
-nous irons au cinéma s'il y a le temps.
-je vais à l'école.
-je m'en vais.
+Conserver et valoriser le patrimoine linguistique oral ou écrit.
+Si les poules avaient des dents.
+Il viendra probablement plus tard.
+Elle viendra probablement plus tard.
+Il va à Quimper.
+Elle va à Quimper.
+Il va à l’école.
+Elle va à l’école.
+Il s’en va.
+Elle s’en va.
+Ça va bien ?
+Il va bien.
+Elle va bien.
+Ils vont très bien.
+Elles vont très bien.
+Je vais à table.
+On fatigue à force d’entendre des bêtises à longueur de journée.
+On fatigue en entendant des bêtises à longueur de journée.
+Il va à cheval.
+Elle va à cheval.
+Elle va.
+Nous irons au cinéma s’il y a le temps.
+Je vais à l’école.
+Je m’en vais.
 Il alla se cacher pour ne pas être grondé.
-il disparut de vue.
-elle disparut de vue.
-ils vont se promener quand le temps est beau.
-J'irai au cinéma cet après-midi.
-j'entrerai en relation avec M.
-J'irai avec lui bien qu'il me déplaise fortement.
-aller à Madagascar.
-se lever de table.
-passer par la cour de l'école.
-passer par Brest.
-aller en train ou aller en avion.
-aller à table.
-aller sur le cheval de mon frère.
-aller à cheval.
-aller et venir.
-aller retour.
+Il disparut de vue.
+Elle disparut de vue.
+Ils vont se promener quand le temps est beau.
+J’irai manger tout à l’heure.
+J’irai au cinéma cet après-midi.
+J’entrerai en relation avec M.
+J’irai avec lui bien qu’il me déplaise fortement.
+Aller à Madagascar.
+Se lever de table.
+Passer par la cour de l’école.
+Passer par Brest.
+Aller en train ou aller en avion.
+Aller à table.
+Aller sur le cheval de mon frère.
+Aller à cheval.
+Aller et venir.
+Aller-retour.
 Morwenna s’inquiète de voir ça.
-Extincteurs, Robinet d'Incendie Armé, Alarme, Désenfumage.
+Extincteurs, robinet d’incendie armé, alarme, désenfumage.
 Ne nous arrêtons pas de ramer.
-Ne parlons pas de cela !
-ne croyez pas tout ce que l'on entend.
-ne pleurez pas.
-Ne faites pas cela !
-ne donne pas de nourriture aux chiens.
-ne donne pas de la nourriture au chat.
-ne soyez par sur vos gardes.
-n'oublie pas de prendre rendez-vous au garage.
-N'allez pas trop vite !
-ne répétez pas ce que je vous ai dit.
+Ne parlons pas de cela !
+Ne croyez pas tout ce que l’on entend.
+Ne pleurez pas.
+Ne faites pas cela !
+Ne donne pas de nourriture aux chiens.
+Ne donne pas de la nourriture au chat.
+Ne soyez pas sur vos gardes.
+N’oublie pas de prendre rendez-vous au garage.
+N’allez pas trop vite !
+Ne répétez pas ce que je vous ai dit.
 Je ne connais pas ça.
 Vous ne le connaissez pas.
-non alors !
-dix-neuf maisons.
-dix-neuf.
-neuf pommes flétries.
-quarante neuf.
-trente neuf.
-vingt neuf lapins.
-quarante neuf sacs.
-neuf tables.
-neuf coups.
-neuf maisons.
-vingt neuf.
-neuf.
+Non alors !
+Dix-neuf maisons.
+Dix-neuf.
+Neuf pommes flétries.
+Quarante-neuf.
+Trente-neuf.
+Vingt-neuf lapins.
+Quarante-neuf sacs.
+Neuf tables.
+Neuf coups.
+Neuf maisons.
+Vingt-neuf.
+Neuf.
 Il ne téléphonera plus maintenant.
 Il ne retéléphonera plus maintenant.
-il ne pêche pas.
-elle ne pêche pas.
-on ne grimpe pas sur la table.
-Je ne peux pas
-il ne demande pas.
-elle ne demande pas.
+Il ne pêche pas.
+Elle ne pêche pas.
+On ne grimpe pas sur la table.
+Je ne peux pas.
+Il ne demande pas.
+Elle ne demande pas.
 Je ne veux pas.
-ça ne vaut la peine.
-ça ne vaut pas grand-chose.
-ça ne vaut rien.
-ça ne vaut pas la peine.
-Il ne viendra pas étant donné qu'il est malade.
-Il ne viendra pas étant donné qu'elle est malade.
-vous ne voulez pas partir.
-il ne veut pas partir.
-elle ne veut pas partir.
-ils ne veulent pas partir.
-elles ne veulent pas partir.
-je ne veux pas partir.
-je ne veux pas.
-tu ne veux pas partir.
-je ne prenais pas part à ces affaires-là.
-je n'entendais pas la cloche.
-ils ne comprenaient pas bien ce que je leur expliquais.
-je ne pense pas qu'il lui plaisait.
+Ça ne vaut la peine.
+Ça ne vaut pas grand-chose.
+Ça ne vaut rien.
+Ça ne vaut pas la peine.
+Il ne viendra pas étant donné qu’il est malade.
+Il ne viendra pas étant donné qu’elle est malade.
+Vous ne voulez pas partir.
+Il ne veut pas partir.
+Elle ne veut pas partir.
+Ils ne veulent pas partir.
+Elles ne veulent pas partir.
+Je ne veux pas partir.
+Tu ne veux pas partir.
+Je ne prenais pas part à ces affaires-là.
+Je n’entendais pas la cloche.
+Ils ne comprenaient pas bien ce que je leur expliquais.
+Je ne pense pas qu’il lui plaisait.
 Yann et Katell ne travailleront pas.
-je ne dirai rien.
-je ne dirai pas cela à mon parrain.
-il n'était pas parti depuis deux minutes que l'autre arriva.
-il n'avait pas assez réfléchi.
-Il n'était pas chaudement vêtu.
-Elle n'était pas chaudement vêtue.
+Je ne dirai rien.
+Je ne dirai pas cela à mon parrain.
+Il n’était pas parti depuis deux minutes que l’autre arriva.
+Il n’avait pas assez réfléchi.
+Il n’était pas chaudement vêtu.
+Elle n’était pas chaudement vêtue.
 Il ne sait pas sa leçon.
-il ne sait pas quoi faire.
-elle ne sait pas quoi faire.
-il ne sait pas qui je suis.
-elle ne sait pas qui je suis.
-il ne savait pas ce qui lui arrivait.
-elle ne savait pas ce qui lui arrivait.
-nous ne savions pas que tu étais arrivé.
-nous ne savions pas que tu étais arrivée.
-Je ne savais pas qu'il était à la maison.
-je ne savais pas que tu serais de retour si tôt.
-on ne sait pas.
-on ne sait jamais.
+Il ne sait pas quoi faire.
+Elle ne sait pas quoi faire.
+Il ne sait pas qui je suis.
+Elle ne sait pas qui je suis.
+Il ne savait pas ce qui lui arrivait.
+Elle ne savait pas ce qui lui arrivait.
+Nous ne savions pas que tu étais arrivé.
+Nous ne savions pas que tu étais arrivée.
+Je ne savais pas qu’il était à la maison.
+Je ne savais pas que tu serais de retour si tôt.
+On ne sait pas.
+On ne sait jamais.
 Il ne fait que manger.
 Il ne pleut plus.
 Il ne pleut pas.
 Il ne fait pas que manger et dormir.
 Il ne fait que manger et dormir.
-il ne fait que se plaindre toute la journée.
-elle ne fait que se plaindre toute la journée.
-il ne faisait que jeter un œil.
-elle ne faisait que jeter un œil.
-il ne faisait qu'observer.
-elle ne faisait qu'observer.
-Peu m'importe.
-nous ne faisons que lui obéir.
-Vas-tu te taire ?
-on n'enfonce pas les clous si fort.
-nous n'avions pas l'impression que c'était utile.
-tu ne sembles pas être très heureux de me voir.
-on n'applaudit pas avant que ce soit le moment.
+Il ne fait que se plaindre toute la journée.
+Elle ne fait que se plaindre toute la journée.
+Il ne faisait que jeter un œil.
+Elle ne faisait que jeter un œil.
+Il ne faisait qu’observer.
+Elle ne faisait qu’observer.
+Peu m’importe.
+Nous ne faisons que lui obéir.
+Vas-tu te taire ?
+On n’enfonce pas les clous si fort.
+Nous n’avions pas l’impression que c’était utile.
+Tu ne sembles pas être très heureux de me voir.
+On n’applaudit pas avant que ce soit le moment.
 Cela importe peu.
-Qu'importe.
+Qu’importe.
 Nous ne vivons pas de notre amour pour la langue.
-je ne suis pas malade en mer.
-vous ne pourrez pas rester.
-vous ne serez pas bien amañ.
+Je ne suis pas malade en mer.
+Vous ne pourrez pas rester.
+Vous ne serez pas bien amañ.
 Je ne vois personne.
-Je ne vois pas l'oiseau.
-je ne vois pas comment faire autrement.
-nous ne voyions pas bien pourquoi nous devions nous conformer à ses dires.
+Je ne vois pas l’oiseau.
+Je ne vois pas comment faire autrement.
+Nous ne voyions pas bien pourquoi nous devions nous conformer à ses dires.
 On ne voit rien avec la brume.
-tu ne manges pas assez.
-il n'arrivait pas à s'en tirer.
-elle n'arrivait pas à s'en tirer.
-Je n'ouvre pas la porte tous les matins.
-Tu n'as pas mal à la jambe ?
+Tu ne manges pas assez.
+Il n’arrivait pas à s’en tirer.
+Elle n’arrivait pas à s’en tirer.
+Je n’ouvre pas la porte tous les matins.
+Tu n’as pas mal à la jambe ?
 Il ne va pas très bien.
 Elle ne va pas très bien.
 Ça ne va pas très bien.
 Je ne suis pas malade.
-c'est Noël.
-je n'ai pas eu le temps de regarder ce soir.
-je n'ai pas eu le temps de regarder cela ce soir.
-je n'ai pas eu le temps de regarder ça ce soir.
-Lizig n'est pas à la maison.
-je ne suis pas d'accord avec lui.
-il n'avait pas assez réfléchi.
-il n'est pas facile de chercher des arguments économiques alors que l'on sait pertinemment qu'il s'agit d'un besoin social.
-le temps n'est pas beau.
-il n'est pas capable de s'en tirer.
-ce n'est pas bien.
-ce n'est pas bon.
-il n'est pas trop tôt pour préparer les vacances.
-Ce pantalon n'est pas trop grand pour toi ?
-il n'y a pas beaucoup de monde.
-il n'y a personne.
-qui que ce soit, cela ne changera rien du tout.
-il n'y a pas de voiture sur le bord de la route.
-il n'est pas question qu'il mette les pieds ici.
-Il n'y a pas de pain sur la table.
-il n'a jamais été question qu'il lui laisse sa place.
-Il n'y a pas beaucoup de voitures sur la route.
-Il n'y a aucun ordinateur à la maison.
-alors, il ouvre la porte et il entre.
+c’est Noël.
+Je n’ai pas eu le temps de regarder ce soir.
+Je n’ai pas eu le temps de regarder cela ce soir.
+Je n’ai pas eu le temps de regarder ça ce soir.
+Lizig n’est pas à la maison.
+Je ne suis pas d’accord avec lui.
+Il n’avait pas assez réfléchi.
+Il n’est pas facile de chercher des arguments économiques alors que l’on sait pertinemment qu’il s’agit d’un besoin social.
+Le temps n’est pas beau.
+Il n’est pas capable de s’en tirer.
+Ce n’est pas bien.
+Ce n’est pas bon.
+Il n’est pas trop tôt pour préparer les vacances.
+Ce pantalon n’est pas trop grand pour toi ?
+Il n’y a pas beaucoup de monde.
+Il n’y a personne.
+Qui que ce soit, cela ne changera rien du tout.
+Il n’y a pas de voiture sur le bord de la route.
+Il n’est pas question qu’il mette les pieds ici.
+Il n’y a pas de pain sur la table.
+Il n’a jamais été question qu’il lui laisse sa place.
+Il n’y a pas beaucoup de voitures sur la route.
+Il n’y a aucun ordinateur à la maison.
+Alors, il ouvre la porte et il entre.
 Première restauration.
-nouveau-né.
-ma voiture est flambant neuve.
-nouvellement reçu.
-ça ne va pas.
-vous n'avez pas mal à la jambe.
-nous, nous aimons.
-nous, nous aimions.
-nous, nous aimerons.
-nous, nous lûmes.
-nous , nous lisions.
-nous, nous lirions.
-nous, nous lirons.
-nous, nous mangeons des fruits tous les jours.
-nous, nous avons été aimé.
-nous, nous sommes aimés.
-c'est nous.
-nous, nous avons eu aimé.
-nous, nous avons aimé.
-l'oiseau s'est envolé.
-l'oiseau s'est envolé de la branche.
-ne partez pas tout de suite.
-ne vous en allez pas tout de suite.
-n° 398.
-numéro 398.
-numéros 398.
-Nolwenn Lagadeg m'a informé qu'elle ne pourrait participer à ce moment-là (sinon elle était prête à revenir).
-je ne suis pas assez grand pour faire ça.
-je ne peux pas y aller.
-je ne peux pas aller.
-Note : les dates peuvent varier d'un jour selon les années.
-on ne sait pas s'il est mort ou vivant.
-on ne sait pas s'il est mort ou bien s'il est encore vivant.
-je ne sais rien.
-je ne sais pas grand-chose.
-je ne sais pas bien.
-je ne sais pas ce qu'il veut.
-la nuit du Mardi-Gras.
-bonsoir.
-bonsoir à tous.
-leurs frères.
-leur frère.
-leur chambre.
-leurs chambres.
-il est en train de jouer.
-elle est en train de jouer.
-leurs mains.
-leur main.
-leur tête.
-leurs têtes.
-leur genou.
-leur verre.
-leur vin.
-le leur.
-c'est le leur.
+Nouveau-né.
+Ma voiture est flambant neuve.
+Nouvellement reçu.
+Ça ne va pas.
+Vous n’avez pas mal à la jambe.
+Nous, nous aimons.
+Nous, nous aimions.
+Nous, nous aimerons.
+Nous, nous lûmes.
+Nous, nous lisions.
+Nous, nous lirions.
+Nous, nous lirons.
+Nous, nous mangeons des fruits tous les jours.
+Nous, nous avons été aimés.
+Nous, nous sommes aimés.
+C’est nous.
+Nous, nous eûmes aimé.
+Nous, nous avons aimé.
+L’oiseau s’est envolé.
+L’oiseau s’est envolé de la branche.
+Ne partez pas tout de suite.
+Ne vous en allez pas tout de suite.
+Numéro trois cent quatre-vingt-dix-huit.
+Numéros trois, neuf et huit.
+Nolwenn Lagadeg m’a informé qu’elle ne pourrait participer à ce moment-là.
+Sinon elle était prête à revenir.
+Je ne suis pas assez grand pour faire ça.
+Je ne peux pas y aller.
+Je ne peux pas aller.
+Note : les dates peuvent varier d’un jour selon les années.
+On ne sait pas s’il est mort ou vivant.
+On ne sait pas s’il est mort ou bien s’il est encore vivant.
+Je ne sais rien.
+Je ne sais pas grand-chose.
+Je ne sais pas bien.
+Je ne sais pas ce qu’il veut.
+La nuit du Mardi-Gras.
+Bonsoir.
+Bonsoir à tous.
+Leurs frères.
+Leur frère.
+Leur chambre.
+Leurs chambres.
+Il est en train de jouer.
+Elle est en train de jouer.
+Leurs mains.
+Leur main.
+Leur tête.
+Leurs têtes.
+Leur genou.
+Leur verre.
+Leur vin.
+Le leur.
+C’est le leur.
 Le bébé était en train de dormir.
-ils sont en train de dormir.
-je suis en train de lire.
-leur mur.
-leurs murs.
-ce sont les leurs.
-les leurs.
-ils sont en train de courir.
-elles sont en train de courir.
+Ils sont en train de dormir.
+Je suis en train de lire.
+Leur mur.
+Leurs murs.
+Ce sont les leurs.
+Les leurs.
+Ils sont en train de courir.
+Elles sont en train de courir.
 Il avait appris un tas de choses en écoutant les gens.
 Herve était en train de laver la vaisselle.
-je suis en train de manger.
-ils sont en train de tondre la pelouse.
-elles sont en train de tondre la pelouse.
-Etant donné que la mer était mauvaise, les bateaux étaient restés au port.
-ça va commencer.
-il va commencer.
-elle va commencer.
-je vais commencer.
-leur père.
-leurs pères.
-leur.
-ça fait du bien.
-il fait semblant.
-elle fait semblant.
-Qu'est-ce qu'il est en train de faire ?
-Qu'est-ce qu'elle est en train de faire ?
-Qu'est-ce que vous êtes en train de faire ?
-Qu'est-ce que je suis en train de faire ?
-Qu'est-ce que tu es en train de faire ?
-Qu'étais-tu en train de faire ?
-je regarderai la télévision ce soir.
-à table.
-de toutes manières plus d'un ½ poste monolingue sera retiré car il est prévu une baisse (ouverture => -1 poste ou -1.5 post mono alors ? C'est pas clair).
-rajouter les formes dérivées pour les substantifs et les adjectifs.
+Je suis en train de manger.
+Ils sont en train de tondre la pelouse.
+Elles sont en train de tondre la pelouse.
+Étant donné que la mer était mauvaise, les bateaux étaient restés au port.
+Ça va commencer.
+Il va commencer.
+Elle va commencer.
+Je vais commencer.
+Nous étions en train d’aller.
+En voyant que la nuit était noire ils étaient revenus sur leurs pas.
+Leur père.
+Leurs pères.
+Leur.
+Ça fait du bien.
+Il fait semblant.
+Elle fait semblant.
+Qu’est-ce qu’il est en train de faire ?
+Qu’est-ce qu’elle est en train de faire ?
+Qu’est-ce que vous êtes en train de faire ?
+Qu’est-ce que je suis en train de faire ?
+Qu’est-ce que tu es en train de faire ?
+Qu’étais-tu en train de faire ?
+Je regarderai la télévision ce soir.
+À table.
+De toutes manières plus d’un demi poste monolingue sera retiré car il est prévu une baisse.
+L’ouverture signifie moins un poste ou moins un poste mono et demi alors ?
+C’est pas clair.
+Rajouter les formes dérivées pour les substantifs et les adjectifs.
 De plus, ils pourraient être perdus.
-quand je ne m'en occupe pas je ne sais pas ce qu'ils font.
-quand je ne m'en occupe pas je ne sais pas ce qu'elles font.
-comme il faisait sombre, j'ai allumé la lumière.
-comme il faisait sombre dans la chambre, j'allumai la lumière.
-quand il fait jour ou quand il fait nuit.
-quand je serais grand je partirai d'ici.
-quand j'ai soif je bois de l'eau.
-des petits gars.
-de grands gars forts.
-arrête d'applaudir.
-arrête d'aller dans les endroits interdits.
-arrête d'y aller.
-n'y va plus.
-Ne pas aller par là !
+Quand je ne m’en occupe pas je ne sais pas ce qu’ils font.
+Quand je ne m’en occupe pas je ne sais pas ce qu’elles font.
+Comme il faisait sombre, j’ai allumé la lumière.
+Comme il faisait sombre dans la chambre, j’allumai la lumière.
+Quand il fait jour ou quand il fait nuit.
+Quand je serais grand je partirai d’ici.
+Quand j’ai soif je bois de l’eau.
+Des petits gars.
+De grands gars forts.
+Arrête d’applaudir.
+Arrête d’aller dans les endroits interdits.
+Arrête d’y aller.
+N’y va plus.
+Ne pas aller par là !
 Quand on va au marché.
-puisqu'il fait beau.
-ou séance à 15h + atelier à 16h 7,00 € par enfant.
-Quel âge as-tu ?
-C'est blanc ou c'est bleu ?
-Quel jour viendra-t-il ?
-Quel jour viendra-t-elle ?
-vingt quatre chaises en bois.
-quatre chaises en bois.
-vingt quatre grandes chaises.
-quatre grandes chaises.
-vint quatre chaises noires.
-quatre chaises noires.
-quatre chaises.
-quatre chiennes.
-quatre filles.
-quarante quatre.
-trente quatre.
-quarante quatre femmes.
-trente quatre femmes.
-trente quatre femmes vertes.
-quatre femmes.
-vingt quatre.
-quatre tables.
-quatre.
-vous êtes invités le 21 février à participer à la campagne de promotion organisée par l'UNESCO pour célébrer la journée internationale de la langue maternelle.
-prier la Vierge Marie.
-quand il était en train de traverser la route.
-Combien de temps encore ?
-Combien de temps ça durera ?
-Combien de temps resteras-tu avec nous ?
-C'est combien ?
-Combien ça coûte ?
-Combien c'était ?
-Combien ça vous a coûté ?
-Combien ça t'as coûté ?
-Que le temps est beau dans votre pays !
-Que le temps est beau dans ton pays !
-Comment ça va ?
-Quand viendra-t-il ?
-Quand viendra-t-elle ?
-C'est quand les vacances ?
-Quand doit-il venir ?
-Quand est-il venu ici ?
-Lequel ?
-Laquelle ?
-C'est lequel ?
-C'est laquelle ?
-Où ?
-Où sont-ils ?
-C'est où ?
-Il est où ?
-Elle est où ?
-Où est la porte de la maison ?
-Où sont nos chaises ?
-Où sont mes crayons ?
-Où est-il ?
-Où est-elle ?
-Où êtes-vous ?
-Où sommes-nous ?
-Où suis-je ?
-Où-suis-je ?
-Où es-tu ?
-je serai long.
-il est parti pour longtemps.
-elle est partie pour longtemps.
-il est loin.
-elle est loin.
-c'est loin.
-Ça fait longtemps que tu es là ?
-ça fait longtemps que je ne l'avais par vu.
-ça fait longtemps que je ne l'avais par vue.
-téléphoner ou y aller.
-j'ai téléphoné à la maman que je n'avais pas vu, et lui ai proposé de la voir à ce moment-là, elle travaille dans la restauration et le père est conducteur de poids-lourds, ils sont débordés et peu à l'école.
-très loin.
-il est cinq heures.
+Puisqu’il fait beau.
+Ou séance à quinze heures plus atelier à seize heures : sept euros par enfant.
+Quel âge as-tu ?
+C’est blanc ou c’est bleu ?
+Quel jour viendra-t-il ?
+Quel jour viendra-t-elle ?
+Vingt-quatre chaises en bois.
+Quatre chaises en bois.
+Vingt-quatre grandes chaises.
+Quatre grandes chaises.
+Vingt-quatre chaises noires.
+Quatre chaises noires.
+Quatre chaises.
+Quatre chiennes.
+Quatre filles.
+Quarante-quatre.
+Trente-quatre.
+Quarante-quatre femmes.
+Trente-quatre femmes.
+Trente-quatre femmes vertes.
+Quatre femmes.
+Vingt-quatre.
+Quatre tables.
+Quatre.
+Vous êtes invités le vingt et un février à participer à la campagne de promotion.
+Elle est organisée par l’UNESCO pour célébrer la journée internationale de la langue maternelle.
+Prier la Vierge Marie.
+Quand il était en train de traverser la route.
+Combien de temps encore ?
+Combien de temps ça durera ?
+Combien de temps resteras-tu avec nous ?
+C’est combien ?
+Combien ça coûte ?
+Combien c’était ?
+Combien ça vous a coûté ?
+Combien ça t’a coûté ?
+Que le temps est beau dans votre pays !
+Que le temps est beau dans ton pays !
+Comment ça va ?
+Quand viendra-t-il ?
+Quand viendra-t-elle ?
+C’est quand les vacances ?
+Quand doit-il venir ?
+Quand est-il venu ici ?
+Lequel ?
+Laquelle ?
+C’est lequel ?
+C’est laquelle ?
+Où ?
+Où sont-ils ?
+C’est où ?
+Il est où ?
+Elle est où ?
+Où est la porte de la maison ?
+Où sont nos chaises ?
+Où sont mes crayons ?
+Où est-il ?
+Où est-elle ?
+Où êtes-vous ?
+Où sommes-nous ?
+Où suis-je ?
+Où es-tu ?
+Je serai long.
+Il est parti pour longtemps.
+Elle est partie pour longtemps.
+Il est loin.
+Elle est loin.
+C’est loin.
+Ça fait longtemps que tu es là ?
+Ça fait longtemps que je ne l’avais pas vu.
+Ça fait longtemps que je ne l’avais pas vue.
+Téléphoner ou y aller.
+J’ai téléphoné à la maman que je n’avais pas vue, et lui ai proposé de la voir à ce moment-là.
+Elle travaille dans la restauration et le père est conducteur de poids-lourds, ils sont débordés et peu à l’école.
+Très loin.
+Il est cinq heures.
 Quarante-cinq.
 Quarante-cinq petits animaux verts.
 Quarante-cinq petits animaux.
 Quarante-cinq animaux.
 Vingt-cinq beaux animaux.
-cinq beaux animaux.
+Cinq beaux animaux.
 Vingt-cinq animaux.
 Trente-cinq éléphants noirs.
 Trente-cinq éléphants.
 Trente-cinq beaux éléphants.
 Vingt-cinq maisons.
-cinq maisons.
+Cinq maisons.
 Vingt-cinq.
-cinq.
-quinze.
-il allait se coucher quand il avait diner.
-Comment ?
-Comment est-il ?
-Comment est-elle ?
-Comment allez-vous ?
-Comment vas-tu ?
-Comment vont-ils ?
-Comment t'en tires-tu ?
-Comment donc ?
-Pour rappel, facturation à la ½ heure et non à l’heure.
+Cinq.
+Quinze.
+Il allait se coucher quand il avait dîné.
+Comment ?
+Comment est-il ?
+Comment est-elle ?
+Comment allez-vous ?
+Comment vas-tu ?
+Comment vont-ils ?
+Comment t’en tires-tu ?
+Comment donc ?
+Pour rappel, facturation à la demi-heure et non à l’heure.
 Pêr Le Bihan.
-Pourquoi ?
-Pourquoi ferais-je cela ?
-Pourquoi devrais-tu mentir ?
-Pourquoi ne nous dit-il pas clairement qu'il ne veut pas venir avec nous ?
-Pourquoi ne nous dit-elle pas clairement qu'elle ne veut pas venir avec nous ?
-Pourquoi donc ?
-Lesquels ?
-Lesquelles ?
-Ce sont lesquels ?
-Ce sont lesquelles ?
-La part des adultes dans le nouvel élan du breton (l'effet des formations longues, ne pas faire porter la réappropriation linguistique sur le dos des enfants uniquement...).
-Quelle couleur ?
-Quelle couleur aimez-vous ?
-C'est quelle couleur ?
-Quel âge avez-vous ?
-Lesquels vous plaisent ?
-Lesquelles vous plaisent ?
-Combien ?
-Combien serons-nous ?
-Combien êtes-vous ?
-Quelle heure est-il ?
-Combien il y en a-t-il ?
-Quoi ?
-qu'est ce que ça changera même si il se plaint.
-Qu'est-ce qui lui arrive ?
-Qu'est ce qui nous arrive ?
-Qu'est-ce que ça vaut ?
-Qu'est-ce que tu veux ?
-Qu'est-ce qu'ils sont en train de faire ?
-Qu'est-ce qu'elles sont en train de faire ?
-C'est quoi ?
-Qu'est-ce que c'est ?
-Qu'est devenu cette commission ?
-Que faire ?
-Qu'est-ce que vous prenez ?
-Quoi donc ?
-Qu'est-ce qu'il y a ?
-Qui y-a-t-il ?
-Qu'est-ce qui se passe ?
-Qu'est-ce qu'il y a ici ?
-Qu'est-ce qu'on mange ce soir ?
-Qu'est-ce qu'on mange au petit-déjeuner ?
-Qu'est-ce qu'on mange ce midi ?
-Qu'est-ce qui est rouge ?
-vingt quatre jeux intéressants.
-quatre jeux intéressants.
-vingt quatre jeux.
-quatre jeux.
-quatre personnes.
-quatre hommes.
-quatre gars.
+Pourquoi ?
+Pourquoi ferais-je cela ?
+Pourquoi devrais-tu mentir ?
+Pourquoi ne nous dit-il pas clairement qu’il ne veut pas venir avec nous ?
+Pourquoi ne nous dit-elle pas clairement qu’elle ne veut pas venir avec nous ?
+Pourquoi donc ?
+Lesquels ?
+Lesquelles ?
+Ce sont lesquels ?
+Ce sont lesquelles ?
+La part des adultes dans le nouvel élan du breton.
+L’effet des formations longues.
+Ne pas faire porter la réappropriation linguistique sur le dos des enfants uniquement.
+Quelle couleur ?
+Quelle couleur aimez-vous ?
+C’est quelle couleur ?
+Quel âge avez-vous ?
+Lesquels vous plaisent ?
+Lesquelles vous plaisent ?
+Combien serons-nous ?
+Combien êtes-vous ?
+Quelle heure est-il ?
+Combien y en a-t-il ?
+Quoi ?
+Qu’est ce que ça changera même s’il se plaint.
+Qu’est-ce qui lui arrive ?
+Qu’est ce qui nous arrive ?
+Qu’est-ce que ça vaut ?
+Qu’est-ce que tu veux ?
+Qu’est-ce qu’ils sont en train de faire ?
+Qu’est-ce qu’elles sont en train de faire ?
+C’est quoi ?
+Qu’est-ce que c’est ?
+Qu’est devenue cette commission ?
+Que faire ?
+Qu’est-ce que vous prenez ?
+Quoi donc ?
+Qu’est-ce qu’il y a ?
+Qui y a-t-il ?
+Qu’est-ce qu’il y a ici ?
+Qu’est-ce qu’on mange ce soir ?
+Qu’est-ce qu’on mange au petit-déjeuner ?
+Qu’est-ce qu’on mange ce midi ?
+Qu’est-ce qui est rouge ?
+Vingt-quatre jeux intéressants.
+Quatre jeux intéressants.
+Vingt-quatre jeux.
+Quatre jeux.
+Quatre personnes.
+Quatre hommes.
+Quatre gars.
 Quarante-quatre éléphants.
 Trente-quatre éléphants.
 Trente-quatre éléphants rouges.
-quatre éléphants.
-quatre coups.
-trente quatre nouvelles maisons avaient été construites.
-quatorze maisons.
-quatorze.
-monter sur la table ou descendre de dessus la table.
-monter sur la table ou en descendre.
-Qui ?
-Qui l'accompagnait ce jour-là ?
-Qui sait ?
-Qui m'accompagnera.
-Qui les accompagnera ?
-C'est qui ?
-Qui est-il ?
-Qui est-elle ?
-Qui sont-ils ?
-Qui sont-elles ?
-Qui sait ce qu'est un ornithorynque ?
-Qui êtes-vous ?
-Qui suis-je ?
-Qui es-tu ?
-Qui est là ?
-Qui est arrivé ?
-Qui est venu ?
-Qui t'accompagne ?
+Quatre éléphants.
+Quatre coups.
+Trente-quatre nouvelles maisons avaient été construites.
+Quatorze maisons.
+Quatorze.
+Monter sur la table ou descendre de dessus la table.
+Monter sur la table ou en descendre.
+Qui ?
+Qui l’accompagnait ce jour-là ?
+Qui sait ?
+Qui m’accompagnera.
+Qui les accompagnera ?
+C’est qui ?
+Qui est-il ?
+Qui est-elle ?
+Qui sont-ils ?
+Qui sont-elles ?
+Qui sait ce qu’est un ornithorynque ?
+Qui êtes-vous ?
+Qui suis-je ?
+Qui es-tu ?
+Qui est là ?
+Qui est arrivé ?
+Qui est venu ?
+Qui t’accompagne ?
 Place du Steïr, quai du Port au Vin, place Terre au Duc et rue Astor.
-il plia le bout de papier et le mit dans sa poche.
-il avait plié le bout de papier.
-il est content.
-elles est contente.
-ça lui plaît.
-J'ai du mal à croire cette histoire.
-il a mal à la tête.
-mal de tête.
-il est grand temps.
-il serait temps.
-il est temps que nous fassions quelque chose.
-il est temps d'aller travailler.
-il est temps d'aller à l'école.
-il est temps d'y aller.
-il est temps de partir.
-il est temps.
-le port du Croizic.
-il se peut que le dossier d'Arvorig soir en retard.
-mon sac est lourd.
-j'ai acheté une voiture et un nouveau canapé.
-j'ai acheté un nouveau canapé.
-j'ai acheté un canapé neuf.
-Qu'ils ne viennent pas
-Qu'elles ne viennent pas
-Qu'il ne vienne pas
-Que je sois maudit si ce n'est pas vrai !
-qu'il soit indemnisé.
-qu'elle soit indemnisée.
-qu'il soit loué.
-qu'elle soit louée.
-Qu'il sourit !
-Qu'elle sourit !
-Qu'ils viennent !
-Qu'elles viennent !
-Qu'il vienne !
-Qu'elle vienne !
-Radio : Nolwenn demande à voir les radios (celles qui sont mécontentes).
-elle a du partir puisqu'elle ne pouvait pas rester plus longtemps.
+Il plia le bout de papier et le mit dans sa poche.
+Il avait plié le bout de papier.
+Il est content.
+Elle est contente.
+Ça lui plait.
+J’ai du mal à croire cette histoire.
+Il a mal à la tête.
+Mal de tête.
+Il est grand temps.
+Il serait temps.
+Il est temps que nous fassions quelque chose.
+Il est temps d’aller travailler.
+Il est temps d’aller à l’école.
+Il est temps d’y aller.
+Il est temps de partir.
+Il est temps.
+Le port du Croisic.
+Il se peut que le dossier d’Arvorig soit en retard.
+Mon sac est lourd.
+J’ai acheté une voiture et un nouveau canapé.
+J’ai acheté un nouveau canapé.
+J’ai acheté un canapé neuf.
+Qu’ils ne viennent pas.
+Qu’elles ne viennent pas.
+Qu’il ne vienne pas.
+Que je sois maudit si ce n’est pas vrai !
+Qu’il soit indemnisé.
+Qu’elle soit indemnisée.
+Qu’il soit loué.
+Qu’elle soit louée.
+Qu’il sourie !
+Qu’elle sourie !
+Qu’ils viennent !
+Qu’elles viennent !
+Qu’il vienne !
+Qu’elle vienne !
+Radio : Nolwenn demande à voir les radios.
+Celles qui sont mécontentes.
+Elle a dû partir puisqu’elle ne pouvait pas rester plus longtemps.
 Il doit rouler constamment avec les feux de croisement et feux de détresse allumés.
-il doit comprendre.
-elle doit comprendre.
-il devait rembourser beaucoup d'argent tous les mois.
-je dois absolument y aller sans faute.
-j'ai trop de travail.
-il avait bu trop d'eau et toi aussi.
-ils sont trop nombreux.
-elles sont trop nombreuses.
-ce pantalon est trop grand pour moi.
-c'est trop grand pour moi.
-il est trop grand.
-elle trop grande.
-c'est trop grand.
-trop grand.
-trop grande.
-ce gars est trop beau.
-cette fille est trop belle.
-c'est trop beau.
-il est trop beau.
-elle est trop belle.
-courir pour donner de l'élan à la langue.
-je vous prie de recevoir toutes mes félicitations.
-les bons restes sont bons à prendre.
+Il doit comprendre.
+Elle doit comprendre.
+Il devait rembourser beaucoup d’argent tous les mois.
+Je dois absolument y aller sans faute.
+J’ai trop de travail.
+Il avait bu trop d’eau et toi aussi.
+Ils sont trop nombreux.
+Elles sont trop nombreuses.
+Ce pantalon est trop grand pour moi.
+C’est trop grand pour moi.
+Il est trop grand.
+Elle est trop grande.
+C’est trop grand.
+Trop grand.
+Trop grande.
+Ce gars est trop beau.
+Cette fille est trop belle.
+C’est trop beau.
+Il est trop beau.
+Elle est trop belle.
+Courir pour donner de l’élan à la langue.
+Je vous prie de recevoir toutes mes félicitations.
+Les bons restes sont bons à prendre.
 Il fallait donc apporter l’eau chaude et froide dans des récipients en forme d’arrosoir jusqu’aux chambres et la verser dans les brocs.
-il faudrait.
-il faudra rentrer dedans.
-il faudra passer à côté.
-il faudra retourner.
-il faudra sortir.
-il faudra partir.
-il faudra s'en aller.
-il faudra entrer à l'intérieur.
-il faudra arranger tes vêtements.
-il faudra arranger vos vêtements.
-il faut que j'y arrive.
- il faut que je travaille plus.
-il faut que je travaille.
-il est nécessaire d'avoir un imperméable.
-Il faut faire croître l’intérêt des étudiants et, de manière générale, des actifs vis-à-vis de ce métier si l’on veut développer la filière et rendre les formations plus efficaces.
-donne cette lettre à la mère de Herve.
-donne un baiser à maman.
-pierre qui roule n'amasse pas mousse.
-il a été viré.
-elle a été virée.
-la liste des décisions.
-la liste des membres.
+Il faudrait.
+Il faudra rentrer dedans.
+Il faudra passer à côté.
+Il faudra retourner.
+Il faudra sortir.
+Il faudra partir.
+Il faudra s’en aller.
+Il faudra entrer à l’intérieur.
+Il faudra arranger tes vêtements.
+Il faudra arranger vos vêtements.
+Il faut que j’y arrive.
+Il faut que je travaille plus.
+Il faut que je travaille.
+Il est nécessaire d’avoir un imperméable.
+Il faut faire croître l’intérêt des étudiants et, de manière générale, des actifs vis-à-vis de ce métier.
+Si l’on veut développer la filière et rendre les formations plus efficaces.
+Donne cette lettre à la mère de Herve.
+Donne un baiser à Maman.
+Pierre qui roule n’amasse pas mousse.
+Il a été viré.
+Elle a été virée.
+La liste des décisions.
+La liste des membres.
 Ronan est aimé.
-la terre est ronde.
+La terre est ronde.
 La Reine du soleil.
-le Royaume de Dieu.
-rouge vif.
-cf. la liste à télécharger.
-Samedi 29, dimanche 30 juin 1985.
-Samedi 4 octobre 2008.
-Samedi 5 juillet 2008.
-j'ai élaboré une liste des structures qui pourrait la recevoir.
-ils ont construit une cabane au coin du jardin.
-j'ai l'impression qu'il a grandi.
-j'ai l'impression qu'elle a grandie.
-j'ai soif.
-tu as soif.
-il a soif.
-elle a soif.
-vous avez soif.
-nous avons soif.
-ils ont soif.
-elles ont soif.
+Le Royaume de Dieu.
+Rouge vif.
+Confer la liste à télécharger.
+Samedi vingt-neuf, dimanche trente juin mille neuf cent quatre-vingt-cinq.
+Samedi quatre octobre deux mille huit.
+Samedi cinq juillet deux mille huit.
+Salles habituellement utilisées.
+Espace Kerne : salle d’accueil, salle socioculturelle, salle omnisports, salle de judo, ancien court de tennis.
+Espace Glazik : salle de danse, salle de tennis, foyer des jeunes.
+Salle de la MPT ou véranda.
+Ti Michel : salle un, salle deux, salle trois, salle quatre.
+Salles de l’ancienne école.
+Salles du camping : camping un, camping deux, camping trois.
+Salle cybercommune.
+J’ai élaboré une liste des structures qui pourrait la recevoir.
+Ils ont construit une cabane au coin du jardin.
+J’ai l’impression qu’il a grandi.
+J’ai l’impression qu’elle a grandi.
+J’ai soif.
+Tu as soif.
+Il a soif.
+Elle a soif.
+Vous avez soif.
+Nous avons soif.
+Ils ont soif.
+Elles ont soif.
 Voici le préposé au courrier qui arrive.
 Voilà le préposé au courrier qui arrive.
-les sporanges sont des petits sacs qui contiennent les cellules reproductrices, ou spores.
-dix-sept maisons.
-dix-sept.
-vingt sept grandes personnes.
-vingt sept adultes.
-vingt sept personnes.
-ils sont sept sur les rangs.
-elles sont sept sur les rangs.
-quarante sept.
-trente sept.
-quarante sept renards.
-sept maisons.
-vingt sept.
-sept.
-j'écoutais les oiseaux.
-Ecoutez !
-tiens donc, les premiers panneaux ont été installés aujourd'hui à Lorient à la maison de la Communauté d'agglomération.
-il regarde en traversant.
-elle regarde en traversant.
-voir les Contacts utiles à la fin de cette plaquette.
-ferme la porte.
-Ferme-là, que l'on ait la paix !
-fermez-là.
-service d'éducation spéciale et de soins à domicile.
-service de l'éducation nationale.
-voici donc ce que je lui proposerais.
-voilà le projet de lettre d'information.
-voilà donc ce que je lui proposerais.
-Voici deux jupes. Laquelle est la tienne ? La blanche.
-voilà le compte-rendu de la réunion que nous avons eu la semaine dernière avec Herri.
-voici quelques trucs auxquels je pense qu'il pourrait être bien de mener des recherches plus approfondies à leur sujet, à mon avis.
-voilà, nous devons faire la même chose.
-le voici.
-la voici.
-les voici.
-me voici.
-nous voici.
-te voici.
-plus c'est loin mieux c'est.
-je me lève tous les jours à sept heures du matin.
-Malheureusement, en France (à l’inverse des autres pays européens), le recensement ne s’intéresse pas aux langues parlées par les citoyens.
-Les « ducs à cause d’elle » sont indiqués en plus clair.
-Aujourd'hui Ecole Jean Jaurès.
-l'école de Morlaix.
-J'avais frémis en le voyant.
-Gwenole Larvol m'écrit qu'il n'a pas été invité par l'Office à participer à la commission lexicographique de mathématique dont on avait parlé au conseil scientifique.
+Les sporanges sont des petits sacs qui contiennent les cellules reproductrices, ou spores.
+Dix-sept maisons.
+Dix-sept.
+Vingt-sept grandes personnes.
+Vingt-sept adultes.
+Vingt-sept personnes.
+Ils sont sept sur les rangs.
+Elles sont sept sur les rangs.
+Quarante-sept.
+Trente-sept.
+Quarante-sept renards.
+Sept maisons.
+Vingt-sept.
+Sept.
+J’écoutais les oiseaux.
+Écoutez !
+Tiens donc, les premiers panneaux ont été installés aujourd’hui à Lorient à la maison de la Communauté d’agglomération.
+Il regarde en traversant.
+Elle regarde en traversant.
+Voir les contacts utiles à la fin de cette plaquette.
+Ferme la porte.
+Ferme-la, que l’on ait la paix !
+Fermez-la.
+Service d’éducation spéciale et de soins à domicile.
+Service de l’éducation nationale.
+Voici donc ce que je lui proposerais.
+Voilà le projet de lettre d’information.
+Voilà donc ce que je lui proposerais.
+Voici deux jupes.
+Laquelle est la tienne ?
+La blanche.
+Voilà le compte-rendu de la réunion que nous avons eu la semaine dernière avec Herri.
+Voici quelques trucs auxquels je pense.
+Je pense qu’il pourrait être bien de mener des recherches plus approfondies à leur sujet, à mon avis.
+Voilà, nous devons faire la même chose.
+Le voici.
+La voici.
+Les voici.
+Me voici.
+Nous voici.
+Te voici.
+Plus c’est loin mieux c’est.
+Je me lève tous les jours à sept heures du matin.
+Malheureusement, en France.
+À l’inverse des autres pays européens, le recensement ne s’intéresse pas aux langues parlées par les citoyens.
+Les « ducs à cause d’elle » sont indiqués en plus clair.
+Aujourd’hui École Jean Jaurès.
+L’école de Morlaix.
+J’avais frémis en le voyant.
+Gwenole Larvol m’écrit qu’il n’a pas été invité par l’Office.
+À participer à la commission lexicographique de mathématique dont on avait parlé au conseil scientifique.
 Écrire en breton.
 Écrivez-moi si vous voyez des choses à rajouter.
 Nous sommes assez fatigués.
@@ -2023,476 +2062,489 @@ Vous êtes fatigués.
 Vous êtes fatiguées.
 Je suis fatigué de regarder la télé.
 Je suis fatigué.
-Tondre l'herbe me fatigue.
+Tondre l’herbe me fatigue.
 Il est très fatigué.
 Elle est très fatiguée.
-C'est fatigant ça.
+C’est fatigant ça.
 Il est fatigant ce gars.
 Elle est fatigante cette femme.
-C'est fatigant.
+C’est fatigant.
 Il est fatigant.
 Elle est fatigante.
-J'ai pensé que l'on enverrait ça par courriel avec un mot d'accompagnement en plus.
-SP à son compte, rétribuée par la mairie, compétente en kayak, premiers secours, danses à l'ancienne, diplômée pour être assistante maternelle.
-notre chienne est intelligente.
-il est épouvantable d'entendre de telles choses.
-nous pouvons vous proposer des stages de toutes sortes pour les semaines et les mois à venir.
-il y aura des stages courts au moment des vacances scolaires.
-se serrer la main l'une l'autre.
-encadré.
+J’ai pensé que l’on enverrait ça par courriel avec un mot d’accompagnement en plus.
+SP à son compte, rétribuée par la mairie, compétente en kayak.
+Premiers secours, danses à l’ancienne, diplômée pour être assistante maternelle.
+Notre chienne est intelligente.
+Il est épouvantable d’entendre de telles choses.
+Nous pouvons vous proposer des stages de toutes sortes pour les semaines et les mois à venir.
+Il y aura des stages courts au moment des vacances scolaires.
+Se serrer la main l’une l’autre.
+Encadré.
 Bouchez-vous les oreilles pour ne pas entendre ce bruit.
-Rue Se Anne - 02.97.60.78.49.
-Etude et correction des noms de villages.
-Dimanche 14 juin 1998.
-dimanche de Pâques.
-je suis sûr qu'il aime.
-je suis sûr qu'elle aime.
-je suis sûr que j'aime.
-je suis sûr qu'il aima.
-je suis sûr qu'elle aima.
-je suis sûr qu'il aimait.
-je suis sûr qu'elle aimait.
-je suis sûr que vous aimiez.
-je suis sûr qu'on aimaient.
-je suis sûr que nous aimions.
-je suis sûr que j'aimais.
-je suis sûr qu'ils aimaient.
-je suis sûr qu'elles aimaient.
-je suis sûr qu'on aime.
-je suis sûr que tu aimais.
-je suis sûr que tu aimes.
-je suis sûr qu'il aimerait.
-je suis sûr qu'elle aimerait.
-je suis sûr vous aimeriez.
-je suis sûr qu'on aimerait.
-je suis sûr que nous aimerions.
-je suis sûr que j'aimerais.
-je suis sûr qu'ils aimeraient.
-je suis sûr qu'elles aimeraient.
-je suis sûr que tu aimerais.
-je suis sûr que tu aimeras.
-je suis sûr que nous aimerons.
-je suis sûr que j'aimerai.
-je suis sûr qu'ils aimeront.
-je suis sûr qu'elles aimeront.
-je suis sûr que j'aimai.
-je suis sûr que vous aimez.
-je suis sûr qu'il aurait aimé.
-je suis sûr qu'elle aurait aimé.
-je suis sûr que vous auriez aimé.
-je suis sûr qu'on aurait aimé.
-je suis sûr que nous aurions aimé.
-je suis sûr que j'aurais aimé.
-je suis sûr qu'ils auraient aimé.
-je suis sûr qu'elles auraient aimé.
-je suis sûr que tu aurais aimé.
-je suis sûr que vous aimâtes.
-Je suis sûr qu'on aima.
-je suis sûr que nous aimâmes.
-je suis sûr qu'ils aimèrent.
-je suis sûr qu'elles aimèrent.
-je suis sûr que tu aimas.
-je suis sûr qu'il aimera.
-je suis sûr qu'elle aimera.
-je suis sûr que vous aimerez.
-je suis sûr que nous aimons.
-je suis sûr qu'ils aiment.
-je suis sûr qu'elles aiment.
-je suis sûr qu'on aimera.
-tu es sûr qu'il aime.
-tu es sûr qu'elle aime.
-tu es sûr que j'aime.
-tu es sûr qu'il aima.
-tu es sûr qu'elle aima.
-tu es sûr qu'il aimait.
-tu es sûr qu'elle aimait.
-tu es sûr que vous aimiez.
-tu es sûr qu'on aimait.
-tu es sûr que nous aimions.
-tu es sûr que j'aimais.
-tu es sûr qu'ils aimaient.
-tu es sûr qu'elles aimaient.
-tu es sûr qu'on aime.
-tu es sûr que tu aimais.
-tu es sûr que tu aimes.
-tu es sûr qu'il aimerait.
-tu es sûr qu'elle aimerait.
-tu es sûr vous aimeriez.
-tu es sûr qu'on aimerait.
-tu es sûr que nous aimerions.
-tu es sûr que j'aimerais.
-tu es sûr qu'ils aimeraient.
-tu es sûr qu'elles aimeraient.
-tu es sûr que tu aimerais.
-tu es sûr que tu aimeras.
-tu es sûr que nous aimerons.
-tu es sûr que j'aimerai.
-tu es sûr qu'ils aimeront.
-tu es sûr qu'elles aimeront.
-tu es sûr que j'aimai.
-tu es sûr que vous aimez.
-tu es sûr qu'il aurait aimé.
-tu es sûr qu'elle aurait aimé.
-tu es sûr que vous auriez aimé.
-tu es sûr qu'on aurait aimé.
-tu es sûr que nous aurions aimé.
-tu es sûr que j'aurais aimé.
-tu es sûr qu'ils auraient aimé.
-tu es sûr qu'elles auraient aimé.
-tu es sûr que tu aurais aimé.
-tu es sûr que vous aimâtes.
-tu es sûr qu'on aima.
-tu es sûr que nous aimâmes.
-tu es sûr qu'ils aimèrent.
-tu es sûr qu'elles aimèrent.
-tu es sûr que tu aimas.
-tu es sûr qu'il aimera.
-tu es sûr qu'elle aimera.
-tu es sûr que vous aimerez.
-tu es sûr que nous aimons.
-tu es sûr qu'ils aiment.
-tu es sûr qu'elles aiment.
-tu es sûr qu'on aimera.
-le père de Yann est mon oncle.
-ça vaut la peine.
-petit à petit.
-plus ou moins.
-peu ou prou.
-quelques trucs.
-des petits morceaux.
-Faites attention à ce que de l'eau ne viennent pas dans la maison.
-Prends ton manteau de peur qu'il ne pleuve.
-Il sera attrapé si les policiers le reconnaisse.
-se tâcher les vêtements en ramassant des mûres.
-tu aimes bien avoir mal.
-toi, tu aimes.
-toi, tu aimais.
-toi tu aimeras.
-toi, tu trouves le temps long.
-toi, tu lus.
-toi, tu lisais.
-toi, tu lirais.
-toi, tu liras.
-toi, tu as été aimé.
-toi, tu es aimé.
-toi, tu as aimé.
-toi, tu as eu aimé.
-toi tu as aimé.
+Rue Sainte Anne, zéro deux quatre-vingt-dix-sept soixante soixante-dix-huit quarante-neuf.
+Étude et correction des noms de villages.
+Dimanche quatorze juin dix-neuf cent quatre-vingt-dix-huit.
+Dimanche de Pâques.
+Je suis sûr qu’il aime.
+Je suis sûr qu’elle aime.
+Je suis sûr que j’aime.
+Je suis sûr qu’il aima.
+Je suis sûr qu’elle aima.
+Je suis sûr qu’il aimait.
+Je suis sûr qu’elle aimait.
+Je suis sûr que vous aimiez.
+Je suis sûr qu’on aimait.
+Je suis sûr que nous aimions.
+Je suis sûr que j’aimais.
+Je suis sûr qu’ils aimaient.
+Je suis sûr qu’elles aimaient.
+Je suis sûr qu’on aime.
+Je suis sûr que tu aimais.
+Je suis sûr que tu aimes.
+Je suis sûr qu’il aimerait.
+Je suis sûr qu’elle aimerait.
+Je suis sûr vous aimeriez.
+Je suis sûr qu’on aimerait.
+Je suis sûr que nous aimerions.
+Je suis sûr que j’aimerais.
+Je suis sûr qu’ils aimeraient.
+Je suis sûr qu’elles aimeraient.
+Je suis sûr que tu aimerais.
+Je suis sûr que tu aimeras.
+Je suis sûr que nous aimerons.
+Je suis sûr que j’aimerai.
+Je suis sûr qu’ils aimeront.
+Je suis sûr qu’elles aimeront.
+Je suis sûr que j’aimai.
+Je suis sûr que vous aimez.
+Je suis sûr qu’il aurait aimé.
+Je suis sûr qu’elle aurait aimé.
+Je suis sûr que vous auriez aimé.
+Je suis sûr qu’on aurait aimé.
+Je suis sûr que nous aurions aimé.
+Je suis sûr que j’aurais aimé.
+Je suis sûr qu’ils auraient aimé.
+Je suis sûr qu’elles auraient aimé.
+Je suis sûr que tu aurais aimé.
+Je suis sûr que vous aimâtes.
+Je suis sûr qu’on aima.
+Je suis sûr que nous aimâmes.
+Je suis sûr qu’ils aimèrent.
+Je suis sûr qu’elles aimèrent.
+Je suis sûr que tu aimas.
+Je suis sûr qu’il aimera.
+Je suis sûr qu’elle aimera.
+Je suis sûr que vous aimerez.
+Je suis sûr que nous aimons.
+Je suis sûr qu’ils aiment.
+Je suis sûr qu’elles aiment.
+Je suis sûr qu’on aimera.
+Tu es sûr qu’il aime.
+Tu es sûr qu’elle aime.
+Tu es sûr que j’aime.
+Tu es sûr qu’il aima.
+Tu es sûr qu’elle aima.
+Tu es sûr qu’il aimait.
+Tu es sûr qu’elle aimait.
+Tu es sûr que vous aimiez.
+Tu es sûr qu’on aimait.
+Tu es sûr que nous aimions.
+Tu es sûr que j’aimais.
+Tu es sûr qu’ils aimaient.
+Tu es sûr qu’elles aimaient.
+Tu es sûr qu’on aime.
+Tu es sûr que tu aimais.
+Tu es sûr que tu aimes.
+Tu es sûr qu’il aimerait.
+Tu es sûr qu’elle aimerait.
+Tu es sûr vous aimeriez.
+Tu es sûr qu’on aimerait.
+Tu es sûr que nous aimerions.
+Tu es sûr que j’aimerais.
+Tu es sûr qu’ils aimeraient.
+Tu es sûr qu’elles aimeraient.
+Tu es sûr que tu aimerais.
+Tu es sûr que tu aimeras.
+Tu es sûr que nous aimerons.
+Tu es sûr que j’aimerai.
+Tu es sûr qu’ils aimeront.
+Tu es sûr qu’elles aimeront.
+Tu es sûr que vous aimez.
+Tu es sûr qu’il aurait aimé.
+Tu es sûr qu’elle aurait aimé.
+Tu es sûr que vous auriez aimé.
+Tu es sûr qu’on aurait aimé.
+Tu es sûr que nous aurions aimé.
+Tu es sûr que j’aurais aimé.
+Tu es sûr qu’ils auraient aimé.
+Tu es sûr qu’elles auraient aimé.
+Tu es sûr que tu aurais aimé.
+Tu es sûr que vous aimâtes.
+Tu es sûr qu’on aima.
+Tu es sûr que nous aimâmes.
+Tu es sûr qu’ils aimèrent.
+Tu es sûr qu’elles aimèrent.
+Tu es sûr que tu aimas.
+Tu es sûr qu’il aimera.
+Tu es sûr qu’elle aimera.
+Tu es sûr que vous aimerez.
+Tu es sûr que nous aimons.
+Tu es sûr qu’ils aiment.
+Tu es sûr qu’elles aiment.
+Tu es sûr qu’on aimera.
+Le père de Yann est mon oncle.
+Ça vaut la peine.
+Petit à petit.
+Plus ou moins.
+Peu ou prou.
+Quelques trucs.
+Des petits morceaux.
+Faites attention à ce que de l’eau ne viennent pas dans la maison.
+Prends ton manteau de peur qu’il ne pleuve.
+Il sera attrapé si les policiers le reconnaissent.
+Se tâcher les vêtements en ramassant des mûres.
+Tu aimes bien avoir mal.
+Toi, tu aimes.
+Toi, tu aimais.
+Toi tu aimeras.
+Toi, tu trouves le temps long.
+Toi, tu lus.
+Toi, tu lisais.
+Toi, tu lirais.
+Toi, tu liras.
+Toi, tu as été aimé.
+Toi, tu es aimé.
+Toi, tu as aimé.
+Toi, tu eus aimé.
 Toi, tu auras un beau cadeau à Noël.
-c'est toi.
-toi, tu aimeras.
-du thé ou du café ?
-ils avaient fui devant le monstre.
-elles avaient fui devant le monstre.
-trois chiennes.
-trois filles.
-trois fois plus grand.
-trente trois.
-trente trois femmes.
-trente trois petites femmes.
-trois femmes.
-vingt trois.
-trois tables blanches.
-vingt-trois tables.
-vingt trois tables blanches.
-trois tables.
-trois.
-textes, photos, plans…
-il y avait trois casseroles sur le feu.
-le temps sera chaud.
-il est chaud.
-le temps est chaud.
-le soleil est chaud.
-elle est chaude.
-c'est chaud.
-le soleil chauffe.
-approche.
-la présentation du billet d'entrée est suffisante, il n'y a rien à payer en sus.
-Ça suffit !
-c'est suffisant.
-trente personnes.
-trente chiens.
-trente.
+C’est toi.
+Du thé ou du café ?
+Ils avaient fui devant le monstre.
+Elles avaient fui devant le monstre.
+Trois chiennes.
+Trois filles.
+Trois fois plus grand.
+Trente-trois.
+Trente-trois femmes.
+Trente-trois petites femmes.
+Trois femmes.
+Vingt-trois.
+Trois tables blanches.
+Vingt-trois tables.
+Vingt-trois tables blanches.
+Trois tables.
+Trois.
+Textes, photos, plans…
+Il y avait trois casseroles sur le feu.
+Le temps sera chaud.
+Il est chaud.
+Le temps est chaud.
+Le soleil est chaud.
+Elle est chaude.
+C’est chaud.
+Le soleil chauffe.
+Approche.
+La présentation du billet d’entrée est suffisante, il n’y a rien à payer en sus.
+Ça suffit !
+C’est suffisant.
+Assez.
+Trente personnes.
+Trente chiens.
+Trente.
 Se passer de manger.
-il est plus que temps de partir.
-il est passé par là.
-elles est passée par là.
+Il est plus que temps de partir.
+Il est passé par là.
+Elle est passée par là.
+Ils sont passés par là.
+Elles sont passées par là.
 Je veux dessiner.
-trois chiens.
-trois hommes.
-on m'a mis trois jours d'arrêt.
-vingt trois grands gars.
-vingt trois gars.
-trois gars.
-trois livres.
-trois jeunes marins étaient venus la voir.
-vingt trois jeunes marins étaient venus la voir.
-il y a trois mois.
-trente trois éléphants noirs.
-vingt trois éléphants noirs.
-trois éléphants noirs.
-trente trois éléphants.
-vingt trois éléphants.
-trois éléphants.
-trois coups.
-vingt trois maisons noires.
-vingt trois maisons en bois.
-trois maisons en bois.
-trois maisons.
-trois par trois.
-dix-huit maisons.
-dix-huit.
-treize maisons.
-treize.
-C'est à qui le tour ?
-C'est à qui le tour de sauter ?
-Je me suis coupé le doigt en épluchant des pommes-de-terre.
+Trois chiens.
+Trois hommes.
+On m’a mis trois jours d’arrêt.
+Vingt-trois grands gars.
+Vingt-trois gars.
+Trois gars.
+Trois livres.
+Trois jeunes marins étaient venus la voir.
+Vingt-trois jeunes marins étaient venus la voir.
+Il y a trois mois.
+Trente-trois éléphants noirs.
+Vingt-trois éléphants noirs.
+Trois éléphants noirs.
+Trente-trois éléphants.
+Vingt-trois éléphants.
+Trois éléphants.
+Trois coups.
+Vingt-trois maisons noires.
+Vingt-trois maisons en bois.
+Trois maisons en bois.
+Trois maisons.
+Trois par trois.
+Dix-huit maisons.
+Dix-huit.
+Treize maisons.
+Treize.
+C’est à qui le tour ?
+C’est à qui le tour de sauter ?
+Je me suis coupé le doigt en épluchant des pommes de terre.
 Je me suis coupé le doigt.
-tout autour.
-merci.
-je vous remercie.
-je te remercie.
-merci pour tes vœux, je te souhaite une année 2015 avec des nouveaux brittophones qui germent partout.
-merci de ta réponse.
-merci de tes réponses.
-merci de votre réponse.
-merci de vos réponses.
-merci beaucoup.
-on pourra de recevoir pour t'écouter et échanger avec toi le vendredi 13 mars à 11 h.
-on pourra de recevoir pour t'écouter et échanger avec toi le vendredi 13 mars à 11 h 10.
-il y avait du monde dans la salle.
-il y a du monde dans la salle.
-des personnes réputées pour leur travail.
-des adultes étaient venus surtout.
-il y avait surtout des adultes.
-des gens bizarres.
-des gens mauvais.
-il y a des malades parmi elles.
-il y a des malades parmi eux.
-des sauvages.
-des personnes réputées.
-des personnes reconnues.
-des petites gens.
-vingt maisons.
-vingt.
-trente et un livres noirs.
-vingt et un livres noirs.
-un livre noir.
-trente et un livres.
-vint et un livres.
-un livre.
-cette nuit-là elle avait reçu une lettre de la part de son père.
-trente et une lettres noires.
-vingt et une lettres noires.
-une lettre noire.
-quarante et une lettres.
-trente et une lettres.
-trente et une longues lettres.
-vingt et une longues lettres.
-un longue lettre.
-vingt et une lettres.
-une lettre.
-une cuillère en bois.
-trente et une tables.
-vingt et une tables.
-une table.
-il a eu une nouvelle harpe, une belle.
-une feuille verte et mince.
-une statue en bois.
-un adulte.
+Tout autour.
+Merci.
+Je vous remercie.
+Je te remercie.
+Merci pour tes vœux, je te souhaite une année deux mille quinze avec des nouveaux brittophones qui germent partout.
+Merci de ta réponse.
+Merci de tes réponses.
+Merci de votre réponse.
+Merci de vos réponses.
+Merci beaucoup.
+On pourra te recevoir pour t’écouter et échanger avec toi le vendredi treize mars à onze heures.
+On pourra te recevoir pour t’écouter et échanger avec toi le vendredi treize mars à onze heures dix.
+Il y avait du monde dans la salle.
+Il y a du monde dans la salle.
+Des personnes réputées pour leur travail.
+Des adultes étaient venus surtout.
+Il y avait surtout des adultes.
+Des gens bizarres.
+Des gens mauvais.
+Il y a des malades parmi elles.
+Il y a des malades parmi eux.
+Des sauvages.
+Des personnes réputées.
+Des personnes reconnues.
+Des petites gens.
+Vingt maisons.
+Vingt.
+Trente et un livres noirs.
+Vingt et un livres noirs.
+Un livre noir.
+Trente et un livres.
+Vingt et un livres.
+Un livre.
+Cette nuit-là elle avait reçu une lettre de la part de son père.
+Trente et une lettres noires.
+Vingt et une lettres noires.
+Une lettre noire.
+Quarante et une lettres.
+Trente et une lettres.
+Trente et une longues lettres.
+Vingt et une longues lettres.
+Une longue lettre.
+Vingt et une lettres.
+Une lettre.
+Une cuillère en bois.
+Trente et une tables.
+Vingt et une tables.
+Une table.
+Une part importante des participants à l’enquête de l’Observatoire de la Langue Bretonne.
+Ils ne se sont pas prononcés sur ce point.
+Soit parce qu’ils jugent que leur devenir est trop incertain, en particulier pour ce qui est des associations.
+Soit parce que les personnes ayant répondu n’étaient pas compétentes pour aller au-delà du constat.
+Dans le monde de l’éducation par exemple.
+Soit parce que la connaissance de la langue bretonne ne serait pas une nécessité dans les postes qu’ils envisagent de créer.
+Bien qu’ils apprécient cette compétence.
+Il a eu une nouvelle harpe, une belle.
+Une feuille verte et mince.
+Une statue en bois.
+Un adulte.
 Une personne à la langue bien pendue.
-c'est une grosse déception qui va à l'encontre du vote fait en 2011 par le conseil communautaire qui avait voté le niveau 1 de la charte.
-Une décision qui, bien entendu, n’a jamais été prise… ni même envisâgée !
-une gardienne d'enfants.
-une garderie d'enfants.
-Il y a là quelque chose à imaginer pour progresser : utiliser toutes les bonnes volontés pour faire avancer la langue bretonne.
-je dois vous demander quelque chose.
-quelque chose.
-c'est une belle chose.
-trente et une belles choses.
-quarante et une choses.
-une très bonne chose.
-c'est une bonne chose de prendre son petit-déjeuner.
-c'est une bonne chose.
-une bonne chose.
-je dois te demander un petit quelque chose.
-un demi morceau.
-une méthode en anglais pour apprendre le cornouaillais, gratuit.
-il reste encore quelques trucs à corriger ou à traduire mais c'est déjà agréable.
-vingt et un grands éléphants.
-un grand éléphant.
-quarante et un éléphants.
-vingt et un éléphants.
-un éléphant.
-un peu d'or.
-un peu d'argent.
-un bout de bois.
-un morceau de sucre.
-un bout.
-un morceau.
-un peu.
-un petit peu.
-un petit morceau.
-c'est une maison.
-trente et une maisons.
-j'ai une nouvelle maison.
-vingt et une maisons.
-une maison.
-il y en aura un à Quimper au mois de février et un autre à Brest au mois d'avril.
-il y en aura un à Quimper en février et un autre à Brest en avril.
+C’est une grosse déception qui va à l’encontre du vote fait en deux mille onze par le conseil communautaire qui avait voté le niveau un de la charte.
+Une décision qui, bien entendu, n’a jamais été prise… ni même envisagée !
+Une gardienne d’enfants.
+Une garderie d’enfants.
+Il y a là quelque chose à imaginer pour progresser : utiliser toutes les bonnes volontés pour faire avancer la langue bretonne.
+Je dois vous demander quelque chose.
+Quelque chose.
+C’est une belle chose.
+Trente et une belles choses.
+Quarante et une choses.
+Une très bonne chose.
+C’est une bonne chose de prendre son petit-déjeuner.
+C’est une bonne chose.
+Une bonne chose.
+Je dois te demander un petit quelque chose.
+Un demi-morceau.
+Une méthode en anglais pour apprendre le cornouaillais, gratuit.
+Il reste encore quelques trucs à corriger ou à traduire mais c’est déjà agréable.
+Vingt et un grands éléphants.
+Un grand éléphant.
+Quarante et un éléphants.
+Vingt et un éléphants.
+Un éléphant.
+Un peu d’or.
+Un peu d’argent.
+Un bout de bois.
+Un morceau de sucre.
+Un bout.
+Un morceau.
+Un peu.
+Un petit peu.
+Un petit morceau.
+C’est une maison.
+Trente et une maisons.
+J’ai une nouvelle maison.
+Vingt et une maisons.
+Une maison.
+Il y en aura un à Quimper au mois de février et un autre à Brest au mois d’avril.
+Il y en aura un à Quimper en février et un autre à Brest en avril.
 L’un d’eux est de disposer d’une connaissance détaillée et actualisée du nombre de locuteurs.
-quelqu'un.
-un beau.
-un noir.
-quarante et un.
-quatre-vingt un.
-trente et un.
-trente et une.
-soixante et un.
-cinquante et un.
-un ou deux il faut savoir.
-vingt et un.
-vingt et une.
-une noire.
-un.
-une.
-quatre-vingt onze.
-soixante et onze.
-onze maisons.
-onze.
-je vous souhaite une bonne année.
-un pantalon beaucoup trop serré.
-un pantalon beaucoup trop grand.
-un pantalon trop serré.
-un pantalon trop grand.
-une petite et jolie chapelle.
-une jolie petite chapelle.
-une petite chapelle, et jolie.
-une chapelle, petite et jolie.
-une petite jambe.
-il y a une voiture sur le bord de la route.
-trente et un chiens.
-vingt et un petits chiens.
-un petit chien.
-un grand chien.
-quarante et un chiens.
-vingt et un chiens.
-un chien.
-un vieux truc.
-un vieux machin.
-un lave-linge bruyant.
-une petite gare.
-une professeure de français.
-une grande ville.
-trente et une chiennes.
-trente et une petites chiennes.
-vingt et une petites chiennes.
-une petite chienne.
-une grande chienne.
-vingt et une chiennes.
-une chienne.
+Quelqu’un.
+Un beau.
+Un noir.
+Quarante et un.
+Quatre-vingt-un.
+Trente et un.
+Trente et une.
+Soixante et un.
+Cinquante et un.
+Un ou deux il faut savoir.
+Vingt et un.
+Vingt et une.
+Une noire.
+Un.
+Une.
+Quatre-vingt-onze.
+Soixante et onze.
+Onze maisons.
+Onze.
+Je vous souhaite une bonne année.
+Un pantalon beaucoup trop serré.
+Un pantalon beaucoup trop grand.
+Un pantalon trop serré.
+Un pantalon trop grand.
+Une petite et jolie chapelle.
+Une jolie petite chapelle.
+Une petite chapelle, et jolie.
+Une chapelle, petite et jolie.
+Une petite jambe.
+Il y a une voiture sur le bord de la route.
+Trente et un chiens.
+Vingt et un petits chiens.
+Un petit chien.
+Un grand chien.
+Quarante et un chiens.
+Vingt et un chiens.
+Un chien.
+Un vieux truc.
+Un vieux machin.
+Un lave-linge bruyant.
+Une petite gare.
+Une professeure de français.
+Une grande ville.
+Trente et une chiennes.
+Trente et une petites chiennes.
+Vingt et une petites chiennes.
+Une petite chienne.
+Une grande chienne.
+Vingt et une chiennes.
+Une chienne.
 C’est une vraie collaboration et c’est très positif.
-un petit gars.
-un pauvre homme.
-un pauvre imbécile.
-un pauvre gars.
-une petite fille.
-une grande fille.
-quelques uns.
-une paire de chaussettes.
-une paire de lunettes.
-une paire de chaussures.
-une paire.
-une robe jaune et non rouge.
+Un petit gars.
+Un pauvre homme.
+Un pauvre imbécile.
+Un pauvre gars.
+Une petite fille.
+Une grande fille.
+Quelques-uns.
+Une paire de chaussettes.
+Une paire de lunettes.
+Une paire de chaussures.
+Une paire.
+Une robe jaune et non rouge.
+Il y a une sorte de plaisir mystérieux pour celui qui n’a plus ni curiosité ni ambition.
+À contempler tous ces mouvements de ceux qui partent et de ceux qui reviennent.
+De ceux qui ont encore la force de vouloir, le désir de voyager ou de s’enrichir .
 Il s’agit là d’un obstacle majeur qui nous empêche d’avoir une connaissance suffisamment fine de l’état de la langue.
-une école de dessin.
-Un exemple quand même, celui d’Yvette Guilbert, chanteuse de cabaret qui avait en 1899 proche de sa chambre, une seule grande pièce fonctionnelle.
-une très grosse bêtise.
-une poissonnerie.
-une boucherie.
-une librairie.
-un magasin de vieilleries.
-une boulangerie.
-un voilier.
-un tout petit petit papillon.
-une mère aimée.
-Une capacité qui pourrait être équivalente à une production de 120 000T de poudre de lait /an.
-c'est une honte.
+Une école de dessin.
+Un exemple quand même, celui d’Yvette Guilbert, chanteuse de cabaret.
+Qui avait en mille huit cent quatre-vingt-dix-neuf proche de sa chambre, une seule grande pièce fonctionnelle.
+Une très grosse bêtise.
+Une poissonnerie.
+Une boucherie.
+Une librairie.
+Un magasin de vieilleries.
+Une boulangerie.
+Un voilier.
+Un tout petit petit papillon.
+Une mère aimée.
+Une capacité qui pourrait être équivalente à une production de cent vingt mille tonnes de poudre de lait par an.
+C’est une honte.
 Un visage rasé de près.
-une belle fleur.
-une tabatière.
-une grande bouteille.
-une bouteille de vin blanc.
-une bouteille de vin.
-une jupe quelconque.
-une jupe noire.
-une vieille vache.
-un verre de vin.
-une poule quelconque.
-ma mère.
-mon père.
-Vacances de février,  pâques et été.
-sur la table.
-la maison est sur la colline.
-sur le coup.
-sur le treize.
-sur le treizième.
+Une belle fleur.
+Une tabatière.
+Une grande bouteille.
+Une bouteille de vin blanc.
+Une bouteille de vin.
+Une jupe quelconque.
+Une jupe noire.
+Une vieille vache.
+Un verre de vin.
+Une poule quelconque.
+Ma mère.
+Mon père.
+Vacances de février, Pâques et été.
+Sur la table.
+La maison est sur la colline.
+Sur le coup.
+Sur le treize.
+Sur le treizième.
 Anquetil et Poulidor sont sur la photo.
 Sur d’autres planètes, ces sondes peuvent fonctionner des années.
-elle allait à l'école sans se presser.
-sur le bord de la fenêtre.
-il va en rajeunissant.
-en pente.
-demain je pêcherai.
-demain tu pêcheras.
-demain ils pêcheront.
-demain elles pêcheront.
-demain il pêchera.
-demain elle pêchera.
-demain vous pêcherez.
-demain nous pêcherons.
-demain on pêchera.
-XIIème au XVIIème siècles.
-oui, c'est fait.
-oui c'est bon, maintenant je regarde la carte de Ronan tous les jours.
-oui tu peux envoyer.
-oui alors.
-Oui, la commission a été réunie sans vous prévenir durant la nuit de Noël et a choisie tous les mots qui ne vous plaisaient pas.
-oui , je viendrai.
-oui, peut-être mais propose lui d'abord les deux dates que nous avions réservé.
-oui.
+Elle allait à l’école sans se presser.
+Sur le bord de la fenêtre.
+Il va en rajeunissant.
+En pente.
+Demain je pêcherai.
+Demain tu pêcheras.
+Demain ils pêcheront.
+Demain elles pêcheront.
+Demain il pêchera.
+Demain elle pêchera.
+Demain vous pêcherez.
+Demain nous pêcherons.
+Demain on pêchera.
+Demain je laverai le linge.
+Douzième au dix-septième siècles.
+Oui, c’est fait.
+Oui c’est bon, maintenant je regarde la carte de Ronan tous les jours.
+Oui tu peux envoyer.
+Oui alors.
+Oui, la commission a été réunie sans vous prévenir durant la nuit de Noël et a choisi tous les mots qui ne vous plaisaient pas.
+Oui , je viendrai.
+Oui, peut-être mais propose lui d’abord les deux dates que nous avions réservées.
+Oui.
 Yann était en train de siffler.
 Yann apprend sa leçon.
 Yann est en train de lire.
-jeudi de l'Ascension.
-elle est froide.
-c'est froid.
-l'atmosphère se refroidit.
-il refroidit l'atmosphère.
-elle refroidit l'atmosphère.
-le temps se refroidit.
-il refroidit.
-ça se refroidit.
+Jeudi de l’Ascension.
+Le temps est froid.
+Elle est froide.
+C’est froid.
+L’atmosphère se refroidit.
+Il refroidit l’atmosphère.
+Elle refroidit l’atmosphère.
+Le temps se refroidit.
+Il refroidit.
+Ça se refroidit.
 Elle refroidit.
-Le cas du zoo de Pont-Scorff, défendu hier aussi par des élus, responsables économiques, hôteliers, restaurateurs, est loin d'être unique.
+Le cas du zoo de Pont-Scorff, défendu hier aussi par des élus, responsables économiques, hôteliers, restaurateurs, est loin d’être unique.
 Zoom sur…
 Récemment.
-Récemment j'ai vu un homme.
-Ça, c'est nouveau.
-Ça c'est assez nouveau.
-Ça c'est assez neuf.
-Ça c'est assez récent.
-C'est connu par d'autres personnes également.
-Ce n'est connu de personne.
-Personne d'autre ne sait ça.
-Personne.
-Il y aura aussi d'autres personnes ?
-J'aime mieux les autres livres que ceux-ci.
-J'avais eu envie d'acheter d'autres livres.
-Tu en achèteras d'autres ?
-Lesquels veux-tu prendre ?
-Tu en auras d'autres ?
-Vous en aurez d'autres ?
+Récemment j’ai vu un homme.
+Ça, c’est nouveau.
+Ça c’est assez nouveau.
+Ça c’est assez neuf.
+Ça c’est assez récent.
+C’est connu par d’autres personnes également.
+Ce n’est connu de personne.
+Personne d’autre ne sait ça.
+Il y aura aussi d’autres personnes ?
+J’aime mieux les autres livres que ceux-ci.
+J’avais eu envie d’acheter d’autres livres.
+Tu en achèteras d’autres ?
+Lesquels veux-tu prendre ?
+Tu en auras d’autres ?
+Vous en aurez d’autres ?
 Une chose bien connue des autres animaux.
 Un autre oiseau rouge était venu sur la branche.
 Mes deux livres.
@@ -2501,151 +2553,146 @@ Nos deux noms.
 Vos trois têtes.
 Nos trois feuilles.
 Leurs cinq accords.
-Tes 50 billets avaient été trouvé par moi.
-Il viendra ?
-Elle viendra ?
-Ça viendra ?
-Il ne pleut pas ?
-Est-ce qu'il viendra ?
-Est-ce qu'il ne pleut pas ?
-Est-ce qu'il pleut ?
-Je ne sais pas s'il viendra.
-Je ne sais pas si le jour viendra où nous verrons clair ?
-Quel âge a-t-il ?
-Quel âge a-t-elle ?
-Quel âge ont-ils ?
-Quel âge ont-elles ?
-Comment t'appelles-tu ?
-De quelle couleur est-ce ?
-Quel bruit entends-je ?
-De quel pays était-elle ?
-En quel état sont-ils ?
-Quelles chaussures mettras-tu pou aller en ville ?
-Combien de fois lui avaient-ils téléphoné ?
-Combien de fois lui avaient-elles téléphoné ?
-Combien de personnes ont-elles été invitées ?
-Combien sont-ils ?
-Combien d'enfants ?
+Tes cinquante billets avaient été trouvés par moi.
+Il viendra ?
+Elle viendra ?
+Ça viendra ?
+Il ne pleut pas ?
+Est-ce qu’il viendra ?
+Est-ce qu’il ne pleut pas ?
+Est-ce qu’il pleut ?
+Je ne sais pas s’il viendra.
+Je ne sais pas si le jour viendra où nous verrons clair ?
+Quel âge a-t-il ?
+Quel âge a-t-elle ?
+Quel âge ont-ils ?
+Quel âge ont-elles ?
+Comment t’appelles-tu ?
+De quelle couleur est-ce ?
+Quel bruit entends-je ?
+De quel pays était-elle ?
+En quel état sont-ils ?
+Quelles chaussures mettras-tu pour aller en ville ?
+Combien de fois lui avaient-ils téléphoné ?
+Combien de fois lui avaient-elles téléphoné ?
+Combien de personnes ont-elles été invitées ?
+Combien sont-ils ?
+Combien d’enfants ?
 Vingt enfants.
-Combien de personnes ?
+Combien de personnes ?
 Dix personnes.
-10 personnes.
-À quel étage habitez-vous ?
-Qui est-ce ?
-Qui a le pain ?
-Qui est cette jeune fille ?
-Qu'entend-on ?
-Qu'est-ce que c'est que ça ?
-Quoi encore ?
-Lequel est le tien ?
-Laquelle est la tienne ?
+À quel étage habitez-vous ?
+Qui est-ce ?
+Qui a le pain ?
+Qui est cette jeune fille ?
+Qu’entend-on ?
+Qu’est-ce que c’est que ça ?
+Quoi encore ?
+Lequel est le tien ?
+Laquelle est la tienne ?
 Je se sais pas lesquels prendre.
 Je ne sais pas lesquelles prendre.
-Ce coureur était le combien ?
-La combien est ta sœur à l'école ?
-À quelle date auront lieu les examens ?
-Où est le chien ?
-Où allez-vous ?
-Quand auras-tu assez de temps ?
-Quand viendront-ils ?
-J'aimerais savoir quand est-ce qu'il pleuvra.
-Combien de temps dure le film ?
-Depuis quand ?
-Depuis combien de temps ?
-Tous les combien de temps sont-ils ici ?
-Combien de temps aurez-vous besoin pour faire cela ?
-Quelle distance y a-t-il entre Brest et Morlaix ?
-Quelle distance y a-t-il entre Quimper et Lorient ?
-Depuis combien de temps êtes-vous ici ?
-Combien coûte le repas ?
-Combien d'eau doit-on donner aux plantes ?
-Combien d'arbres devra-t-on abattre ?
-Combien de monde y a-t-il ici ?
-À quelle vitesse roulait-il ?
-De quel hauteur est cette montagne ?
-Le combien est-il arrivé ?
-En premier.
-Comment est-il venu ?
+Ce coureur était le combien ?
+La combien est ta sœur à l’école ?
+À quelle date auront lieu les examens ?
+Où est le chien ?
+Où allez-vous ?
+Quand auras-tu assez de temps ?
+Quand viendront-ils ?
+J’aimerais savoir quand est-ce qu’il pleuvra.
+Combien de temps dure le film ?
+Depuis quand ?
+Depuis combien de temps ?
+Tous les combien de temps sont-ils ici ?
+Combien de temps aurez-vous besoin pour faire cela ?
+Quelle distance y a-t-il entre Brest et Morlaix ?
+Quelle distance y a-t-il entre Quimper et Lorient ?
+Depuis combien de temps êtes-vous ici ?
+Combien coûte le repas ?
+Combien d’eau doit-on donner aux plantes ?
+Combien d’arbres devra-t-on abattre ?
+Combien de monde y a-t-il ici ?
+À quelle vitesse roulait-il ?
+De quel hauteur est cette montagne ?
+Le combien est-il arrivé ?
+Comment est-il venu ?
 Nous ne savons pas comment nous nous débrouillerons.
 Nous ne savons pas comment ils se débrouilleront.
-À cause de quoi ?
-Pour quoi faire ?
-Tu es prêt ?
+À cause de quoi ?
+Pour quoi faire ?
+Tu es prêt ?
 Oui, je suis prêt.
-On te verra demain ?
+On te verra demain ?
 Oui, on me verra.
 Je ne suis pas prêt.
 On ne me verra pas.
-Il fait froid ?
-Comment est le temps ce matin ?
-Ces gens étaient riches ?
-Il y a de l'eau ?
-Vous entendez ?
-C'est toi qui l'a ?
-Vous avez mangé ensemble ?
-Tu veux tu café ?
-Toi tu iras danser ?
-Ils connaissent la nouvelle ?
-Il tombera ?
-Ils seraient venus ?
-Je n'irai pas.
-Il ne seraient pas
+Il fait froid ?
+Comment est le temps ce matin ?
+Ces gens étaient riches ?
+Il y a de l’eau ?
+Vous entendez ?
+C’est toi qui l’a ?
+Vous avez mangé ensemble ?
+Tu veux du café ?
+Toi tu iras danser ?
+Ils connaissent la nouvelle ?
+Il tombera ?
+Ils seraient venus ?
+Je n’irai pas.
+Il ne seraient pas.
 Ils ne savent pas.
-Je n'aurai pas.
-Nous n'avons pas.
+Je n’aurai pas.
+Nous n’avons pas.
 Nous ne faisons pas.
-Tu n'es pas prêt ? Non.
-On ne te verra pas demain ? Non.
-Tu n'es pas prêt ? Si.
-On ne te verra pas demain ? Si.
-Il ne fait pas froid ?
-Ces gens n'étaient pas riches ?
-Il n'y a pas d'eau ?
-Vous n'entendez pas ?
-Tu ne l'as pas ?
-Vous n'avez pas mangé ensemble ?
-Vous ne voulez pas de café ?
-Je serai an retard.
+Tu n’es pas prêt ?
+On ne te verra pas demain ?
+Il ne fait pas froid ?
+Ces gens n’étaient pas riches ?
+Il n’y a pas d’eau ?
+Vous n’entendez pas ?
+Tu ne l’as pas ?
+Vous n’avez pas mangé ensemble ?
+Vous ne voulez pas de café ?
+Je serai en retard.
 Je ne serai pas en retard.
-Tu n'iras pas danser ?
-Ils ne connaissent pas la nouvelle ?
-Il ne tombera pas ?
-Ils ne seraient pas venus ?
-Ils ne se plaindront pas ? Si.
-Il faisait beau hier. Oui.
-Il n'est pas venu aujourd'hui. Non.
-Quel stupide animal !
+Tu n’iras pas danser ?
+Ils ne connaissent pas la nouvelle ?
+Il ne tombera pas ?
+Ils ne seraient pas venus ?
+Ils ne se plaindront pas ?
+Il faisait beau hier.
+Il n’est pas venu aujourd’hui.
+Quel stupide animal !
 Ce tableau représente la Sainte Vierge.
-Quel hurluberlus !
-Quelles bruyantes voitures !
-Comme il est fort !
-Qu'est-ce qu'on les voit souvent !
-Tous les combien de temps on les voit ?
-Qu'est-ce que ça fait comme bruit !
-Qu'est-ce qu'elle aime ce chanteur !
-Qu'il fait froid !
-Que c'est froid !
-Combien n'ont-ils pas été attrapés comme cela !
-Que de monde !
-Que de pluie !
-Que d'eau !
-Qu'est-ce qu'il fait chaud !
-Quel bavard !
-Quelle bavarde !
-Qu'est-ce que c'est mauvais !
-Qu'est-ce que c'est bon !
-Qu'ils soient maudits si ce n'est pas vrai !
-Que Dieu soit bénit !
-Qu'il ne vienne pas.
-Pourvu qu'il ne pleuve pas !
-J'espère qu'il n'aura pas perdu son chemin !
-J'espère que nous réussirons !
-Nous réussirons, je l'espère !
-Dieu vous bénisse !
+Quel hurluberlu !
+Quelles bruyantes voitures !
+Comme il est fort !
+Qu’est-ce qu’on les voit souvent !
+Tous les combien de temps on les voit ?
+Qu’est-ce que ça fait comme bruit !
+Qu’est-ce qu’elle aime ce chanteur !
+Qu’il fait froid !
+Que c’est froid !
+Combien n’ont-ils pas été attrapés comme cela !
+Que de monde !
+Que de pluie !
+Que d’eau !
+Qu’est-ce qu’il fait chaud !
+Quel bavard !
+Quelle bavarde !
+Qu’est-ce que c’est mauvais !
+Qu’est-ce que c’est bon !
+Qu’ils soient maudits si ce n’est pas vrai !
+Que Dieu soit bénit !
+Pourvu qu’il ne pleuve pas !
+J’espère qu’il n’aura pas perdu son chemin !
+J’espère que nous réussirons !
+Nous réussirons, je l’espère !
+Dieu vous bénisse !
 Que le gouvernement ne se mêle pas de ces affaire-là.
-Qu'ils écoutent !
-Ainsi soit-il !
-Vivement Noël !
+Qu’ils écoutent !
+Ainsi soit-il !
+Vivement Noël !
 Le grand.
 La grande.
 Les grands.
@@ -2657,7 +2704,7 @@ Le directeur.
 Le vendredi.
 Une minute.
 Un détail.
-L'hiver.
+L’hiver.
 Une demi-heure.
 Deux heures.
 Une seconde.
@@ -2667,14 +2714,13 @@ Vent de noroît.
 Le sud-est.
 Vent de suroît.
 Un b.
-L'acier.
+L’acier.
 La terre.
 Le blé.
 Les châtaignes.
 Le ramassage de pommes.
 Le collage.
 Une coupure.
-Le jaune.
 Un tas.
 Le pourquoi et le comment.
 Une journaliste.
@@ -2683,16 +2729,16 @@ La présidente.
 Le pays.
 Le Grande-Bretagne.
 Quimper et sa cathédrale.
-Pitié !
-Liberté !
+Pitié !
+Liberté !
 Un liquide.
-L'étude des sciences.
+L’étude des sciences.
 La pêche.
 Une étude de notaire.
 Les quatre vents.
 Celui-là, ce temps-là.
 Deux livres.
-Il y a une mauvaise odeur ici, il faut l'éliminer.
+Il y a une mauvaise odeur ici, il faut l’éliminer.
 Il fait beau temps.
 Du vent fort.
 Cinq livres de viandes.
@@ -2715,10 +2761,10 @@ La tourterelle mâle.
 La tourterelle femelle.
 La tourterelle.
 Les tourterelles.
-Le merle mâle
+Le merle mâle.
 Le merle femelle.
 Le matou.
-Une Bigoudenn.
+Une bigouden.
 Une Chikolodenn.
 Mon frère et mes deux sœurs étaient venus, ils avaient tous trois des cadeaux.
 Mon frère et ma sœur se téléphonaient souvent.
@@ -2733,38 +2779,38 @@ Le poulailler.
 La faculté des lettres.
 Il y a des étoiles dans le ciel.
 Celui-là vend des fruits qui ont un goût savoureux.
-Il y avait là-bas des fourmis qui n'étaient pas aussi noires que celles de ce pays-ci.
+Il y avait là-bas des fourmis qui n’étaient pas aussi noires que celles de ce pays-ci.
 Deux huîtres.
 Les poires sont mûres.
 Il y a des poires mûres dans le panier.
-Le pain n'est pas bon dans ce magasin.
-L'espoir ? C'est de lui que je vis.
+Le pain n’est pas bon dans ce magasin.
+L’espoir ? C’est de lui que je vis.
 Un pain.
 Une bouteille de Bordeaux.
 Ces châtaignes ne sont pas pourries.
 Quelques châtaignes.
 Les châtaigniers ne sont pas encore en fleur.
 Le bois de châtaignier est clair.
-Le goémon non-pourri n'est pas bon comme engrais.
+Le goémon non-pourri n’est pas bon comme engrais.
 Ses oreilles ne sont pas sales.
-La libellule a deux paires d'ailes.
-Des paires d'yeux me regardaient.
+La libellule a deux paires d’ailes.
+Des paires d’yeux me regardaient.
 Le temps était si froid que les oreilles des gens étaient rouges.
 Nettoie ton oreille.
 Nettoie tes oreilles.
-Il est capable d'écrire des deux mains.
+Il est capable d’écrire des deux mains.
 Mes chaussures.
 Elle avait aux pieds une paire de chaussures de cuir à talons hauts.
 Une cuillère en argent.
 Le morceau de pain.
-Une bande d'enfants.
+Une bande d’enfants.
 Le cheval de guerre.
-Un buveur d'eau.
+Un buveur d’eau.
 Du cidre de ferme.
 La boîte aux lettres.
 Un dinde.
 La coquille Saint-Jacques.
-Le premier de l'an.
+Le premier de l’an.
 Une personne de cœur.
 La fontaine de jouvence.
 Un marin.
@@ -2775,14 +2821,14 @@ Une voiture de cinq mille euros.
 Une tour de trente mètres.
 Un enfant de trois ans.
 Des jeunes de vingt ans.
-Un bon moceau de pain.
-Une bonne poignée de pièces d'or.
+Un bon morceau de pain.
+Une bonne poignée de pièces d’or.
 Un vacarme assourdissant.
 La fenêtre de la maison.
-Le mât d'un bateau.
-À l'heure du dîner.
+Le mât d’un bateau.
+À l’heure du dîner.
 Les gens de la ville.
-L'école de deux communes.
+L’école de deux communes.
 La porte de chaque maison.
 La fenêtre de notre maison.
 Le chien de Yann.
@@ -2794,58 +2840,58 @@ La belle-fille du Français.
 La Fête de la Toussaint.
 La voiture de celui-ci.
 La clé de la porte de la maison de mon père.
-Le but du nez du chien d'Erwan.
-Le début du mois d'août.
-L'homme aux cheveux roux.
+Le bout du nez du chien d’Erwan.
+Le début du mois d’août.
+L’homme aux cheveux roux.
 La ville aux trois châteaux.
 Jean au bâton de fer.
 Une amie de ma sœur.
 Une pièce de la machine.
-De l'eau d'un puits.
-Une page d'un livre.
-Des gens d'un pays lointain.
-Des sportives d'Afrique.
+De l’eau d’un puits.
+Une page d’un livre.
+Des gens d’un pays lointain.
+Des sportives d’Afrique.
 Des sonneurs du Bagad Kemper.
 Une invitation de ma part.
-C'est un homme du pays.
-Cet animal d'Australie.
+C’est un homme du pays.
+Cet animal d’Australie.
 Cette pièce en est une partie.
-La moitié de l'équipe.
+La moitié de l’équipe.
 Trois des soldats.
 Aucun de ceux-là.
 Aucune de celles-là.
 Les petits de chez moi.
-J'ai vu cinq d'entre eux.
+J’ai vu cinq d’entre eux.
 Le plus âgé des élus.
-Le plus neuf d'entre eux.
-La plus neuve d'entre elles.
+Le plus neuf d’entre eux.
+La plus neuve d’entre elles.
 Le chemin de la plage.
-l'aide des pompiers.
+L’aide des pompiers.
 Les gens de la campagne.
 Un bateau à voile.
-La bonté à l'égard des pauvres
-L'amour du prochain.
+La bonté à l’égard des pauvres.
+L’amour du prochain.
 La peur des chiens.
 Les cheveux de Yann sont noirs.
 Le cœur de cette fille tressaille.
-J'aime bien les règles de ce jeu.
+J’aime bien les règles de ce jeu.
 Une machine à écrire.
 Le moment de partir.
-L'avenir.
+L’avenir.
 Un bureau.
 Le bateau de pêche.
 Un restaurant.
 Un moment de repos.
 Un mois de travail.
-C'est passionnant.
+C’est passionnant.
 Aucune chaise.
 Aucune autre chaise.
 Aucune maison.
 Aucune autre maison.
-Il n'y a pas de chaises.
-Il n'y a aucune autre chaise.
-Il n'y a pas de maisons.
-Il n'y a pas d'autre maison.
+Il n’y a pas de chaises.
+Il n’y a aucune autre chaise.
+Il n’y a pas de maisons.
+Il n’y a pas d’autre maison.
 Si les enfants ne peuvent pas jouer.
 Si tu ne peux pas jouer.
 Si les enfants ne peuvent pas jouer il faudra trouver autre chose.
@@ -2861,16 +2907,15 @@ La cane.
 Les canards.
 Le livre.
 Une cuillère.
-L'école.
+L’école.
 Une poule.
 La voile.
 La fête.
-La connaissance.
 Un jean.
 Les johnnies.
 Un éléphant.
 Des éléphants.
-Dans l'armoire.
+Dans l’armoire.
 À la maison.
 À la bibliothèque.
 Dans une armoire.
@@ -2883,31 +2928,30 @@ Dans les villes.
 Dans les armoires.
 Dans les bibliothèques.
 En Israël.
-À l'abbaye du Relecq.
-J'ai de l'amour pour toi.
+À l’abbaye du Relecq.
+J’ai de l’amour pour toi.
 Il y avait du vacarme à la maison.
 Il y avait du bruit à la maison.
 Mieux vaut instruction que richesse.
-Qu'est-ce que tu prendras ?
-Du thé ou du café ?
+Qu’est-ce que tu prendras ?
+Du thé ou du café ?
 Il y a de la sauce à rajouter.
-J'aime bien les crêpes.
-J'aime courir.
+J’aime bien les crêpes.
+J’aime courir.
 Il aime lire.
 Elle aime lire.
-Y aura-t-il de la neige à Noël ?
+Y aura-t-il de la neige à Noël ?
 Nous avons bu du vin que vous aviez apporté hier.
 Un perroquet des îles.
-Parle-t-il le breton ?
-Nous sommes en train d'apprendre l'anglais.
-À quelle heure dînera-t-on ?
-Qu'y aura-t-il pour le déjeuner ?
+Parle-t-il le breton ?
+Nous sommes en train d’apprendre l’anglais.
+À quelle heure dînera-t-on ?
+Qu’y aura-t-il pour le déjeuner ?
 Le petit-déjeuner est prêt.
 Le petit-déjeuner était bon.
 Ce fut un grand dîner.
 Ce sera agréable de passer le mois de mai au pays.
 Il a fait froid au mois de janvier.
-Il a fait froid au mois en janvier.
 Le mois de septembre fut difficile.
 Nous avons eu un mois de novembre venteux cette année.
 Le mois de mars où vous étiez venus.
@@ -2915,207 +2959,200 @@ Le mois de mars où vous étiez venus.
 Le Mardi-Gras à Lannion.
 Le lundi de Pâques.
 Bonne nuit, les filles.
-D'ici on voit la ville.
+D’ici on voit la ville.
 Aller en ville.
-Ce mois d'août-là avait été très chaud.
+Ce mois d’août-là avait été très chaud.
 Les employés sont en train de nettoyer les rues de la ville.
-Aller jusqu'à la grande ville.
+Aller jusqu’à la grande ville.
 Faire la tête.
-courir le pays.
+Courir le pays.
 Il court le pays.
 Il fait la tête.
 La première personne que je vis ce jour-là…
-C'est encore une plus grande maison !
+C’est encore une plus grande maison !
 La prochaine fois.
-La prochaine fois que tu viendras ici, dis le mois d'abord.
+La prochaine fois que tu viendras ici, dis-le-moi d’abord.
 La première chose à faire…
 La meilleure chose à faire...
-Le pire c'est que…
+Le pire c’est que…
 Il y a un an.
-Il y avait un mois qu'il n'était pas venu.
+Il y avait un mois qu’il n’était pas venu.
 Il a atteint ses vingt-et-un ans.
 La porte de la chambre.
 La lettre de Yuna.
 La fille aux lunettes noires.
-Tu as vu le petit Tangi ?
+Tu as vu le petit Tangi ?
 La grande Lena est allée se promener.
 La maison du renard.
 La maison de Le Louarn.
 La voix de Keraotred.
-Qui c'est celui-là ?
-C'est Keraotred.
-Comment vous appelez-vous ?
-Je m'appelle Keraotred.
-Madame la directrice n'est pas ici.
+Qui c’est celui-là ?
+C’est Keraotred.
+Comment vous appelez-vous ?
+Je m’appelle Keraotred.
+Madame la directrice n’est pas ici.
 Allez voir monsieur Le Goff.
 Écrire à madame Louarn.
-J'ai vu le docteur Keraotred.
-Monsieur l'abbé.
-Monseigneur l'évêque.
+J’ai vu le docteur Keraotred.
+Monsieur l’abbé.
+Monseigneur l’évêque.
 Monsieur Louarn.
 Madame la directrice, venez vite.
 Bonjour monsieur Le Goff.
 Au revoir madame Louarn.
-Docteur Keraotred, écoutez-moi s'il vous plaît.
+Docteur Keraotred, écoutez-moi s’il vous plait.
 Les Trégorois sont moqueurs.
 Tous les Irlandais.
 Ces Écossais portaient des kilts.
-J'ai vu des Quimpérois l'autre jour.
+J’ai vu des Quimpérois l’autre jour.
 Les Quimpérois étaient accourus pour voir le spectacle.
 Les États-Unis.
 Les Îles Kerguelen.
 Les Montagnes Noires.
 Les Rocheuses.
-L'Océan Pacifique.
+L’Océan Pacifique.
 Les Alpes.
-Les Monts d'Arrée.
+Les Monts d’Arrée.
 La Loire.
 Saint-Sauveur.
 La ville de Brest.
 Le Guilvinec.
 La Ville du Guilvinec.
-La Fédaration de Russie.
+La Fédération de Russie.
 Le Royaume-Uni.
-Le Royaume-Uni de Grande-Bretagne et d'Irlande du Nord.
+Le Royaume-Uni de Grande-Bretagne et d’Irlande du Nord.
 La République du Pérou.
 Le canton de Landerneau.
-L'étoile Véga.
-La constellation d'Orion.
+L’étoile Véga.
+La constellation d’Orion.
 La planète Mars.
 La constellation du Taureau.
 Le Grand chariot.
 La ville du Faou.
-L'Union des Enseignants de Breton.
-L'UGB s'était réunie la semaine dernière.
-Il est bien pauvre, sa paye n'atteint même pas le SMIC.
+L’Union des Enseignants de Breton.
+L’UGB s’était réunie la semaine dernière.
+Il est bien pauvre, sa paye n’atteint même pas le SMIC.
 Une trentaine de moules.
 Une trentaine de personnes.
 Dix soldats étaient en train de tirer environ.
-Une dizaine de soldats étaient en train de tirer.
+Une dizaine de soldats était en train de tirer.
 Une paire de lunettes fines sur le nez.
-Des yeux emplis d'amour me regardaient.
+Des yeux emplis d’amour me regardaient.
 Mourir de froid.
 Tressaillir de joie.
 Rougir de honte.
-L'odeur de roussi
-Une odeur de roussi
+L’odeur de roussi.
+Une odeur de roussi.
 Goût de vieux.
 Le chien est avec eux.
 Le chien est avec elles.
-Moi, j'étais trop fatigué.
-Moi, j'étais trop fatiguée.
+Moi, j’étais trop fatigué.
+Moi, j’étais trop fatiguée.
 Ton père et toi, vous viendrez certainement rapidement.
 Elle, elle ne regardera pas ce film.
-Vous, vous ne travailliez pas beaucoup à l'école.
-C'est toi ?
-C'était vous ?
-C'est elle la maîtresse d'école.
-Qui conduira ? - Lui.
-C'est lui qui conduira.
+Vous, vous ne travailliez pas beaucoup à l’école.
+C’est toi ?
+C’était vous ?
+C’est elle la maîtresse d’école.
+Qui conduira ?
+Lui.
+C’est lui qui conduira.
 Me voilà.
-La voilà attrapée
-Qui croiras-tu ? - Elle.
-Il nous a aidé mon frère et moi.
+La voilà attrapée.
+Qui croiras-tu ?
+Elle.
+Il nous a aidés mon frère et moi.
 Aussi fatigué que toi.
 Aussi fatiguée que toi.
 Ni vous ni moi ne sommes assez compétents.
 Écoutez-moi.
 Croyez-la.
-Moi, je l'ai vu.
-Ils ne l'avaient pas écoutée.
-Elles ne l'avaient pas écoutée.
-Ils ne l'avaient pas écouté.
-Elles ne l'avaient pas écouté.
-D'ici à demain nous les aurons informés.
-D'ici à demain nous les aurons informées.
+Moi, je l’ai vu.
+Ils ne l’avaient pas écoutée.
+Elles ne l’avaient pas écoutée.
+Ils ne l’avaient pas écouté.
+Elles ne l’avaient pas écouté.
+D’ici à demain nous les aurons informés.
+D’ici à demain nous les aurons informées.
 Ils se méfiaient comme toi et moi.
 Il y avait eu une dispute entre lui et sa femme.
-Iras-tu, toi, au cinéma après dîner ?
+Iras-tu, toi, au cinéma après dîner ?
 On ne vous verra pas, vous, vous occuper des enfants.
 Ma chemise était toute froissée.
-Quant à moi, je n'irai pas.
-Ils n'avaient pas besoin de deux voitures parce qu'elle travaillait souvent à la maison.
-Je ne l'achèterai pas.
-Moi, je n'ai pas envie d'entendre cette chanson.
-C'est mon crayon.
+Quant à moi, je n’irai pas.
+Ils n’avaient pas besoin de deux voitures parce qu’elle travaillait souvent à la maison.
+Je ne l’achèterai pas.
+Moi, je n’ai pas envie d’entendre cette chanson.
+C’est mon crayon.
 Ses lunettes sont noires.
 Avec moi.
 Dis-tu.
 À nous.
-Qu'est-ce que vous cherchez ?
-Que cherchez-vous ?
-Ceci est à vous ?
+Qu’est-ce que vous cherchez ?
+Que cherchez-vous ?
+Ceci est à vous ?
 Je vous appellerai demain.
-J'étais en train de l'attendre lorsque je vis son frère accourir.
-Je les ai entendu se plaindre l'autre jour.
+J’étais en train de l’attendre lorsque je vis son frère accourir.
+Je les ai entendus se plaindre l’autre jour.
 Le gendarme me vit.
 Il est allé le voir de bonne heure.
 Elle est allée le voir de bonne heure.
 Il est allé la voir de bonne heure.
 Elle est allée la voir de bonne heure.
 Nous le réparerons à la maison.
-Ne l'écoutez pas !
-Je le jure !
-Il était allé le voir de bonne heure.
-J'étais allé le voir de bonne heure.
-Écoute-la un peu !
-J'avais donné la bouteille d'eau à ton père.
-Vous ne me verrez plus m'occuper des animaux.
+Ne l’écoutez pas !
+Je le jure !
+J’étais allé le voir de bonne heure.
+Écoute-la un peu !
+J’avais donné la bouteille d’eau à ton père.
+Vous ne me verrez plus m’occuper des animaux.
 Il y a de quoi manger dans mon sac.
-Nous, nous t'attraperons un jour ou l'autre.
-Il m'appelle souvent pour venir lui prêter main forte.
+Nous, nous t’attraperons un jour ou l’autre.
+Il m’appelle souvent pour venir lui prêter main forte.
 Ils avaient fait le travail eux-mêmes.
 Elles avaient fait le travail elles-mêmes.
-J'avais fait le travail moi-même.
+J’avais fait le travail moi-même.
 Tu avais fait le travail toi-même.
 Il avait fait le travail lui-même.
 Elle avait fait le travail elle-même.
-Ils avaient fait le travail nous-mêmes.
+Ils avaient fait le travail eux-mêmes.
 Vous aviez fait le travail vous-mêmes.
-Pour moi tout seul
+Pour moi tout seul.
 Pour moi-même.
 Pour toi tout seul.
 Pour toi-même.
 Le patron lui-même était venu les voir.
 Nous resterons ici tous les deux.
-Dis leur à tous les cinq.
+Dis-leur à tous les cinq.
 Nous étions absolument seuls.
-J'étais absolument seul.
+J’étais absolument seul.
 Il est resté tout seul à la maison.
 Nous irons en vacances rien que nous deux.
 Guéris-toi toi-même.
 Les soldats se battaient avec courage.
 Je me voyais dans le miroir.
-L'un et l'autre.
-L'une et l'autre.
-L'un ou l'autre.
-L'une ou l'autre.
-Ils s'entraidaient beaucoup l'un l'autre.
+Ils s’entraidaient beaucoup l’un l’autre.
 Mes frères se battaient entre-eux.
-Les enfants disent qu'ils sont fatigués.
+Les enfants disent qu’ils sont fatigués.
 Les fruits se vendent sur le marché.
-Il s'en tire bien.
+Il s’en tire bien.
 Je me lave.
 Je me lave les mains.
-Tu t'habilles ?
-Demain te t'habilleras d'un chaud manteau.
+Tu t’habilles ?
+Demain tu t’habilleras d’un chaud manteau.
 Écoutez-le.
 Écoutez-la.
 Écoutez-nous.
 Écoutez-les.
-Ne m'écoutez pas.
-Ne l'écoutez pas.
+Ne m’écoutez pas.
+Ne l’écoutez pas.
 Ne nous écoutez pas.
-Ne les écoutez pas
-Je l'ai entendu chanter.
-Elle est venue d'elle-même.
-La caisse ? J'en avais retiré un billet de 20 euros.
+Ne les écoutez pas.
+Je l’ai entendu chanter.
+Elle est venue d’elle-même.
+La caisse ? J’en avais retiré un billet de vingt euros.
 Le mien.
 La mienne.
-Le tien.
-La tienne.
-Le sien.
-La sienne.
 Le nôtre.
 La nôtre.
 Le vôtre.
@@ -3124,19 +3161,12 @@ Le leur.
 La leur.
 Les miens.
 Les miennes.
-Les tiens.
-Les tiennes.
-Les siens.
-Les siennes.
-Les nôtres.
 Les vôtres.
-O re.
 Où est le vôtre.
 Où est la vôtre.
-Les nôtre ne sont pas aussi solides.
+Les nôtres ne sont pas aussi solides.
 Le grand gars.
 La grande fille.
-Les grandes filles.
 Les grands gars.
 Ce petit chat.
 Ce petit.
@@ -3168,22 +3198,22 @@ Les cinq grandes sportives.
 Les cinq grandes.
 Les enfants, venez manger.
 On va commencer.
-On y va !
+On y va !
 Faire la fête.
 Il faisait nuit.
 Le temps est à la pluie.
-D'ici on voit bien la route.
-J'aimerais que l'on cessât de lui parler odieusement.
+D’ici on voit bien la route.
+J’aimerais que l’on cessât de lui parler odieusement.
 On lève le courrier deux fois par jour.
 On ne sait plus quoi penser.
 On en voit de toutes les couleurs en mer.
 On ne peut pas durer avec le bruit.
-Avoir quelqu'un à s'occuper de soi.
+Avoir quelqu’un à s’occuper de soi.
 Rire à gorge déployée.
 Quand on a froid on attrape la crève.
-Ça lui fait mal d'entendre de tels propos.
-Avoir quelqu'un à s'occuper de vous.
-On ne fait pas d'omelette sans casser des œufs.
+Ça lui fait mal d’entendre de tels propos.
+Avoir quelqu’un à s’occuper de vous.
+On ne fait pas d’omelette sans casser des œufs.
 Il est plus agréable de voyager quand il y a des gens avec soi.
 Quand on travaille pour soi-même.
 Quand on ne sait pas soi-même.
@@ -3194,10 +3224,10 @@ Notre lettre.
 Nos poules.
 Notre panier.
 Notre mère.
-J'écris souvent à mon père.
-Ceci est à ton frère ?
+J’écris souvent à mon père.
+Ceci est à ton frère ?
 Dans ma chambre il y a de belles affiches.
-Il y a de grandes villes dans ton pays ?
+Il y a de grandes villes dans ton pays ?
 Mon chien.
 Ma chienne.
 Mes chiens.
@@ -3206,13 +3236,13 @@ Ma main.
 Son chien.
 Le chien de Janedig.
 Il a eu mal à la jambe.
-Vous êtes venu à pied ?
-Levez le doigt !
+Vous êtes venu à pied ?
+Levez le doigt !
 Elle a mal à la tête.
 Il marchait les mains dans les poches.
-Si vous faites le mouton vous serez tondus.
-Cesse de faire la tête !
-Il ne fait que jouer au caïd depuis qu'il est revenu.
+Si vous faites le mouton vous serez tondu.
+Cesse de faire la tête !
+Il ne fait que jouer au caïd depuis qu’il est revenu.
 Toutes ses envies.
 Leurs cinq sœurs.
 Mon idée.
@@ -3221,28 +3251,27 @@ Son idée.
 Notre idée
 Votre idée.
 Leur idée.
-Cela m'a été dit par un de ses frères.
-Son prix est à 100 euros.
+Cela m’a été dit par un de ses frères.
+Son prix est à cent euros.
 Son toit est rouge.
 Ses chambres sont vastes.
 Et son jardin bien entretenu.
 Prends les trois feuilles qui sont sur la table.
-Vingt personnes étaient venues l'écouter.
+Vingt personnes étaient venues l’écouter.
 Vingt-quatre heures.
 Vingt-et-une voitures bouchaient la route.
-J'ai invité trente cinq enfants à sa fête d'anniversaire.
-On étudiera quatre vingt-douze leçons cette année.
+J’ai invité trente-cinq enfants à sa fête d’anniversaire.
+On étudiera quatre-vingt-douze leçons cette année.
 Il y a une pomme sur la table.
-J'ai acheté des pommes et j'en ai mangé une.
+J’ai acheté des pommes et j’en ai mangé une.
 Une rouge.
 Un rouge.
 Une ou deux fois.
 Trois ou quatre fois.
-Deux filles.
 Trois chaises.
 Quatre leçons.
 Cinquante oiseaux.
-Quatre mille litres d'eau.
+Quatre mille litres d’eau.
 Les vingt avions sont gros.
 Mes deux sœurs sont plus jeunes.
 Cinquante-six bonbons.
@@ -3251,12 +3280,12 @@ Sept cent douze mille six cent soixante-neuf anciens francs.
 Les mères qui ont eu trois enfants.
 Une voiture de six chevaux.
 Trois enfants.
-Soixante douze pour cent.
+Soixante-douze pour cent.
 Cela a été construit il y a vingt-cinq ans.
 Les cinq chaises.
 Un million cinq cents.
-Un million d'enfants.
-Trois millions d'appels téléphoniques.
+Un million d’enfants.
+Trois millions d’appels téléphoniques.
 Trois euros et demi.
 Un mètre et demi.
 Vingt kilos et demi.
@@ -3266,33 +3295,31 @@ Vingt kilos cinq cents grammes.
 Une minute cinquante.
 Une trentaine de kilos de bananes.
 Il y a une quarantaine de personnes sur la place.
-Une douzaine d'œufs de poules.
-La leçon trois.
-La page quarante-quatre.
-Louis XIV.
-Jean-Paul II.
-François 1er.
+Une douzaine d’œufs de poules.
+Louis quatorze.
+Jean-Paul deux.
+François premier.
 Cinquante et unième.
 Soixante-seizième.
-Cent quatre-vingt neuf millième.
+Cent quatre-vingt-neuf millième.
 Deux cent mille deux cent vingt-sixième.
 Le cinquantième.
 Le soixantième.
-C'est le septième film de ce réalisateur.
+C’est le septième film de ce réalisateur.
 Il faudra encore faire un second tour.
 La troisième chanson est beaucoup plus belle.
 Sa troisième chanson est beaucoup plus belle.
 Le vingt-sixième jour.
 Goulven est le premier élève de sa classe.
-C'est écrit sur la dernière page.
+C’est écrit sur la dernière page.
 La troisième porte est ouverte.
-L'avant-dernier
-L'avant-dernière.
+L’avant-dernier.
+L’avant-dernière.
 Le dernier.
 La dernière.
-L'avant avant-dernier.
-L'avant dernier coureur de l'étape.
-Le XVIIème siècle.
+L’avant-avant-dernier.
+L’avant-dernier coureur de l’étape.
+Le dix-septième siècle.
 La dixième partie du tas.
 Le onzième.
 Deux huitièmes.
@@ -3304,11 +3331,11 @@ Le quart.
 Un quart.
 Une cuillerée et demie.
 Une demi-cuillerée.
-Un mètre-carré et quart.
-Un quart de mètre-carré.
+Un mètre carré et quart.
+Un quart de mètre carré.
 Un vingt-et-unième.
 Il est dix heures.
-À quelle heure te lèveras-tu dimanche ?
+À quelle heure te lèveras-tu dimanche ?
 Neuf heures du matin.
 Neuf heures.
 Neuf heures dix.
@@ -3318,7 +3345,7 @@ Neuf heures vingt minutes et trente secondes.
 Neuf heures et demi.
 Dix heures moins le quart.
 Midi.
-Deux heures de l'après-midi.
+Deux heures de l’après-midi.
 Neuf heures du soir.
 Neuf heures cinq du soir.
 Minuit.
@@ -3327,23 +3354,20 @@ Une heure du matin.
 Deux heures après minuit.
 Deux heures du matin.
 Le vote du douze septembre.
-On prélèvera l'argent de votre compte le quinze du mois.
-Le combien sommes-nous ?
+On prélèvera l’argent de votre compte le quinze du mois.
+Le combien sommes-nous ?
 Le premier mai.
-Le dimanche 24 février 2008.
-Le mardi 18 mars.
+Le dimanche vingt-quatre février deux mille huit.
+Le mardi dix-huit mars.
 Un jeudi.
-Le contenu d'un mercredi de travail.
+Le contenu d’un mercredi de travail.
 Cette route mène au port.
 Ce Benoni est têtu.
 Cette maison.
-cette année.
+Cette année.
 Cette année-là.
 Cette maison là-bas.
 En cette année-là.
-Ceux-ci.
-Ceux-là.
-Ceux-là là-bas.
 Celles-ci.
 Celles-là.
 Celles-là là-bas.
@@ -3354,15 +3378,15 @@ Cette grande personne-là.
 Cette grande maison blanche-là.
 Cette voiture rouge flambant neuve là-bas.
 Ce dernier article.
-C'est clair comme de l'eau de roche.
-Ça c'est être connu !
-Elle n'a pas pas parlé de ça avec toi ?
+C’est clair comme de l’eau de roche.
+Ça c’est être connu !
+Elle n’a pas parlé de ça avec toi ?
 Ceci étant dit…
 Malgré cela.
 À cause de cela.
 Par conséquent.
 Ainsi donc.
-L'arbre est aussi haut que ça maintenant.
+L’arbre est aussi haut que ça maintenant.
 Prends celui qui te plaît.
 Le petit est amusant.
 Jette ceux qui sont pourris.
@@ -3374,7 +3398,7 @@ Ce grand-ci.
 Cette petite-là.
 Ce petit-là.
 Ce grand-là.
-Voici ce qu'il écrivit.
+Voici ce qu’il écrivit.
 À telle ou telle heure.
 Telle ou telle personne.
 Tel ou tel jour.
@@ -3383,24 +3407,24 @@ Tel ou tel.
 Telle ou telle.
 Un tel.
 Une telle.
-Çà et là
+Çà et là.
 Et patati et patata.
 Un tas de livres.
 Une marée humaine.
-Un certains nombre d'hurluberlus.
+Un certains nombre d’hurluberlus.
 Tout le monde sait ça.
 Dans chaque commune il y a une mairie.
 Tous ceux qui étaient là-bas ce jour-là virent son frère.
-Tous ces jouets sont à toi ?
+Tous ces jouets sont à toi ?
 Il avait passé tout son temps à jouer aux cartes.
-Tout le monde était venu voir ce qui s'était passé.
-Tu as perdu tout ton argent ?
+Tout le monde était venu voir ce qui s’était passé.
+Tu as perdu tout ton argent ?
 Tout Rennes est content du résultat du match.
 Le pays tout entier avait été pillé.
 Tout ce monde-ci.
-J'ai envie de voir ce monde magnifique en entier.
-Ce ne sont que des mensonges !
-Rien que des idioties !
+J’ai envie de voir ce monde magnifique en entier.
+Ce ne sont que des mensonges !
+Rien que des idioties !
 Nous étions allés en ville, nous tous.
 Morgan est tout content.
 Ton pull est tout crotté.
@@ -3408,191 +3432,191 @@ Il a acheté de beaux vêtements pour nous tous.
 On les verra tous à cette fête sans doute.
 Nous avons tous dix-huit ans.
 Nous viendrons tous.
-Je crois qu'ils viendront tous.
+Je crois qu’ils viendront tous.
 Dans le monde entier il y a riches et des pauvres.
-Ne me dis pas que tu as complètement oublié d'acheter du pain !
-Ton travail est mauvais, il faut que tu le refasse entièrement.
-Tu as lu le livre entièrement ?
+Ne me dis pas que tu as complètement oublié d’acheter du pain !
+Ton travail est mauvais, il faut que tu le refasses entièrement.
+Tu as lu le livre entièrement ?
 Elle est entièrement tombée dans la mare.
 Il est entièrement tombé dans la mare.
-C'est le mieux à faire.
-C'est ça le plus inquiétant.
+C’est le mieux à faire.
+C’est ça le plus inquiétant.
 Il y avait de belles fleurs dans tous les jardins.
 Tout le monde est bien habillé ce soir.
 Ils ont chacun un chapeau.
 Les enfants ont tous eu une part de gâteau.
-Vous prendrez tous un café ?
-On donnera trois livres à chacun.
+Vous prendrez tous un café ?
+On leur donnera trois livres à chacun.
 Les invités ont eu chacun leur tasse de café.
 Nous, nous avons fait chacun notre travail.
-Après le jeu, il ne leur en restait qu'un seul à chacun.
+Après le jeu, il ne leur en restait qu’un seul à chacun.
 Il rentre à la maison tous les deux jours.
 Il regardait sa montre toutes les cinq minutes.
-Ils n'écoutent la radio que de temps en temps.
+Ils n’écoutent la radio que de temps en temps.
 De temps en temps il fait froid ici.
 Il reprenait sa respiration à chaque pas.
-Il s'était cassé la jambe et ce n'était pas le pire de ce qui lui été arrivé.
-J'ai appris l'essentiel.
+Il s’était cassé la jambe et ce n’était pas le pire de ce qui lui été arrivé.
+J’ai appris l’essentiel.
 Le plus facile serait de ne rien faire.
 La plupart des gens ne font que se plaindre.
 Elle allait à chaque maison où il y avait encore de la lumière.
-Toutes les personnes qui sont venus en train seront défrayées.
-Il allait à la plage toutes les fois qu'il venait au pays.
-Ils ont contredit tout ce que j'avais moi-même dit.
-Il avait été émerveillé par tout ce qu'elle avait vu.
+Toutes les personnes qui sont venues en train seront défrayées.
+Il allait à la plage toutes les fois qu’il venait au pays.
+Ils ont contredit tout ce que j’avais moi-même dit.
+Il avait été émerveillé par tout ce qu’elle avait vu.
 Tout ce que vous apporterez sera bienvenu.
 Tout ceci avait déjà été dit.
-Je n'avais jamais entendu parler de tout cela !
-Et si vous en aviez vu tout autant vous n'en seriez pas plus content.
+Je n’avais jamais entendu parler de tout cela !
+Et si vous en aviez vu tout autant vous n’en seriez pas plus content.
 Tous les enfants.
 En tout.
 Du travail tout fait.
 Tout a été vendu.
-Elle était morte d'inquiétude.
-Il était mort d'inquiétude.
+Elle était morte d’inquiétude.
+Il était mort d’inquiétude.
 Ils ont mangé plein leur ventre.
 Nombre de gens donnent leur avis trop hâtivement.
 Plein de monde attendait le train.
 Ils avaient apporté plein de choses.
-Beaucoup d'entre eux sont vieux.
+Beaucoup d’entre eux sont vieux.
 Beaucoup de gens ne vous montrent pas leur affliction.
 Beaucoup partiront avant la nuit.
-Beaucoup n'ont même aucune maison.
+Beaucoup n’ont même aucune maison.
 Ils étaient venus nombreux le voir.
-Ma mère m'a beaucoup aidé.
-J'entendis alors de nombreuses plaintes.
+Ma mère m’a beaucoup aidé.
+J’entendis alors de nombreuses plaintes.
 Son cœur est plein de méchanceté.
 Nous avons largement le temps de faire une promenade.
-On s'inquiète énormément pour eux.
+On s’inquiète énormément pour eux.
 Il parlait énormément à la maison.
-J'ai largement préféré le livre au film.
+J’ai largement préféré le livre au film.
 Ce téléphone est largement meilleur que celui-là.
 Il y aura beaucoup de monde au fest-noz samedi.
 Il y aura plein de monde au fest-noz samedi.
-Il n'avait pas beaucoup travaillé l'anné dernière.
+Il n’avait pas beaucoup travaillé l’année dernière.
 On lui a fait payer cher son forfait.
 On avait beaucoup donné aux impôts.
-Il n'y a pas eu beaucoup de pluie.
+Il n’y a pas eu beaucoup de pluie.
 Je sais cela beaucoup mieux que toi.
-Ils avaient mal au ventre parce qu'ils avaient beaucoup trop mangé.
+Ils avaient mal au ventre parce qu’ils avaient beaucoup trop mangé.
 Beaucoup sont venus en voiture.
-Beaucoup entendront ce que j'ai à dire.
+Beaucoup entendront ce que j’ai à dire.
 Beaucoup ont crié de peur.
 Beaucoup de renards étaient venus manger les poules du paysan.
 La majorité du travail a été faite.
-J'ai suffisamment d'or.
+J’ai suffisamment d’or.
 Ils avaient eu suffisamment de chagrin.
-J'ai assez d'or.
+J’ai assez d’or.
 Ils avaient eu assez de chagrin.
-Nous n'aurons pas assez de temps pour aller voir ta sœur.
+Nous n’aurons pas assez de temps pour aller voir ta sœur.
 Il y a eu suffisamment de pluie cet hiver.
 Je lui ai donné suffisamment de livres pour monter une bibliothèque convenable.
 Nous avons assez attendu comme ça.
 Ils peinent suffisamment à élever leurs enfants.
 Ce que vous dites est plutôt vrai.
 Ils sont assez loin maintenant.
-Tu reprendras de la viande ?
-Tu auras de la viande ?
-Non, j'en ai mangé suffisamment.
+Tu reprendras de la viande ?
+Tu auras de la viande ?
+Non, j’en ai mangé suffisamment.
 Il a suffisamment à faire avec son travail.
 Il avait joué et remporta suffisamment pour acheter un nouveau vélo.
 Il acheta suffisamment pour lire pendant dix ans.
 Ils étaient assez pour former une équipe de volley.
-Tu as acheté suffisamment de vêtement maintenant.
-Il n'a pas suffisamment de cheveux pour lui plaire.
-Tu as de l'argent ?
-Oui, j'en ai suffisamment pour payer le repas.
-Ils n'en ont jamais assez.
+Tu as acheté suffisamment de vêtements maintenant.
+Il n’a pas suffisamment de cheveux pour lui plaire.
+Tu as de l’argent ?
+Oui, j’en ai suffisamment pour payer le repas.
+Ils n’en ont jamais assez.
 Plusieurs enfants pleuraient dans la salle.
 Elle avait attendu plusieurs années avant de vendre sa maison.
 Ils étaient venus plusieurs fois au pays.
-Des centaines d'années s'étaient écoulées.
-Plusieurs terres avaient été laisser en jachère.
-N'y a-t-il pas là de quoi faire perdre la tête à plus d'un ?
-J'en vois plus d'un venir par la route.
-Plusieurs sortes de gens avaient dis la même chose.
+Des centaines d’années s’étaient écoulées.
+Plusieurs terres avaient été laissées en jachère.
+N’y a-t-il pas là de quoi faire perdre la tête à plus d’un ?
+J’en vois plus d’un venir par la route.
+Plusieurs sortes de gens avaient dit la même chose.
 Plusieurs ne sont pas venus jusque chez moi.
-Plus d'un d'entre nous ne chantera pas.
-Plus d'une d'entre vous ne marchait pas suffisamment vite.
-Plus d'un avait mangé sa part.
+Plus d’un d’entre nous ne chantera pas.
+Plus d’une d’entre vous ne marchait pas suffisamment vite.
+Plus d’un avait mangé sa part.
 Plusieurs personnes étaient venues me voir.
-J'avais acheté plusieurs choses.
+J’avais acheté plusieurs choses.
 Je suis venu par plusieurs chemins.
 Beaucoup de gens sont restés là-bas.
 Il y a peu de froment cette année.
-Je ne pourrai rien faire avec si peu d'argent.
+Je ne pourrai rien faire avec si peu d’argent.
 Maintenant nous somme peu de monde.
-J'ai quelques livres qui traitent de l'informatique.
-J'aime l'informatique.
-Il n'est pas compétent en informatique.
-Les quelques rares nouvelles qu'elle m'avait envoyées n'étaient pas très bonnes.
+J’ai quelques livres qui traitent de l’informatique.
+J’aime l’informatique.
+Il n’est pas compétent en informatique.
+Les quelques rares nouvelles qu’elle m’avait envoyées n’étaient pas très bonnes.
 Ils vivent de peu.
 Peu sont venus manger ce soir.
 Il y a beaucoup de nourriture sur la table.
 On leur en donnera peu cependant.
-Peu de gens ne sont pas vêtu de rouge.
-Quelques choses n'avaient pas été faites.
+Peu de gens ne sont pas vêtus de rouge.
+Quelques choses n’avaient pas été faites.
 Peu ne rient pas.
-J'ai trop peu d'argent pour acheter une maison.
-J'ai trop peu d'argent pour acheter un char.
-J'ai bien peu confiance en lui.
+J’ai trop peu d’argent pour acheter une maison.
+J’ai trop peu d’argent pour acheter une voiture.
+J’ai bien peu confiance en lui.
 Il est vraiment préoccupé.
-C'est vraiment beau.
-C'est vraiment problématique.
-C'est problématique.
+C’est vraiment beau.
+C’est vraiment problématique.
+C’est problématique.
 Il est vraiment grand.
-C'est vraiment grand.
+C’est vraiment grand.
 Elle est vraiment grande.
 Ils étaient trop peu pour faire ce travail.
 Tu manges bien peu.
-Top peu sont venus nous donner un coup de main.
+Trop peu sont venus nous donner un coup de main.
 Tu en as emporté bien peu.
-Il n'y a pas de chat dans le jardin.
-Il n'y a pas de bus aujourd'hui.
-Il n'y aura personne au bureau demain.
+Il n’y a pas de chat dans le jardin.
+Il n’y a pas de bus aujourd’hui.
+Il n’y aura personne au bureau demain.
 Ils étaient venus sans outil.
 Ils étaient venus sans aucun outil.
-Ils étaient venus sans chaise
+Ils étaient venus sans chaise.
 Ils étaient venus sans aucune chaise.
-Elles étaient venus sans outil.
-Elles étaient venus sans aucun outil.
-Elles étaient venus sans chaise
-Elles étaient venus sans aucune chaise.
+Elles étaient venues sans outil.
+Elles étaient venues sans aucun outil.
+Elles étaient venues sans chaise.
+Elles étaient venues sans aucune chaise.
 Pas une goutte.
-Il n'y a pas un souffle de vent ce matin.
+Il n’y a pas un souffle de vent ce matin.
 Ces gens-là ne mangent pas du tout de fruits.
 Ces gens-là ne mangent pas du tout de viande.
-Il n'y en a plus aucun.
-Il n'en reste plus aucun.
-Il n'en reste plus aucune.
+Il n’y en a plus aucun.
+Il n’en reste plus aucun.
+Il n’en reste plus aucune.
 Rien.
 Rien du tout.
 De rien.
 Nulle part.
 Absolument nulle part.
 Je ne comprends rien.
-Il y avait plus de trois cent personnes dans la salle.
+Il y avait plus de trois cents personnes dans la salle.
 Elle a plus de deux sœurs.
 Il a plus de deux sœurs.
 Il avait attendu plus de sept heures.
 Elle avait attendu plus de sept heures.
-Il n'y avait pas que des chiens qui hurlaient.
+Il n’y avait pas que des chiens qui hurlaient.
 En plus de savoir dessiner il sait aussi écrire.
-Plus d'un avait été pris.
-Il n'y a pas que des écrivains dans la salle.
+Plus d’un avait été pris.
+Il n’y a pas que des écrivains dans la salle.
 Il nous faut plus que vous remercier.
-Il n'y avait pas que des marins qui étaient venus à la fête de Douarnenez.
-Ma tante vient me rendre visite plus d'une fois par an.
+Il n’y avait pas que des marins qui étaient venus à la fête de Douarnenez.
+Ma tante vient me rendre visite plus d’une fois par an.
 Je ne comprenais rien.
-Il n'y a pas que ta mère qui sait faire de bons gâteaux.
-Je pars en vacances plus d'une fois par an.
+Il n’y a pas que ta mère qui sait faire de bons gâteaux.
+Je pars en vacances plus d’une fois par an.
 Il y a quelques rares maisons au sommet de la montagne.
 Il a mangé quelques menus fruits pour son dîner.
 Il a mangé quelques menus fruits au dîner.
 Elle a mangé quelques menus fruits pour son dîner.
 Elle a mangé quelques menus fruits au dîner.
-J'ai bu quelques gorgées d'eau avant de partir.
-J'ai bu quelques gorgées d'eau avant de sortir.
+J’ai bu quelques gorgées d’eau avant de partir.
+J’ai bu quelques gorgées d’eau avant de sortir.
 Ils ont trouvé quelques terres à acheter en centre Bretagne.
 Un morceau de pain.
 Un morceau de bois.
@@ -3604,28 +3628,28 @@ Il y a environ dix personnes dans mon bureau.
 Il y a environ dix personnes dans le bureau.
 Il pouvait peut-être avoir dans les soixante ans.
 Une trentaine de femmes.
-A-t-il quelque excuse pour être en retard ?
+A-t-il quelque excuse pour être en retard ?
 Il est allé se promener quelque part.
 Il doit être quelque part.
 Il devait être quelque part.
 Il devra être quelque part.
 Le nid de la pie doit probablement être dans un grand arbre quelconque.
 Quelque chose.
-Quelqu'un.
+Quelqu’un.
 Une personne.
-Montre moi quelqu'un.
+Montre-moi quelqu’un.
 Quelque chose de neuf.
 Quelque chose de nouveau.
-S'il y a des problèmes il faut le dire.
-S'il y a le temps c'est bien.
-S'il n'y a pas le temps ce n'est pas bien.
-S'il n'y a pas de problème ce n'est pas la peine de le dire.
-S'il n'y a pas de problème il faut le dire aussi.
-Il est connu d'autres personnes.
+S’il y a des problèmes il faut le dire.
+S’il y a le temps c’est bien.
+S’il n’y a pas le temps ce n’est pas bien.
+S’il n’y a pas de problème ce n’est pas la peine de le dire.
+S’il n’y a pas de problème il faut le dire aussi.
+Il est connu d’autres personnes.
 Il est connu des autres.
-Il y a d'autres chaises ici.
-Il y a d'autres grands singes comme les chimpanzés et les orangs-outans.
-Il n'a pas respecté les règles.
+Il y a d’autres chaises ici.
+Il y a d’autres grands singes comme les chimpanzés et les orangs-outans.
+Il n’a pas respecté les règles.
 Il faut respecter les personnes.
 Notre sang et notre maison.
 Une part de notre histoire et de notre mémoire.
@@ -3654,7 +3678,7 @@ Quatre sonneurs.
 Les frères.
 Deux frères.
 Cinq frères.
-Améliorer l'état des choses.
+Améliorer l’état des choses.
 Comprendre la vie des gens.
 Il ne comprend pas la vie des gens.
 Développer les compétences humaines.
@@ -3662,41 +3686,41 @@ Développer les compétences des gens.
 Acheter le territoire commun.
 Diffuser à tous.
 Diffuser aux personnes qui ont participé.
-Quel jour téléphonera-t-il donc ?
-Quelle genre de robe mettrais-tu donc pour aller à la soirée ?
-Combien y a-t-il de personnes environ ?
-Combien y a-t-il  de personnes ?
-Combien coûte ce tableau environ ?
-Quand iras-tu en vacances environ ?
-Combien de temps était-il resté en Alaska environ ?
-Pourquoi donc es-tu allé raconter des mensonges ?
-Où donc étiez-vous resté traîner ?
-Comment donc avez-vous su cela ?
-J'aimerais savoir quand donc tu pourras venir avec nous ?
+Quel jour téléphonera-t-il donc ?
+Quelle genre de robe mettrais-tu donc pour aller à la soirée ?
+Combien y a-t-il de personnes environ ?
+Combien y a-t-il  de personnes ?
+Combien coûte ce tableau environ ?
+Quand iras-tu en vacances environ ?
+Combien de temps était-il resté en Alaska environ ?
+Pourquoi donc es-tu allé raconter des mensonges ?
+Où donc étiez-vous resté traîner ?
+Comment donc avez-vous su cela ?
+J’aimerais savoir quand donc tu pourras venir avec nous ?
 Peu importe lequel tu prendras je serai content de te le donner.
 Peu importe lesquels vous apporterez, ils nous conviendront.
 Peu importe combien il empochera, cela ne lui suffira jamais.
 Peu importe combien de temps je devrai travailler, je lui rembourserai son argent.
-Peu importe ce pourquoi tu es venu, je n'ai pas le temps de parler avec toi.
+Peu importe ce pourquoi tu es venu, je n’ai pas le temps de parler avec toi.
 Quiconque lira comprendra tout de suite.
 Quiconque viendra sera le bienvenu.
-Quelque vite qu'il puisse courir, il est trop tard.
+Quelque vite qu’il puisse courir, il est trop tard.
 Aussi grand soit-il, il ne parvient pas à prendre la pomme de cette haute branche.
-Bien qu'il fût fatigué, il continuait à travailler.
-Bien qu'il fût en colère, il essayait de se calmer.
-Bien qu'il soit venu jusqu'ici, il ne trouvera rien.
-Quand donc iras-tu en vacances ?
+Bien qu’il fût fatigué, il continuait à travailler.
+Bien qu’il fût en colère, il essayait de se calmer.
+Bien qu’il soit venu jusqu’ici, il ne trouvera rien.
+Quand donc iras-tu en vacances ?
 Je ne trouve aucune graine dans ce champ.
 Là-bas, aucun arbre ne pousse.
-Bien qu'il eût fait une grave erreur, il s'en retourna sans aucune honte.
-On peut courir à n'importe quelle période de l'année.
-Voici une œuvre qui me plaît plus qu'aucune autre.
-J'achèterai une autre maison quand j'aurai de l'argent.
+Bien qu’il eût fait une grave erreur, il s’en retourna sans aucune honte.
+On peut courir à n’importe quelle période de l’année.
+Voici une œuvre qui me plait plus qu’aucune autre.
+J’achèterai une autre maison quand j’aurai de l’argent.
 Ton autre manteau est dans le couloir.
-Quand viendront les autres personnes ?
-Vous mangerez quelque chose d'autre ?
-Ils mangent quelque chose d'autre ?
-Personne d'autre.
+Quand viendront les autres personnes ?
+Vous mangerez quelque chose d’autre ?
+Ils mangent quelque chose d’autre ?
+Personne d’autre.
 Cette autre chose.
 Une quelconque autre maison.
 Un quelconque autre livre.
@@ -3704,29 +3728,29 @@ Un autre livre.
 Aussi grand.
 Tout aussi grand.
 Pour un peu, je serais tombé.
-Pour un peu, j'aurais commis une erreur.
+Pour un peu, j’aurais commis une erreur.
 Il est facile de commettre des erreurs.
 Il est facile de se tromper.
 Tu te trompes.
 Il se trompe.
 Je me trompe souvent quand je suis pressé.
-Tu es pressé d'être arrivé ?
-C'est incroyable !
+Tu es pressé d’être arrivé ?
+C’est incroyable !
 Et cet autre-ci qui pensait avoir fait un beau coup.
 Et cet autre-ci qui vient vous embêter.
-Et qu'est-ce j'avais vu alors ?
-Cette autre -ci en train de danser avec lui !
-Des pommes de terres en robe des champs.
-Donnez-moi l'autre.
+Et qu’est-ce j’avais vu alors ?
+Cette autre-ci en train de danser avec lui !
+Des pommes de terre en robe des champs.
+Donnez-moi l’autre.
 Donnez-moi les autres.
-L'un rit, l'autre pleure.
-Celle-ci est sereine et l'autre est angoissée.
-Celle-ci est sereine et l'autre est angoissé.
-Celui-ci est serein et l'autre est angoissée.
-Celui-ci est serein et l'autre est angoissé.
+L’un rit, l’autre pleure.
+Celle-ci est sereine et l’autre est angoissée.
+Celle-ci est sereine et l’autre est angoissé.
+Celui-ci est serein et l’autre est angoissée.
+Celui-ci est serein et l’autre est angoissé.
 Je ne suis pas à même de vous répondre.
 Il sera à même de vous en dire plus.
-Que le temps soit beau ou pas ce n'est pas grave.
+Que le temps soit beau ou pas ce n’est pas grave.
 Que les gens prennent leur temps ou non ça ne changera rien.
 Que les gens prennent leur temps ou pas ça ne changera rien.
 Diffuser la bonne nouvelle auprès des gens.
@@ -3734,38 +3758,38 @@ Diffuser la bonne nouvelle aux gens.
 Si le vent faiblit.
 Si la force me manque.
 Si tout le monde se met ensemble pour danser on y arrivera.
-Si les gens s'ennuient ils peuvent toujours éteindre la télé et aller se promener.
-Je ne suis pas sûr d'avoir éteint la télé avant de sortir.
-Je ne suis pas sûr d'avoir éteint la lumière avant de sortir.
+Si les gens s’ennuient ils peuvent toujours éteindre la télé et aller se promener.
+Je ne suis pas sûr d’avoir éteint la télé avant de sortir.
+Je ne suis pas sûr d’avoir éteint la lumière avant de sortir.
 Si le jardin de Douarnenez avait été nettoyé le site aurait été mieux conservé.
-Il y a des débutants ?
-Combien de débutants y a-t-il dans la classe ?
-Le soleil s'est couché.
+Il y a des débutants ?
+Combien de débutants y a-t-il dans la classe ?
+Le soleil s’est couché.
 Le soleil se couche tous les soirs.
-Son métier est d'élaguer les arbres.
+Son métier est d’élaguer les arbres.
 On lui a rendu hommage.
-Il peut passer de 2 à 3 km heure en une seconde.
+Il peut passer de deux à trois kilomètres-heure en une seconde.
 En un mois de temps on peut tout détruire.
 En une année de temps il avait réussi à construire sa maison.
 Tu devras venir le plus vite possible.
-La réparation de la maison est prévu au plus vite.
-La bataille a eu lieu le 7 septembre 1492.
-La bataille s'est déroulée le 7 septembre 1492.
+La réparation de la maison est prévue au plus vite.
+La bataille a eu lieu le sept septembre quatorze cent quatre-vingt-douze.
+La bataille s’est déroulée le sept septembre mille quatre cent quatre-vingt-douze.
 Un futur lointain.
 Une chance lointaine.
 Il faudra acheter des chaussons.
 Mettre ses chaussures à ses pieds.
 Tourner sur lui-même.
-Tourner sur elle-même
-Mis à part le directeur de l'entreprise, ils sont tous partis.
+Tourner sur elle-même.
+Mis à part le directeur de l’entreprise, ils sont tous partis.
 Bien des communes sont mal équipées.
-Plus d'une commune est mal équipée.
-Je m'efforce d'épargner mes forces.
+Plus d’une commune est mal équipée.
+Je m’efforce d’épargner mes forces.
 Elle a pénétré dans la chambre.
 Il a pénétré dans la chambre.
 Elle est entrée dans la chambre.
 Il est entré dans la chambre.
-Il est interdit d'entrer.
+Il est interdit d’entrer.
 Les fraises les plus fraîches.
 La meilleure viande.
 Le livre le plus jaune.
@@ -3778,11 +3802,11 @@ Le plus jaune.
 Les plus jaunes.
 Le plus vieux.
 Le plus ancien.
-La plus vieille
+La plus vieille.
 La plus ancienne.
 Les plus vieux.
 Les plus anciens.
-Les plus vielles.
+Les plus vieilles.
 Les plus anciennes.
 Le plus long.
 La plus longue.
@@ -3794,23 +3818,23 @@ La feuille la plus longue.
 Les feuilles les plus longues.
 Les uns et les autres.
 Les unes et les autres.
-Donne une poire à l'une aussi bien qu'à l'autre.
-Ils s'aiment l'un l'autre.
-Ils s'écrivent l'un à l'autre.
-Aller se cogner l'une contre l'autre.
-J'ai le même jeu à la maison.
-La soirée a été préparée de la même manière que l'année dernière.
-Je n'avais jamais vu pareille chose.
+Donne une poire à l’une aussi bien qu’à l’autre.
+Ils s’aiment l’un l’autre.
+Ils s’écrivent l’un à l’autre.
+Aller se cogner l’une contre l’autre.
+J’ai le même jeu à la maison.
+La soirée a été préparée de la même manière que l’année dernière.
+Je n’avais jamais vu pareille chose.
 Tel père, tel fils.
 On vous demandera la même chose.
 Ils arrivèrent en même temps.
-Je n'ai pas envie d'avoir le même manteau que toi.
+Je n’ai pas envie d’avoir le même manteau que toi.
 Le même que le tien.
-Son opinion est la même maintenant que celle qu'il avait autrefois.
-Je n'aime pas ce genre de personnes.
+Son opinion est la même maintenant que celle qu’il avait autrefois.
+Je n’aime pas ce genre de personnes.
 Ce genre de choses ne se vend pas bien.
-J'aimerais bien avoir une maison telle que celle-là.
-J'aimerais bien avoir un travail tel que celui-là.
+J’aimerais bien avoir une maison telle que celle-là.
+J’aimerais bien avoir un travail tel que celui-là.
 Un grand garçon.
 La petite cuillère.
 De petites voitures rouges.
@@ -3827,46 +3851,45 @@ Une histoire vraie.
 Une véritable histoire.
 Cette foutue bagnole est encore en panne.
 Ce sale vieux chien.
-Un demi tour.
+Un demi-tour.
 Un tour et demi.
-Un demi-heure.
+Une demi-heure.
 Une heure et demie.
 En bref.
 En bref, je démissionne.
 Il est parti dans des pays lointains.
 Peu de chose.
 À force de temps.
-C'est un homme porté à dire la vérité.
+C’est un homme porté à dire la vérité.
 Un gars qui ne ressemble pas à son père.
-Une bouteille pleine d'eau.
-Cet homme, porté à dire la vérité, me plaît.
+Une bouteille pleine d’eau.
+Cet homme, porté à dire la vérité, me plait.
 Cet écrivain, connu pour ses pièces de théâtre, a également écrit un roman.
 Il fait beau.
 Le beau temps.
 Ses cheveux sont noirs, longs et brillants.
 Le grand-père est fatigué.
 Le temps est beau.
-Le grand-père n'est pas fatigué.
+Le grand-père n’est pas fatigué.
 Les grands-pères ne sont pas fatigués.
 Hier, le grand-père était fatigué.
 Le temps était effectivement beau.
 Il ne fait pas beau.
-La chaise est cassé.
+La chaise est cassée.
 Le magasin est ouvert.
 Il a sauté sur le lit et maintenant il est cassé.
 La porte a été ouverte, elle est ouverte maintenant.
 Il est décédé à onze heures, il est mort.
-C'est obligé.
-Les feuilles ont été entassés, des feuilles entassés.
+C’est obligé.
+Les feuilles ont été entassées, des feuilles entassées.
 Rouge foncé.
 Rouge vif.
 Nouveau-né.
 Bien connu.
 Du bon.
 Le malade.
-La malade
+La malade.
 La femme malade.
-Les malades.
 Un grand.
 Une grande.
 Deux grands.
@@ -3875,46 +3898,46 @@ Quatre grands.
 Quatre grandes.
 Un beau brin de fille.
 Un métier bien facile.
-J'étais trempé de sueur tant j'avais chaud.
+J’étais trempé de sueur tant j’avais chaud.
 Il ne voyait rien tant la nuit était sombre.
 La maison est plutôt jolie.
 Le chemin est plutôt long.
-C'est un homme plutôt grand.
+C’est un homme plutôt grand.
 Le tas sera un peu plus grand.
-J'ai beaucoup de mal à me lever.
-J'ai une grande douleur au bras.
-J'ai beaucoup de mal à croire qu'il a été enlevé.
-J'ai une douleur au bras.
-J'ai du mal à croire ce que tu m'expliques.
+J’ai beaucoup de mal à me lever.
+J’ai une grande douleur au bras.
+J’ai beaucoup de mal à croire qu’il a été enlevé.
+J’ai une douleur au bras.
+J’ai du mal à croire ce que tu m’expliques.
 Les trous sont nombreux par ici.
 Les gens ne sont pas nombreux.
 Les gens sont peu nombreux.
 Les roses sont très abondantes.
 Les gens qui savent sont peu nombreux.
-À partir de 845 jusqu'à 978
-De 845 à 978
+À partir de huit cent quarante-cinq jusqu’à neuf cent septante-huit.
+De huit cent quarante-cinq à neuf cent soixante-dix-huit.
 Il faut que tu mettes ça en place.
 Tu doit mettre ça en place.
-Il s'occupe d'une grande charge.
-Cet endroit me plaît.
-Cet endroit me plaît, qu'on y vende des maisons ou non.
+Il s’occupe d’une grande charge.
+Cet endroit me plait.
+Cet endroit me plait, qu’on y vende des maisons ou non.
 Je vais directement à la maison.
 Il ira directement à la maison.
-Deux points d'avance.
-Tu as été invité ou pas ?
+Deux points d’avance.
+Tu as été invité ou pas ?
 Il va inviter les gens.
 Prier Dieu.
 Prier Jésus.
 Prier la Vierge.
 Il a invité beaucoup de monde.
-Cela n'a pas de fin si l'on doit inviter tout le monde.
+Cela n’a pas de fin si l’on doit inviter tout le monde.
 Vous serez laissés de côté.
 La règle a été mise en biais.
-J'écris des livres.
+J’écris des livres.
 Le gâteau est fait avec de la farine et des œufs.
-Les gâteaux sont fait avec de la farine et des œufs.
+Les gâteaux sont faits avec de la farine et des œufs.
 La route est bloquée.
-La route n'est pas bloquée.
+La route n’est pas bloquée.
 La route a été débloquée.
 Les routes sont peu nombreuses dans ce pays.
 Il faut ratifier la Charte européenne des langues.
@@ -3925,30 +3948,30 @@ Il est absolument indispensable de ratifier la Charte européenne des langues.
 Il est absolument nécessaire de ratifier la Charte européenne des langues.
 Les gens les plus frappés.
 Les gens les plus durement frappés.
-On l'a frappé.
-Il l'a frappé.
+On l’a frappé.
+Il l’a frappé.
 Il a été frappé.
-J'ai été frappé.
-J'ai été frappé par leurs opinions tranchées.
+J’ai été frappé.
+J’ai été frappé par leurs opinions tranchées.
 Ils ont été frappés par la crise.
-La crise les a frappé.
-La crise les a durement frappé.
-Ils ont été durement frappé par la crise.
+La crise les a frappés.
+La crise les a durement frappés.
+Ils ont été durement frappés par la crise.
 Les choses ont été facilitées.
-C'est respectueux de l'environnement.
-C'est plus respectueux.
+C’est respectueux de l’environnement.
+C’est plus respectueux.
 Il est plus respectueux.
-Cela te plaira
+Cela te plaira.
 Cette maison te plaira.
 Il respire de travers.
 Malheureusement pour moi.
-Il s'est cogné la tête contre le mur.
-Il s'est cogné le pied contre la porte.
-Elle s'est cognée le bras contre les escaliers.
+Il s’est cogné la tête contre le mur.
+Il s’est cogné le pied contre la porte.
+Elle s’est cognée le bras contre les escaliers.
 Je ne les ai pas trouvés.
-Les as-tu trouvés ?
+Les as-tu trouvés ?
 Quand je les aurai trouvés je vous dirai.
-Le gâteau est fait avec de l'eau.
+Le gâteau est fait avec de l’eau.
 Au sud de Quimper il y a une croix.
 Ce serait une aide pour eux.
 Ce serait une aide pour toi.
@@ -3964,15 +3987,15 @@ Ils se sont battus.
 Les femmes se sont battues.
 Une quarantaine de personnes.
 Une vingtaine de joueurs.
-Une trentaine d'étudiants.
+Une trentaine d’étudiants.
 Une cinquantaine de policiers.
-Une quinzaine d'hurluberlus.
+Une quinzaine d’hurluberlus.
 Les choses ont été grandement facilitées.
-Trois point d'avance.
+Trois points d’avance.
 Il faut apporter du changement.
 Ça apporte du changement.
 Un grand changement.
-Il y a eu de grands changement.
+Il y a eu de grands changements.
 Il apprend bien.
 Elle apprend bien.
 Tu apprends bien tes leçons.
@@ -3985,9 +4008,9 @@ On met le linge au panier.
 On met la musique trop fort.
 Et comme ça les choses sont faites.
 Et comme ça on perd du temps.
-Et c'est comme ça que les choses sont faites.
-Et c'est comme ça qu'on perd du temps.
-J'écrivis une lettre.
+Et c’est comme ça que les choses sont faites.
+Et c’est comme ça qu’on perd du temps.
+J’écrivis une lettre.
 Je lui écrivis une lettre.
 Il écrivit une lettre.
 Il lui écrivit une lettre.
@@ -4004,20 +4027,20 @@ Mettre un but.
 Le doigt marque la direction.
 Le doigt rouge marque la direction.
 Le cubisme est un art moderne.
-Le cubisme c'est de l'art moderne.
-Qu'est ce qu'il est devenu ?
+Le cubisme c’est de l’art moderne.
+Qu’est-ce qu’il est devenu ?
 Il est devenu amer.
 Yann traversa la mer.
 Au nord du talus il y a des arbres.
-À l'est du talus il y a des arbres.
+À l’est du talus il y a des arbres.
 Au sud-ouest du talus il y a des arbres.
 Au sud du talus il y a des arbres.
 Au nord-ouest du talus il y a des arbres.
 Au nord-est du talus il y a des arbres.
-Ils ont trouvés un emploi.
-Qui trouvera un emploi dans cette ville ?
+Ils ont trouvé un emploi.
+Qui trouvera un emploi dans cette ville ?
 Des panneaux totalement bilingues.
-J'entendais les grenouilles.
+J’entendais les grenouilles.
 Tu entendais les grenouilles.
 Elle entendait les grenouilles.
 Il entendait les grenouilles.
@@ -4025,7 +4048,7 @@ Il entendait les grenouilles.
 À certains endroits il y a des manques.
 Dans certains pays.
 Dans certaines maisons.
-Dans certaines maisons il fait froid durant l'hiver.
+Dans certaines maisons il fait froid durant l’hiver.
 Un autre animal.
 Une autre chaise.
 Un autre grand animal.
@@ -4034,14 +4057,14 @@ Un autre animal jaune.
 Une autre chaise jaune.
 Un autre grand animal jaune.
 Une autre grande chaise jaune.
-D'autres animaux.
-D'autres chaises.
-D'autres grands animaux.
-D'autres grandes chaises
-D'autres animaux jaunes.
-D'autres chaises jaunes.
-D'autres grands animaux jaunes.
-D'autres grandes chaises jaunes.
+D’autres animaux.
+D’autres chaises.
+D’autres grands animaux.
+D’autres grandes chaises.
+D’autres animaux jaunes.
+D’autres chaises jaunes.
+D’autres grands animaux jaunes.
+D’autres grandes chaises jaunes.
 Ils ont mal travaillé.
 Il ne bougea absolument pas.
 Il est très étonné.
@@ -4050,7 +4073,7 @@ Il est extrêmement beau.
 Elle est extrêmement belle.
 Vraiment mauvais.
 Assez fatigué.
-C'est vivant que le renard avait été attrapé.
+C’est vivant que le renard avait été attrapé.
 On mange le far froid ou tiède.
 Il avait appris beaucoup de chansons étant jeune.
 Blanc comme neige.
@@ -4064,25 +4087,25 @@ Rouillé.
 Plus rouillé.
 Il est plus grand que ton frère.
 Il est plus grand que son frère.
-Le voyage en sera d'autant plus long.
-Il n'en sera que plus riche.
-Nous n'en serons que plus déçus.
+Le voyage en sera d’autant plus long.
+Il n’en sera que plus riche.
+Nous n’en serons que plus déçus.
 Tant pis.
 Tant mieux.
-Aussi jaune que l'or.
+Aussi jaune que l’or.
 Aussi grand que la maison.
 Aussi rapide que la flèche.
-Aussi beau qu'une rose.
-Aussi fort qu'un taureau.
-Yann et Gwenc'hlan sont aussi sages l'un que l'autre.
-C'est tout aussi cher.
-C'est aussi cher.
-Il n'avait jamais fait aussi froid.
-C'est si cher que ça ?
-Ce livre n'est pas aussi épais.
+Aussi beau qu’une rose.
+Aussi fort qu’un taureau.
+Yann et Gwenc’hlan sont aussi sages l’un que l’autre.
+C’est tout aussi cher.
+C’est aussi cher.
+Il n’avait jamais fait aussi froid.
+C’est si cher que ça ?
+Ce livre n’est pas aussi épais.
 Ce livre est plus mince.
 Celui qui travaille le moins.
-C'est plus ou moins sale.
+C’est plus ou moins sale.
 Ils étaient plus ou moins malades.
 Les gens restaient travailler pour des durées plus ou moins longues.
 Plus ou moins.
@@ -4094,36 +4117,36 @@ Mon chien est aussi fou que le sien.
 La maison la plus jaune.
 Les maisons les plus jaunes.
 La grande maison la plus jaune.
-D'autres maisons plus jaunes.
-L'oiseau le plus lent.
+D’autres maisons plus jaunes.
+L’oiseau le plus lent.
 Le plus lent.
 Le plus rouillé.
-Apportez-moi ce qu'il y a de mieux.
+Apportez-moi ce qu’il y a de mieux.
 Faisons le plus difficile en premier.
-C'est lui le meilleur.
+C’est lui le meilleur.
 Des choses très importantes.
 On lui a confié une mission très importante.
-C'est un travail très important.
-Est-ce que ça apportera un changement ?
-Est-ce que ça apportera des changements ?
+C’est un travail très important.
+Est-ce que ça apportera un changement ?
+Est-ce que ça apportera des changements ?
 On a apporté des changements au texte.
 On a apporté de grands changements au texte.
 Depuis longtemps les maires doivent faire attention à ça.
 Ce livre te plaira.
-Ces événements leur plaisaient.
-L'orage est à son maximum.
+Ces évènements leur plaisaient.
+L’orage est à son maximum.
 La radio est au maximum.
-Quelle jolie maison !
+Quelle jolie maison !
 Amenez-en plus.
 Le plus possible.
 Cinq au plus.
-Au plus on sera mouillé.
-Au pire on sera mouillé.
-Au mieux on sera mouillé.
+Au plus on sera mouillés.
+Au pire on sera mouillés.
+Au mieux on sera mouillés.
 Il faut faire au mieux.
 Nous ne savons plus quoi faire.
-Autant de monde que l'année dernière.
-Il y en a tout autant das chacun d'entre eux.
+Autant de monde que l’année dernière.
+Il y en a tout autant dans chacun d’entre eux.
 Il y en a tout autant.
 Comme ça ce sera moins visible.
 De cette façon-là nous avions été moins salis.
@@ -4134,7 +4157,7 @@ Ce soir je rirai moins.
 Ce soir ils riront moins.
 Ce soir elles riront moins.
 Ce soir elles ne riront pas autant.
-Donne lui moins d'eau.
+Donne-lui moins d’eau.
 Il est arrivé depuis midi au moins.
 Des cheveux mieux coupés.
 Il vaut mieux y aller tout de suite.
@@ -4143,10 +4166,10 @@ Les meilleures places.
 Je préfère.
 Je préfère partir immédiatement.
 Ils feraient aussi bien de partir tout de suite.
-Ce vin n'est pas aussi bon que l'autre.
+Ce vin n’est pas aussi bon que l’autre.
 Elle chante aussi bien que sa mère.
-Encore pire !
-Quel temps exécrable !
+Encore pire !
+Quel temps exécrable !
 La pire des maladies.
 Un coup aussi terrible que le premier.
 La maison la plus chère.
@@ -4166,34 +4189,33 @@ Des plus chers.
 Des plus chères.
 La meilleure équipe.
 Les deux meilleures équipes.
-Le plus beau château que j'ai vu.
-Le premier que j'ai regardé était Cendrillon.
-Je n'avais jamais vu de plus beau spectacle.
+Le plus beau château que j’ai vu.
+Le premier que j’ai regardé était Cendrillon.
+Je n’avais jamais vu de plus beau spectacle.
 Le Morvran était un bien meilleur bateau.
 Il sera difficile de trouver un aussi bon joueur que lui.
 On ne voit pas souvent de joueur aussi doué que lui.
-Ils ont plus d'enfants que nous.
-Il boit moins de vin qu'autrefois.
+Ils ont plus d’enfants que nous.
+Il boit moins de vin qu’autrefois.
 Nous ne savons pas quand nous avions vu le plus de monde.
 La plus belle église de la région.
-Le plus vieux d'entre nous.
-Il n'était pas aussi solide que je le croyais.
-Ce n'était pas aussi solide que je le croyais.
+Le plus vieux d’entre nous.
+Il n’était pas aussi solide que je le croyais.
+Ce n’était pas aussi solide que je le croyais.
 Je fais du mieux que je peux.
-C'était plus lourd que je ne le pensais.
-L'essence est de plus en plus chère.
+C’était plus lourd que je ne le pensais.
+L’essence est de plus en plus chère.
 De moins en moins.
 On entend le biniou de plus en plus fort.
 De mieux en mieux.
 De pis en pis.
-De plus en plus.
 Le vent est de plus en plus fort.
-C'était d'autant plus difficile que n'avais aucun outil.
-C'était d'autant plus difficile que n'avais aucun outil à ma disposition.
+C’était d’autant plus difficile que je n’avais aucun outil.
+C’était d’autant plus difficile que je n’avais aucun outil à ma disposition.
 Plus nous serons nombreux, et plus ce sera facile.
 Plus tôt ce sera, mieux cela sera.
 Le plus tôt sera le mieux.
-Plus nous marchions et plus nous  fatiguions.
+Plus nous marchions et plus nous fatiguions.
 Très fatigué.
 Très très très fatigué.
 Tout à fait fatigué.
@@ -4220,18 +4242,18 @@ Assez léger.
 Doucement.
 Mon amour.
 Ma chérie.
-C'est propret.
+C’est propret.
 Il sera ici sous peu.
 Un énorme trou.
 Quatre chiens énormes.
-L'énorme.
+L’énorme.
 Un château immense.
 Un énorme géant.
 Ces gros trucs.
 En direction de la place.
 Dans sa direction.
 Autour de la place.
-Autour d'elle.
+Autour d’elle.
 Dans les pots.
 Dans eux.
 Vers moi.
@@ -4244,497 +4266,498 @@ Il y a un obstacle entre moi et le but.
 Ce cadeau est à toi et à moi.
 Mon père était malade, mais son esprit, en revanche, restait alerte.
 Le téléphone est petit, il est léger également.
-Il m'avait pourtant dit qu'il serait venu.
-Qui achète le journal ?
+Il m’avait pourtant dit qu’il serait venu.
+Qui achète le journal ?
 Mon père achète le journal à la boutique tous les jours.
-Quand ton père achète-il le journal ?
-Qu'achète ton père tous les jours ?
-Où ton père achète le journal ?
+Quand ton père achète-t-il le journal ?
+Qu’achète ton père tous les jours ?
+Où ton père achète le journal ?
 Que fait ton père tous les jours.
 Faire des crêpes.
 Se peigner les cheveux.
 Bien jouer.
 Il joue bien.
-Mon père est en train d'acheter le journal à la boutique.
+Mon père est en train d’acheter le journal à la boutique.
 Je vais voir.
 Ils étaient à la maison à ce moment-là.
 Achète le journal tous les jours.
-Regardez ce qu'il est en train de montrer.
-Tiens donc !
-Si !
-On n'aura pas le temps d'y aller ? Si !
-Que si !
-Voilà qui est bien!
-Voilà qui est vrai !
-Ça se pourrait !
-Vous croyez ?
+Regardez ce qu’il est en train de montrer.
+Tiens donc !
+Si !
+On n’aura pas le temps d’y aller ? Si !
+Que si !
+Voilà qui est bien !
+Voilà qui est vrai !
+Ça se pourrait !
+Vous croyez ?
 Je le crains.
 Je vais y aller maintenant.
-Tu va voir !
-Mon père n'achète pas le journal à la boutique tous les jours.
-Je m'en vais maintenant.
+Tu vas voir !
+Mon père n’achète pas le journal à la boutique tous les jours.
+Je m’en vais maintenant.
 Tu vas voir.
-N'achète pas le journal !
-Mes voisins n'achètent pas le journal tous les jours.
-Je n'achète pas le journal à la boutique tous les jours.
-Moi, je n'achète pas le journal à la boutique tous les jours.
-Ils n'achètent pas le journal à la boutique tous les jours
-Elles n'achètent pas le journal à la boutique tous les jours
-Mes parents n'achètent pas le journal à la boutique tous les jours.
+N’achète pas le journal !
+Mes voisins n’achètent pas le journal tous les jours.
+Je n’achète pas le journal à la boutique tous les jours.
+Moi, je n’achète pas le journal à la boutique tous les jours.
+Ils n’achètent pas le journal à la boutique tous les jours.
+Elles n’achètent pas le journal à la boutique tous les jours.
+Mes parents n’achètent pas le journal à la boutique tous les jours.
 Mes sœurs ne sont pas en train de jouer.
 Mes sœurs, elles ne sont pas en train de jouer.
-Il faisait beau hier.
-Il ne fait pas beau aujourd'hui.
+Il ne fait pas beau aujourd’hui.
 Le déjeuner a été pris dans la cuisine.
-Mon père n'était pas en train d'acheter le journal.
-Mon père n'a pas été acheter le journal.
-L'enfant colorie le dessin avec des crayons.
+Mon père n’était pas en train d’acheter le journal.
+Mon père n’a pas été acheter le journal.
+L’enfant colorie le dessin avec des crayons.
 Mon père a acheté ce journal pour moi.
-J'achète le journal dans cette boutique tous les jours.
-J'ai souvent entendu cela.
-Je vous appellerai
+J’achète le journal dans cette boutique tous les jours.
+J’ai souvent entendu cela.
+Je vous appellerai.
 Je les cirais et les lustrais souvent.
-Yann n'avait pas ouvert la lettre.
-Quand Yulizh s'était cassée le bras.
+Yann n’avait pas ouvert la lettre.
+Quand Yulizh s’était cassée le bras.
 Nous vous avions vu.
-Je l'avais rapidement déconseillé.
-Je l'avais encore vu hier.
-J'achète le journal à la boutique tous les jours.
-Hier soir j'étais fatigué de l'écouter.
-Il fait froid aujourd'hui.
-Ça va ?
-Le bébé s'est endormi.
+Je l’avais rapidement déconseillé.
+Je l’avais encore vu hier.
+J’achète le journal à la boutique tous les jours.
+Hier soir j’étais fatigué de l’écouter.
+Il fait froid aujourd’hui.
+Ça va ?
+Le bébé s’est endormi.
 Le voyage avait été difficile, la mer était mauvaise et le vent soufflait fort.
 Il ne faut pas passer par là.
-Il ne faut pas parler trop fort !
-Tirez, les gars !
-Et le chat ? - Parti par la fenêtre.
-S'en aller ou rester encore à attendre ?
-Qui ? - Moi.
-Quoi ? - Ça.
-Fera-t-il beau ? Peut être bien.
+Il ne faut pas parler trop fort !
+Tirez, les gars !
+Et le chat ?
+Parti par la fenêtre.
+S’en aller ou rester encore à attendre ?
+Qui ?
+Moi.
+Quoi ?
+Ça.
+Fera-t-il beau ?
+Peut-être bien.
 Me voilà un peu intimidé.
 Voilà le renard qui part.
-Et le voici qui descend, qui prend l'échelle, et qui s'en va.
-Malédiction !
-Peut être.
-Bonne nuit !
-Il se leva et alla jusqu'à la fenêtre.
-L'île a une petite superficie.
-La superficie de l'île est petite.
+Et le voici qui descend, qui prend l’échelle, et qui s’en va.
+Malédiction !
+Peut-être.
+Bonne nuit !
+Il se leva et alla jusqu’à la fenêtre.
+L’île a une petite superficie.
+La superficie de l’île est petite.
 Le chien que je poursuis.
-L'homme avec qui je me suis disputé.
+L’homme avec qui je me suis disputé.
 Les larmes montaient aux yeux du petit enfant.
-L'église que vous voyez là-bas est grande.
-À qui est le chien qui est en train d'aboyer ?
-La fille que j'aime.
-Celui qui a de l'argent paiera pour les autres.
+L’église que vous voyez là-bas est grande.
+À qui est le chien qui est en train d’aboyer ?
+La fille que j’aime.
+Celui qui a de l’argent paiera pour les autres.
 Ceux qui vous liront seront grandement étonnés.
-L'homme viendra ce soir.
-L'homme qui viendra ce soir.
-Elle qui devait être ici depuis un quart d'heure…
-Moi qui suit de devenu vieux…
+L’homme viendra ce soir.
+L’homme qui viendra ce soir.
+Elle qui devait être ici depuis un quart d’heure…
+Moi qui suis devenu vieux…
 Ronan, qui était malade, était resté à la maison également.
 Une lettre qui est joliment écrite.
-J'irai demander à quelqu'un qui connaît la route.
-La porte que vous être en train de peindre.
-L'homme avec qui j'étais en train de parler est mon voisin.
+J’irai demander à quelqu’un qui connait la route.
+La porte que vous êtes en train de peindre.
+L’homme avec qui j’étais en train de parler est mon voisin.
 Dites-moi quel est ce médicament dont on parle tellement.
-Les gens avec qui j'aime bien être sont des gens sans façons.
+Les gens avec qui j’aime bien être sont des gens sans façons.
 Cet homme-là, qui avait vécu dans les pays lointains, savait un tas de choses.
 Mon père, qui venait de perdre son travail, préféra changer de profession.
-L'oiseau qui ne chante plus.
-Les choses que je n'aime plus.
-Les choses que je n'aime pas.
-Les personnes que je n'aime plus.
-Les personnes que je n'aime pas.
+L’oiseau qui ne chante plus.
+Les choses que je n’aime plus.
+Les choses que je n’aime pas.
+Les personnes que je n’aime plus.
+Les personnes que je n’aime pas.
 Voici les gens qui ne savent pas bien chanter.
 Donnez-lui des vêtements qui ne grattent pas.
-Au moment où j'étais en train d'ouvrir la porte.
-Dans l'état où nous sommes.
+Au moment où j’étais en train d’ouvrir la porte.
+Dans l’état où nous sommes.
 Le magasin où elle acheta ses lunettes.
-le bois où nous avions été nous promener.
+Le bois où nous avions été nous promener.
 Le mieux que tu peux.
-Autant qu'il veuille.
-Le plus qu'il peut.
-À l'époque où je ne pourrai plus me débrouiller.
+Autant qu’il veuille.
+Le plus qu’il peut.
+À l’époque où je ne pourrai plus me débrouiller.
 Quand je ne pourrai plus me débrouiller.
-Il faudra que j'aille voir le gars au chien malade.
-L'enfant au bras cassé.
-Il faudra que j'aille voir le gars dont le chien est malade.
-L'enfant dont le bras est cassé.
-On dit à la radio qu'il y aura de la pluie et du vent.
+Il faudra que j’aille voir le gars au chien malade.
+L’enfant au bras cassé.
+Il faudra que j’aille voir le gars dont le chien est malade.
+L’enfant dont le bras est cassé.
+On dit à la radio qu’il y aura de la pluie et du vent.
 Je vois que mon frère est en train de travailler dur.
-Je crois qu'ils ne viendront pas.
-Je ne pense pas qu'il soit capable de porter un fardeau aussi lourd.
-Je ne voulais pas qu'il s'en aille.
+Je crois qu’ils ne viendront pas.
+Je ne pense pas qu’il soit capable de porter un fardeau aussi lourd.
+Je ne voulais pas qu’il s’en aille.
 Il ne sait pas que je suis ici.
-Je ne savais pas qu'il avait été reçu.
-JE ne savais pas qu'il aurait été reçu.
-Ferme-la, que je puisse en placer une !
-Le roi demande que son maître de maison vienne.
-Faites en sorte que la route ne soit pas bloquée.
-Il demande qu'il paye.
-Il exige qu'il paye.
-Il essaye de savoir ce que c'est.
+Je ne savais pas qu’il avait été reçu.
+Je ne savais pas qu’il aurait été reçu.
+Ferme-la, que je puisse en placer une !
+Il demande qu’il paye.
+Il exige qu’il paye.
+Il essaye de savoir ce que c’est.
 Il ne veut pas dire combien il gagne par mois.
-J'aimerais savoir s'il y aura grève demain.
-Regardez comme c'est beau !
+J’aimerais savoir s’il y aura grève demain.
+Regardez comme c’est beau !
 Prenez le chien avec vous si vous allez vous promener.
 Quand vous irez en ville.
 Quand ils sont partis.
 Quand il arrivera.
 Quand nous étions.
-Si j'étais.
-S'il fait.
+Si j’étais.
+S’il fait.
 Si vous mangiez.
-Nous irons au cinéma s'il pleut.
+Nous irons au cinéma s’il pleut.
 Nous allons au cinéma quant il pleut.
-Nous étions allés au cinéma parce qu'il pleuvait.
-S'il pleut nous irons au cinéma.
+Nous étions allés au cinéma parce qu’il pleuvait.
+S’il pleut nous irons au cinéma.
 Quand il pleut nous allons au cinéma.
-Puisqu'il pleuvait nous étions allés au cinéma.
-S'il ne pleut pas nous n'irons pas au cinéma.
-Quand il ne pleut pas nous n'allons pas au cinéma.
-Puisqu'il ne pleuvait pas nous n'étions pas allés au cinéma.
+Puisqu’il pleuvait nous étions allés au cinéma.
+S’il ne pleut pas nous n’irons pas au cinéma.
+Quand il ne pleut pas nous n’allons pas au cinéma.
+Puisqu’il ne pleuvait pas nous n’étions pas allés au cinéma.
 Autant que tu le désires.
 Il est plus bête que je ne le pensais.
-Je courrais d'autant plus vite que j'avais de bonnes chaussures.
-J'ai tellement chaud que je sue.
-Comme il ne venait pas, nous n'étions pas restés attendre.
-J'avais peur qu'ils n'eussent pu se débrouiller seuls.
-Ferme bien la porte de crainte qu'il n'essayent de fuir.
+Je courais d’autant plus vite que j’avais de bonnes chaussures.
+J’ai tellement chaud que je sue.
+Comme il ne venait pas, nous n’étions pas restés attendre.
+J’avais peur qu’ils n’eussent pu se débrouiller seuls.
+Ferme bien la porte de crainte qu’il n’essayent de fuir.
 Fais attention à ce que les verres ne cassent pas.
-Faites attention à ce qu'il ne salisse pas ses vêtements.
-Attendez ici jusqu'à ce que je vous le dise.
-Il restera jusqu'à ce que le travail soit fini.
-Jusqu'à hier ils ne connaissaient pas la nouvelle.
-Le voleur avait pénétré dans la maison sans que j'eusse été réveillé.
-Il était plus vieux que je ne le croyait.
+Faites attention à ce qu’il ne salisse pas ses vêtements.
+Attendez ici jusqu’à ce que je vous le dise.
+Il restera jusqu’à ce que le travail soit fini.
+Jusqu’à hier ils ne connaissaient pas la nouvelle.
+Le voleur avait pénétré dans la maison sans que j’eusse été réveillé.
+Il était plus vieux que je ne le croyais.
 Moi, je cherche alors que toi tu ne le fais pas.
-Je vais manger car j'ai faim.
-C'est joli mais c'est trop cher.
-Ce n'était pas quelqu'un de très instruit mais il savait bien s'exprimer.
-Ce n'était pas quelqu'un de très instruit sauf qu'il savait bien s'exprimer.
-J'allais à l'école en bus et je devais me lever tôt.
+Je vais manger car j’ai faim.
+C’est joli mais c’est trop cher.
+Ce n’était pas quelqu’un de très instruit mais il savait bien s’exprimer.
+Ce n’était pas quelqu’un de très instruit sauf qu’il savait bien s’exprimer.
+J’allais à l’école en bus et je devais me lever tôt.
 Arrête tout de suite où je le dirai à mon père.
 Elle ira.
-C'est elle qui ira.
-C'était le fils qui était en train de godiller.
+C’est elle qui ira.
+C’était le fils qui était en train de godiller.
 Il ne chantait pas, il beuglait.
-Ce n'est pas d'un jeu.
-Il ne s'agit pas d'un jeu.
-C'est ici qu'il est.
-C'est le chien qui a fait le coup.
-C'est qu'il rigole.
-C'est demain qu'il y aura une éclipse de soleil.
-C'est demain qu'il se produira une éclipse de soleil.
+Ce n’est pas d’un jeu.
+Il ne s’agit pas d’un jeu.
+C’est ici qu’il est.
+C’est le chien qui a fait le coup.
+C’est qu’il rigole.
+C’est demain qu’il y aura une éclipse de soleil.
+C’est demain qu’il se produira une éclipse de soleil.
 Ce sont les gens qui sont responsables.
-C'est qu'elle a continué son chemin.
+C’est qu’elle a continué son chemin.
 Nous lisons.
 Nous sommes en train de lire.
 Vous aurez assez de temps.
 Vous aviez assez de temps.
 Je lis.
-J'étais effectivement au fest-noz à cette heure-là.
+J’étais effectivement au fest-noz à cette heure-là.
 Dis-moi si tu viendras.
-Tu en auras ?
+Tu en auras ?
 Un litre de vin.
 Un kilomètre de route.
 Les sciences humaines.
-300 phrases anglaises de base.
+Trois cents phrases anglaises de base.
 Un peu.
 Il y a longtemps.
 Un billet aller.
 Un billet aller-retour.
-Environ 300 kilomètres.
-Environ 8 heures de voyage avec la route.
+Environ trois cents kilomètres.
+Environ huit heures de voyage avec la route.
 En face de la poste.
 Quand il sera arrivé nous irons tous dehors.
-L'agriculture est la principale occupation des gens là-bas.
+L’agriculture est la principale occupation des gens là-bas.
 Tout.
 Tout est bon.
 Ils sont tous bons.
 Toute la journée.
 Il vous suffit de rajouter les lettres.
-Est-ce que je prononce bien ?
+Est-ce que je prononce bien ?
 Amy est la petite amie de John.
-Et toi ?
-Et vous ?
-Quelque chose d'autre ?
-Est-ce que les magasins sont ouverts ?
-Les magasins sont ouverts ?
-Il y a des concerts ?
-Il y a des crayons gris dans ta boîte ?
-Est-ce que ces choses sont des livres ?
-Ils viendront ici demain ?
-ils viennent ce soir ?
-Ce sont des étrangers ?
-Ils sont identiques ?
-Ce sont des parents à vous ?
-Ce sont des parents à toi ?
-Est-ce que ceux-là sont des crayons gris ?
-Es-tu une fille ?
-Vous êtes une fille ?
-Tu es une fille-toi ?
-Vous êtes une fille-vous ?
-Êtes-vous une fille ?
-Vous êtes parent avec M. Mohan ?
-Tu es parent avec M. Mohan ?
-Vous avez peur d'eux ?
-Tu as peur d'eux ?
-Vous avez peur ?
-Tu as peur ?
-Êtes-vous allergique à quelque chose ?
-Êtes-vous Américain ?
-Vous êtes fâché contre moi ?
-Êtes-vous réveillé ?
-Es-tu réveillé ?
-Connaissez-vous cela ?
-Vous êtes pressé ?
-Vous êtes confortable ?
-Vous venez ce soir ?
-Avez-vous un travail ?
-Vous êtes libre maintenant ?
-Vous êtes libre ce soir ?
-Vous pensez aller à la noce ?
-Est-ce que vous allez l'aider ?
-Vous irez en avion ou en train ?
-Vous irez avec eux ?
-Vous êtes ici tout seul ?
-Vous avez faim ?
-Ça vous intéresse ?
-Vous blaguez ?
-Vous agrandissez votre maison ?
-Vous êtes marié ?
-Tu es marié ?
-C'est vous M. Murthy ?
-Vous ne vous sentez pas bien ?
-Vous vous sentez bien ?
-Vous êtes prêt ?
-Vous êtes d'accord maintenant ?
-Vous êtes malade ?
-Êtes-vous sûr ?
-Êtes-vous certain ?
-Vous êtes fatigué ?
-Êtes-vous fatigué ?
-Vous essayez de vous moquer de moi ?
-Vous attendez quelqu'un ?
-Vous travaillez aujourd'hui ?
-Vous travaillez demain ?
-Vos enfants sont avec vous ?
+Et toi ?
+Et vous ?
+Quelque chose d’autre ?
+Est-ce que les magasins sont ouverts ?
+Les magasins sont ouverts ?
+Il y a des concerts ?
+Il y a des crayons gris dans ta boîte ?
+Est-ce que ces choses sont des livres ?
+Ils viendront ici demain ?
+Ils viennent ce soir ?
+Ce sont des étrangers ?
+Ils sont identiques ?
+Ce sont des parents à vous ?
+Ce sont des parents à toi ?
+Est-ce que ceux-là sont des crayons gris ?
+Es-tu une fille ?
+Vous êtes une fille ?
+Tu es une fille, toi ?
+Vous êtes une fille, vous ?
+Êtes-vous une fille ?
+Vous êtes parent avec monsieur Mohan ?
+Tu es parent avec monsieur Mohan ?
+Vous avez peur d’eux ?
+Tu as peur d’eux ?
+Vous avez peur ?
+Tu as peur ?
+Êtes-vous allergique à quelque chose ?
+Êtes-vous Américain ?
+Vous êtes fâché contre moi ?
+Êtes-vous réveillé ?
+Es-tu réveillé ?
+Connaissez-vous cela ?
+Vous êtes pressé ?
+Vous êtes confortable ?
+Vous venez ce soir ?
+Avez-vous un travail ?
+Vous êtes libre maintenant ?
+Vous êtes libre ce soir ?
+Vous pensez aller à la noce ?
+Est-ce que vous allez l’aider ?
+Vous irez en avion ou en train ?
+Vous irez avec eux ?
+Vous êtes ici tout seul ?
+Vous avez faim ?
+Ça vous intéresse ?
+Vous blaguez ?
+Vous agrandissez votre maison ?
+Vous êtes marié ?
+Tu es marié ?
+C’est vous monsieur Murthy ?
+Vous ne vous sentez pas bien ?
+Vous vous sentez bien ?
+Vous êtes prêt ?
+Vous êtes d’accord maintenant ?
+Vous êtes malade ?
+Êtes-vous sûr ?
+Êtes-vous certain ?
+Vous êtes fatigué ?
+Êtes-vous fatigué ?
+Vous essayez de vous moquer de moi ?
+Vous attendez quelqu’un ?
+Vous travaillez aujourd’hui ?
+Vous travaillez demain ?
+Vos enfants sont avec vous ?
 Rangez les livres en ordre.
-Dès qu'il sera possible.
+Dès qu’il sera possible.
 Dès que nous serons arrivés là-bas nous commencerons à travailler.
-Demander sa route et un peu d'aide.
-À 3 heures de l'après-midi.
-À 3 heures.
-À la 5è rue.
-À 19 heures.
-À 7 heures du soir.
-À 7 heures du matin.
-À quelle heure c'est arrivé ?
-À quelle heure ?
-S'occuper du téléphone.
+Demander sa route et un peu d’aide.
+À trois heures de l’après-midi.
+À trois heures.
+À la cinquième rue.
+À dix-neuf heures.
+À sept heures du soir.
+À sept heures du matin.
+À quelle heure c’est arrivé ?
+À quelle heure ?
+S’occuper du téléphone.
 Attention en conduisant.
 Attention.
 Restez calme.
 Sois-y.
 Soyez-y.
-Sois-y à l'heure !
-Soyez-y à l'heure !
-Soyez-y à temps !
-Sois-y à temps !
-Sois-y en temps et en heure !
-Soyez-y en temps et en heure !
+Sois-y à l’heure !
+Soyez-y à l’heure !
+Soyez-y à temps !
+Sois-y à temps !
+Sois-y en temps et en heure !
+Soyez-y en temps et en heure !
 Souvenez-vous.
 Soyez poli ou vous entendrez parler de moi.
-À l'arrière de la banque.
-Grand / Petit.
+À l’arrière de la banque.
+Grand ou petit.
 Dieu vous pardonne.
 Fermer la porte à clef.
-Emmenez-moi ma chemise s'il vous plaît.
+Emmenez-moi ma chemise s’il vous plait.
 Emmenez-les ici.
 Les affaires sont bonnes.
 Téléphonez-moi.
 Appelez-moi.
 Téléphonez à la police.
-Dites-leurs d'entrer.
-Je peux me connecter à Internet ici ?
-Je peux me connecter au réseau ici ?
-Je peux emprunter un peu d'argent ?
-Je peux venir avec mon ami ?
-Est-ce que je peux avoir un verre d'eau s'il vous plaît ?
-Est-ce que je peux avoir une facture s'il vous plaît ?
-Est-ce que je peux avoir la note s'il vous plaît ?
-Un peu d'aide ?
-Je peux vous aider ?
-Je peux mettre un rendez-vous pour mercredi ?
-Puis-je voir votre passeport s'il vous plaît ?
-Je peux prendre un message ?
-Est-ce que je peux l'essayer ?
-Je peux utiliser votre téléphone ?
-Il peut être meilleur marché ?
-Est-ce que nous pouvons avoir la carte s'il vous plaît ?
-Nous pouvons avoir un peu plus de pain s'il vous plaît ?
-Est-ce que nous pouvons avoir un peu plus de pain s'il vous plaît ?
-Pouvons-nous avoir un peu plus de pain s'il vous plaît ?
-Nous pouvons nous asseoir par là ?
-Pouvez-vous retéléphoner plus tard ?
-Pouvez-vous me retéléphoner plus tard ?
-Pouvez-vous porter ça pour moi s'il vous plaît.
-Pouvez-vous me rendre un petit service ?
-Pouvez-vous arranger ça ?
-Vous pouvez me donner un exemple ?
-Pouvez-vous m'aider ?
-Vous pouvez tenir ça pour moi ?
-Vous pouvez redire ça ?
-Vous pouvez nous recommander un bon restaurant ?
-Vous pouvez redire ça s'il vous plaît ?
-Vous pouvez le redire s'il vous plaît ?
-Vous pouvez me montrer ?
-Vous pouvez parler plus fort  s'il vous plaît ?
-Vous pouvez parler doucement ?
-Vous savez nager ?
-Pouvez-vous lancer ça dehors pour moi ?
-Vous pouvez me traduire ça ?
-Bien sûr !
-Santé !
-Chennai est à 200 km de Bombay.
+Dites-leur d’entrer.
+Je peux me connecter à Internet ici ?
+Je peux me connecter au réseau ici ?
+Je peux emprunter un peu d’argent ?
+Je peux venir avec mon ami ?
+Est-ce que je peux avoir un verre d’eau s’il vous plait ?
+Est-ce que je peux avoir une facture s’il vous plait ?
+Est-ce que je peux avoir la note s’il vous plait ?
+Un peu d’aide ?
+Je peux vous aider ?
+Je peux mettre un rendez-vous pour mercredi ?
+Puis-je voir votre passeport s’il vous plait ?
+Je peux prendre un message ?
+Est-ce que je peux l’essayer ?
+Je peux utiliser votre téléphone ?
+Il peut être meilleur marché ?
+Est-ce que nous pouvons avoir la carte s’il vous plait ?
+Nous pouvons avoir un peu plus de pain s’il vous plait ?
+Est-ce que nous pouvons avoir un peu plus de pain s’il vous plait ?
+Pouvons-nous avoir un peu plus de pain s’il vous plait ?
+Nous pouvons nous asseoir par là ?
+Pouvez-vous retéléphoner plus tard ?
+Pouvez-vous me retéléphoner plus tard ?
+Pouvez-vous porter ça pour moi s’il vous plait.
+Pouvez-vous me rendre un petit service ?
+Pouvez-vous arranger ça ?
+Vous pouvez me donner un exemple ?
+Pouvez-vous m’aider ?
+Vous pouvez tenir ça pour moi ?
+Vous pouvez redire ça ?
+Vous pouvez nous recommander un bon restaurant ?
+Vous pouvez redire ça s’il vous plait ?
+Vous pouvez le redire s’il vous plait ?
+Vous pouvez me montrer ?
+Vous pouvez parler plus fort s’il vous plait ?
+Vous pouvez parler doucement ?
+Vous savez nager ?
+Pouvez-vous lancer ça dehors pour moi ?
+Vous pouvez me traduire ça ?
+Bien sûr !
+Santé !
+Chennai est à deux cents kilomètres de Bombay.
 Chicago est très différent de Boston.
 Venez ici.
-Venez avec moi !
+Venez avec moi !
 Félicitations.
-Vous pourriez me dire quelque chose au sujet de votre famille ?
-Vous pourriez nous dire quelque chose au sujet de ma famille ?
-Vous pourriez nous dire quelque chose au sujet de votre famille ?
-Et quelqu'un est venu ?
-Il vous a demandé une chose ou une autre à ce sujet ?
-Il est venu ici hier ?
-Il est venu ?
-Il a dit quelque chose ?
-Je vous ai demandé ?
-Je vous ai donné la balance ?
-Il a plu là ?
-Il a neigé hier ?
-Vous m'avez téléphoné ?
-Vous étiez venu avec votre famille ?
-Vous avez eu mon mail ?
-Vous avez eu mon courrier ?
-Vous étiez arrivé à temps ?
-Vous étiez au bureau hier ?
-Ça vous a plu ici ?
-Vous avez fermé la porte à clef ?
-Vous avez ouvert la porte ?
-Vous avez reçu mon courrier ?
-Vous avez reçu ma lettre ?
-Vous avez ramené le livre ?
-Vous m'avez amené des fleurs ?
-Vous avez éteint la télévision ?
-Vous avez pris votre médicament ?
-Vous avez tapé la lettre ?
-Vous avez compris cette leçon ?
-Votre femme aime-t-elle la Californie ?
-Votre femme se plaît en Californie ?
+Vous pourriez me dire quelque chose au sujet de votre famille ?
+Vous pourriez nous dire quelque chose au sujet de ma famille ?
+Vous pourriez nous dire quelque chose au sujet de votre famille ?
+Et quelqu’un est venu ?
+Il vous a demandé une chose ou une autre à ce sujet ?
+Il est venu ici hier ?
+Il est venu ?
+Il a dit quelque chose ?
+Je vous ai demandé ?
+Je vous ai donné la balance ?
+Il a plu là ?
+Il a neigé hier ?
+Vous m’avez téléphoné ?
+Vous étiez venu avec votre famille ?
+Vous avez eu mon mail ?
+Vous avez eu mon courrier ?
+Vous étiez arrivé à temps ?
+Vous étiez au bureau hier ?
+Ça vous a plu ici ?
+Vous avez fermé la porte à clef ?
+Vous avez ouvert la porte ?
+Vous avez reçu mon courrier ?
+Vous avez reçu ma lettre ?
+Vous avez ramené le livre ?
+Vous m’avez amené des fleurs ?
+Vous avez éteint la télévision ?
+Vous avez pris votre médicament ?
+Vous avez tapé la lettre ?
+Vous avez compris cette leçon ?
+Votre femme aime-t-elle la Californie ?
+Votre femme se plait en Californie ?
 Faites vos devoirs.
-Nous aimons l'école ?
-Vous acceptez les dollars USA ?
-Et vous croyez ça ?
-Vous allez mieux ?
-Vous allez souvent en Floride ?
-Vous avez un amoureux ?
-Vous avez une amoureuse ?
-Vous avez un crayon gris ?
-Vous avez un problème ?
-Vous avez une piscine ?
-Vous avez rendez-vous ?
-Vous en avez un autre ?
-Vous avez des enfants ?
-Vous avez du café ?
-Vous avez de l'argent ?
-Vous avez des crayons gris ?
-Il y a des places vacantes ?
-Vous avez quelque chose ?
-Vous avez quelque chose de meilleur marché ?
-Vous avez assez d'argent sur vous ?
-Vous avez le numéro du taxi ?
-Vous avez celui-ci en taille 11.
-Et vous avez le temps de lire le journal le matin ?
-Vous avez entendu ?
-Vous la connaissez ?
-Vous savez combien il coûte ?
-Vous savez combien ça coûte ?
-Vous savez combien elle coûte ?
-Vous savez comment cuisiner ?
-Vous savez comment aller à l'hôtel Mariott ?
-Vous savez comment se rendre à l'hôtel Mariott ?
-Vous savez ce qu'il veut dire ?
-Vous savez ce qui est écrit là ?
-Vous savez où je peux prendre un taxi ?
-Vous savez où sont mes lunettes ?
-Vous savez qui elle est ?
-Est-ce que vous savez qui elle est ?
-Savez-vous où est-ce qu'il y a un magasin qui vend des serviettes ?
-Vous savez où est-ce qu'il y a un magasin qui vend des serviettes ?
-Vous vous plaisez ici ?
-Ça vous plaît ?
-Le livre vous plaît ?
-Vous aimez regarder la télévision ?
-Votre directeur vous plaît ?
-Vos collaborateurs vous plaisent ?
-Vous avez besoin de quelque chose d'autre ?
-Vous avez besoin de quelque chose ?
-Vous ouvrez la porte ?
-Vous faites un sport quelconque ?
-Vous pratiquez un sport quelconque ?
-Vous jouez au Basket ?
-Vous vendez des piles ?
-Vous vendez des médicaments ?
-Vous fumez ?
-Vous parlez anglais ?
-Vous parlez français ?
-Vous parlez espagnol ?
-Vous apprenez l'anglais ?
-Vous prenez les cartes de crédit ?
-Et vous pensez que je ne sais pas cela ?
-Il va pleuvoir aujourd'hui, vous pensez ?
-Et vous pensez qu'il va pleuvoir demain ?
-C'est possible, vous pensez ?
-Et vous pensez être une personne intelligente ?
-Vous serez de retour pour 11h30, vous pensez ?
-Vous comprenez ?
-Vous voulez que je vienne vous prendre ?
-Vous voulez venir avec moi ?
-Vous voulez aller au cinéma ?
-Vous voulez y aller avec moi ?
-Quelqu'un sait l'anglais ici ?
-Quelqu'un sait l'allemand ici ?
-Il se plaît à l'école ?
-L'école lui plaît ?
-Il ouvre la porte ?
-Il neige souvent pendant l'hiver au Massachusetts ?
-Cette route va à Auray ?
-Cette route va à Nantes ?
-Cette route va à New York ?
+Nous aimons l’école ?
+Vous acceptez les dollars USA ?
+Et vous croyez ça ?
+Vous allez mieux ?
+Vous allez souvent en Floride ?
+Vous avez un amoureux ?
+Vous avez une amoureuse ?
+Vous avez un crayon gris ?
+Vous avez un problème ?
+Vous avez une piscine ?
+Vous avez rendez-vous ?
+Vous en avez un autre ?
+Vous avez des enfants ?
+Vous avez du café ?
+Vous avez de l’argent ?
+Vous avez des crayons gris ?
+Il y a des places vacantes ?
+Vous avez quelque chose ?
+Vous avez quelque chose de meilleur marché ?
+Vous avez assez d’argent sur vous ?
+Vous avez le numéro du taxi ?
+Vous avez celui-ci en taille onze.
+Et vous avez le temps de lire le journal le matin ?
+Vous avez entendu ?
+Vous la connaissez ?
+Vous savez combien il coûte ?
+Vous savez combien ça coûte ?
+Vous savez combien elle coûte ?
+Vous savez comment cuisiner ?
+Vous savez comment aller à l’hôtel Mariott ?
+Vous savez comment se rendre à l’hôtel Mariott ?
+Vous savez ce qu’il veut dire ?
+Vous savez ce qui est écrit là ?
+Vous savez où je peux prendre un taxi ?
+Vous savez où sont mes lunettes ?
+Vous savez qui elle est ?
+Est-ce que vous savez qui elle est ?
+Savez-vous où est-ce qu’il y a un magasin qui vend des serviettes ?
+Vous savez où est-ce qu’il y a un magasin qui vend des serviettes ?
+Vous vous plaisez ici ?
+Ça vous plait ?
+Le livre vous plait ?
+Vous aimez regarder la télévision ?
+Votre directeur vous plait ?
+Vos collaborateurs vous plaisent ?
+Vous avez besoin de quelque chose d’autre ?
+Vous avez besoin de quelque chose ?
+Vous ouvrez la porte ?
+Vous faites un sport quelconque ?
+Vous pratiquez un sport quelconque ?
+Vous jouez au Basket ?
+Vous vendez des piles ?
+Vous vendez des médicaments ?
+Vous fumez ?
+Vous parlez anglais ?
+Vous parlez français ?
+Vous parlez espagnol ?
+Vous apprenez l’anglais ?
+Vous prenez les cartes de crédit ?
+Et vous pensez que je ne sais pas cela ?
+Il va pleuvoir aujourd’hui, vous pensez ?
+Et vous pensez qu’il va pleuvoir demain ?
+C’est possible, vous pensez ?
+Et vous pensez être une personne intelligente ?
+Vous serez de retour pour onze heures et demi, vous pensez ?
+Vous comprenez ?
+Vous voulez que je vienne vous prendre ?
+Vous voulez venir avec moi ?
+Vous voulez aller au cinéma ?
+Vous voulez y aller avec moi ?
+Quelqu’un sait l’anglais ici ?
+Quelqu’un sait l’allemand ici ?
+Il se plait à l’école ?
+L’école lui plait ?
+Il ouvre la porte ?
+Il neige souvent pendant l’hiver au Massachusetts ?
+Cette route va à Auray ?
+Cette route va à Nantes ?
+Cette route va à New York ?
 Ne tournons pas autour du pot.
 Soyons clairs.
 Il ne faut pas le frapper.
 Ne le frappez pas.
-Ne reviens pas !
-Ne revenez pas !
-Il ne faut pas que tu reviennes
+Ne reviens pas !
+Ne revenez pas !
+Il ne faut pas que tu reviennes.
 Il ne faut pas que vous reveniez.
-Ne compliques pas mon esprit.
+Ne complique pas mon esprit.
 Ne pleure pas.
 Ne me dérangez pas.
 Ne faites pas ça.
 Il ne faut pas faire ça.
 Ne mangez pas trop.
-Ce n'est pas la peine de s'énerver.
-N'y allez pas !
-N'y vas pas !
+Ce n’est pas la peine de s’énerver.
+N’y allez pas !
+N’y va pas !
 Il ne faut pas que vous y alliez.
-Ne laissez pas la parte ouverte.
+Ne laissez pas la porte ouverte.
 Ne me faites pas me mettre en colère.
 Ne faites pas de bruit.
 Il ne faut pas faire de bruit.
@@ -4744,89 +4767,93 @@ Ne déménagez pas avec eux.
 Ne bougez pas avec eux.
 Ne bougez pas.
 Ne vous querellez pas avec lui.
-Ne m'attaquez pas.
+Ne m’attaquez pas.
 Ne hurlez pas.
-Ne dépensez pas tout l'argent.
+Ne dépensez pas tout l’argent.
 Ne parlez pas de ça.
 Ne me parlez pas.
 Ne racontez pas de mensonges.
 Ne croyez pas que vous êtes intelligent.
 Ne me faites pas perdre patience.
 Ne me faites pas perdre de temps.
-Ne vous en faites pas !
+Ne vous en faites pas !
 Il ne faut pas vous en faire.
 Ne vous en faites pas. Tout ira bien.
-Ne vous en faites pas. J'ai le même problème.
+Ne vous en faites pas. J’ai le même problème.
 Mangez doucement.
 Anglais.
-Expressions et mots d'anglais.
-Bon appétit ! (pour les repas…).
+Expressions et mots d’anglais.
+Bon appétit !
+Pour les repas.
 Toutes les semaines.
 Tout le monde va bien.
 Tout le monde se trompe tôt ou tard, vous savez.
-Je me lève tous les jours à 6h du matin.
+Je me lève tous les jours à six heures du matin.
 Tout sauf la fille.
 Tout est prêt.
 Super.
-Excusez-moi… ! (pour demander quelque chose).
-Excusez-moi ! (pour passer).
-Excusez-moi, qu'est-ce que vous avez dit ?
-Excusez-moi, qu'avez-vous dit ?
-Excusez-moi
+Excusez-moi…
+Pour demander quelque chose.
+Excusez-moi !
+Pour passer.
+Excusez-moi, qu’est-ce que vous avez dit ?
+Excusez-moi, qu’avez-vous dit ?
+Excusez-moi.
 Date de fin.
 Extra.
-Remplissez-le s'il vous plaît.
+Remplissez-le s’il vous plait.
 Bien.
 Excellent.
 En très bonne santé.
 Suivez-moi.
-Pour combien de nuits ?
+Pour combien de nuits ?
 Laissez tomber.
-Laissez tomber. Tout le monde peut se tromper.
+Tout le monde peut se tromper.
 Oubliez le passé.
-Quatre, Cinq, Six.
-D'ici à là-bas.
+Quatre, cinq, six.
+D’ici à là-bas.
 De temps en temps.
 Habillez-vous, vite.
 Allez vous faire voir.
-Partez d'ici.
+Partez d’ici.
 Levez-vous.
-Donnez-le leur.
-Donnez-la leur.
+Donnez-le-leur.
+Donnez-la-leur.
 Donnez-moi le crayon.
 Donnez-moi ça.
 Allez tout droit.
-Allez tout droit ! Après tournez à gauche/ à droite !
-Allez chier !
+Allez tout droit !
+Après tournez à gauche ou à droite !
+Allez chier !
 Bon après-midi.
-Au revoir !
+Au revoir !
 Bonsoir monsieur.
-Bonsoir !
+Bonsoir !
 Bonne idée.
-Bonne chance !
-Bonjour !
-Bonne nuit et dormez bien !
-Bien/ mal/ entre les deux.
-Bien/ entre les deux.
-Bon anniversaire !
-Bonne année !
-Est-ce que votre frère a déjà été en Californie ?
+Bonne chance !
+Bonjour !
+Bonne nuit et dormez bien !
+Bien, mal, entre les deux.
+Bien, entre les deux.
+Bon anniversaire !
+Bonne année !
+Est-ce que votre frère a déjà été en Californie ?
 Bon voyage.
-Est-ce qu'ils l'ont déjà rencontré ?
-Vous avez des crayons ?
-Vous êtes arrivé ?
-Vous avez déjà été à Boston ?
-Vous avez attendu longtemps ?
-Est-ce que vous avez déjà fait ça ?
-Est-ce que vous avez déjà mangé dans ce restaurant ?
-Vous avez mangé ?
-Est-ce que vous avez déjà mangé auparavant de la soupe de pommes-de-terre ?
-Vous avez terminé vos études ?
-Vous avez vu ce film ?
+Est-ce qu’ils l’ont déjà rencontré ?
+Vous avez des crayons ?
+Vous êtes arrivé ?
+Vous avez déjà été à Boston ?
+Vous avez attendu longtemps ?
+Est-ce que vous avez déjà fait ça ?
+Est-ce que vous avez déjà mangé dans ce restaurant ?
+Vous avez mangé ?
+Est-ce que vous avez déjà mangé auparavant de la soupe de pommes de terre ?
+Vous avez terminé vos études ?
+Vous avez vu ce film ?
 Il fait toujours ça pour moi.
 Il a brisé la fenêtre.
 Il a cassé la fenêtre.
-Il s'est débrouillé dans la vie.
+Il s’est débrouillé dans la vie.
 Il est venu en bus.
 Il est venu en voiture.
 Il est venu ici tout seul.
@@ -4834,171 +4861,171 @@ Il était venu ici la semaine dernière.
 Il est venu ici hier.
 Il est venu ici.
 Il est venu pour rencontrer mon père.
-Il est venu à mon bureau pour demander de l'argent.
+Il est venu à mon bureau pour demander de l’argent.
 Il est venu à mon bureau.
-Il n'ouvre pas la porte.
+Il n’ouvre pas la porte.
 Ellen ne ressemble pas à une infirmière.
 Il a une belle voiture.
-Est-ce qu'il a quelques lettres pour votre père ?
-C'est un affairiste.
-C'est un gars rigolo.
+Est-ce qu’il a quelques lettres pour votre père ?
+C’est un affairiste.
+C’est un gars rigolo.
 Il est ingénieur en informatique chez WIPRO.
-C'est Andrew.
-Il s'appelle Andrew.
+C’est Andrew.
+Il s’appelle Andrew.
 Il réussit bien.
 Il va bien.
 Il est en classe avec moi.
-C'est un de mes collaborateurs.
-C'est mon frère aîné.
-C'est mon père.
-C'est mon grand-père.
-C'est mon voisin.
-Il est en train d'ouvrir la porte…
+C’est un de mes collaborateurs.
+C’est mon frère ainé.
+C’est mon père.
+C’est mon grand-père.
+C’est mon voisin.
+Il est en train d’ouvrir la porte…
 Il travaille comme ingénieur en informatique chez WIPRO.
 Il travaille chez MSN - USA.
 Il est venu faire un tour seulement.
-Ça lui plaît énormément.
-Il aime bien le jus mais il n'aime pas le lait.
+Ça lui plait énormément.
+Il aime bien le jus mais il n’aime pas le lait.
 Il habite à Paris en France.
 Nous avons besoin de quelques nouveaux vêtements.
 Il ne me donne jamais rien.
 Il ouvre la porte.
 La porte ouvre.
-Il dit que c'est un lieu agréable.
+Il dit que c’est un lieu agréable.
 Il dit que vous aimez regardez des films.
-Il étudie à l'université de Boston.
+Il étudie à l’université de Boston.
 Il pense que nous ne voulons y aller.
-Il travaille dans une entreprise d'informatique à New York.
-Il reviendra dans 20 minutes.
+Il travaille dans une entreprise d’informatique à New York.
+Il reviendra dans vingt minutes.
 Salut.
-Au secours !
+Au secours !
 Voilà quelques lettres pour que vous appreniez.
 Voilà votre salade.
 Voilà.
 Vous êtes là.
-Voilà (quand on donne quelque chose).
-Voilà (lorsque l'on donne quelque chose).
-À partir de maintenant je n'irai pas avec eux.
+Voilà quand on donne quelque chose.
+Voilà lorsque l’on donne quelque chose.
+À partir de maintenant je n’irai pas avec eux.
 Voilà mon numéro.
 Voilà votre ordre.
-C'est un gars rigolo.
-C'est un très bon étudiant.
+C’est un gars rigolo.
+C’est un très bon étudiant.
 Il est américain.
-Il est ingénieur?
+Il est ingénieur ?
 Il arrive bientôt.
 Il sera bientôt ici.
 Il va plus vite que moi.
 Il est à la cuisine.
-Il n'a jamais été en Amérique.
-Il n'est pas ici pour le moment.
-Il a raison.
-C'est une personne très ennuyeuse.
+Il n’a jamais été en Amérique.
+Il n’est pas ici pour le moment.
+C’est une personne très ennuyeuse.
 Il est très connu.
-Il travaille d'arrache-pied.
-Alors ! Mon gars !
-Alors ! Comment est-ce que vous pouvez me parlez comme ça ?
-Salut !
-Salut ! Mme Smith est là, s'il vous plaît ?
-Cachez le quelque part.
+Il travaille d’arrache-pied.
+Alors ! Mon gars !
+Alors ! Comment est-ce que vous pouvez me parlez comme ça ?
+Salut !
+Salut ! Madame Smith est là, s’il vous plait ?
+Cachez-le quelque part.
 Sa famille vient demain.
 Sa chambre est très petite.
 Son fils.
-Attendez un petit moment ! (téléphone)
-Pourquoi pas samedi ?
-Pourquoi pas aller à l'eau ?
-Comment vont les choses ?
-Combien êtes-vous intéressé par mes affaires ?
-Comment ferez-vous pour réussir ?
-Comment payerez-vous ?
-Comment vont vos parents ?
-Comment il est venu ?
-Comment ont-ils réussi à s'enfuir ?
-Comment avez-vous réussi à les convaincre ?
-Comment avez-vous fait pour aller jusque là ?
-Comment avez-vous trouver la maison ?
-Comment avez-vous pu atteindre le lieu ?
-Comment je fais pour y aller ?
-Comment je fais pour aller à la rue Daniel ?
-Comment je fais pour aller à l'ambassade des États-Unis ?
-Comment est-ce que je sais ça ?
-Comment je fais avec ça ?
-Comment avez-vous trouver la leçon ?
-Comment allez-vous au travail ?
-Comment savez-vous ça ?
-Comment le savez-vous ?
-Comment réussissez-vous ?
-Comment on explique ça ?
-Comment est-ce que je dis ça en anglais ?
-Comment est-ce que vous écrivez ça ?
-Comment est-ce que vous écrivez le mot Seattle ?
-Quel goût a-t-il ?
-Quel niveau d'étude avez-vous ?
-À quelle distance est-il de Chennai ?
-À quelle distance est-il de Bombay ?
-Est-ce que c'est loin d'ici à Chicago ?
-À quelle distance est-il ?
-À quelle distance se trouve Salem d'ici ?
-Comment va tout le monde à la maison ?
-Comment va tout le monde ?
-Comment est le film ?
-Comment est la maison neuve ?
-Comment est le temps ?
-Quelle allure a le temps ?
-Comment est votre frère ?
-Comment est votre père ?
-Comment va votre frère Suresh ?
-Comment va votre mariage ?
-Comment va votre mère ?
-Comment va votre sœur ?
-Combien de temps resterez-vous en Californie ?
-Combien de temps allez-vous rester là ?
-Combien de temps allez-vous rester ?
-Combien de temps ça prend en voiture ?
-Combien de temps pour aller en Géorgie ?
-Combien de temps avez-vous été ici ?
-Combien de temps avez-vous été en Amérique ?
-Combien de temps avez-vous habité ici ?
-Combien de temps avez-vous travaillé ici ?
-À quelle distance est-ce ?
-Combien de temps dure le vol ?
-Combien de temps il va supporter ?
-Combien de temps ça va durer .
-Combien de temps resterez-vous ?
-Combien de temps allez-vous attendre ?
-Combien de frères avez-vous ?
-Combien d'enfants avez-vous ?
-Combien d'heures travaillez-vous par semaine ?
-Combien d'heures de conduite ?
-Combien de langues parlez-vous ?
-Combien de miles y a-t-il d'ici en Pennsylvanie ?
-Combien y a-t-il d'habitants à New York ?
-Combien de personnes vivent à New York ?
-Combien êtes-vous dans votre famille ?
-Combien de chambres y a-t-il dans la maison ?
-Combien de sœurs avez-vous ?
-Combien le tout  ?
-Combien valent ces boucles d'oreille ?
-Combien je vous dois ?
-Combien ça coûte par jour ?
-Combien coûte ceci ?
-Combien ça coûte d'aller à Miami ?
-C'est combien ça ?
-Combien d'argent avez-vous sur vous ?
-Combien d'argent gagnez-vous ?
-Combien de riz y a-t-il là ?
-Combien est-ce que ça coûtera ?
-Combien aimerez-vous ?
-Tous les combien de temps allez-vous là-bas ?
+Attendez un petit moment !
+Pourquoi pas samedi ?
+Pourquoi pas aller à l’eau ?
+Comment vont les choses ?
+Combien êtes-vous intéressé par mes affaires ?
+Comment ferez-vous pour réussir ?
+Comment payerez-vous ?
+Comment vont vos parents ?
+Comment il est venu ?
+Comment ont-ils réussi à s’enfuir ?
+Comment avez-vous réussi à les convaincre ?
+Comment avez-vous fait pour aller jusque là ?
+Comment avez-vous trouvé la maison ?
+Comment avez-vous pu atteindre le lieu ?
+Comment je fais pour y aller ?
+Comment je fais pour aller à la rue Daniel ?
+Comment je fais pour aller à l’ambassade des États-Unis ?
+Comment est-ce que je sais ça ?
+Comment je fais avec ça ?
+Comment avez-vous trouvé la leçon ?
+Comment allez-vous au travail ?
+Comment savez-vous ça ?
+Comment le savez-vous ?
+Comment réussissez-vous ?
+Comment on explique ça ?
+Comment est-ce que je dis ça en anglais ?
+Comment est-ce que vous écrivez ça ?
+Comment est-ce que vous écrivez le mot Seattle ?
+Quel goût a-t-il ?
+Quel niveau d’étude avez-vous ?
+À quelle distance est-il de Chennai ?
+À quelle distance est-il de Bombay ?
+Est-ce que c’est loin d’ici à Chicago ?
+À quelle distance est-il ?
+À quelle distance se trouve Salem d’ici ?
+Comment va tout le monde à la maison ?
+Comment va tout le monde ?
+Comment est le film ?
+Comment est la maison neuve ?
+Comment est le temps ?
+Quelle allure a le temps ?
+Comment est votre frère ?
+Comment est votre père ?
+Comment va votre frère Suresh ?
+Comment va votre mariage ?
+Comment va votre mère ?
+Comment va votre sœur ?
+Combien de temps resterez-vous en Californie ?
+Combien de temps allez-vous rester là ?
+Combien de temps allez-vous rester ?
+Combien de temps ça prend en voiture ?
+Combien de temps pour aller en Géorgie ?
+Combien de temps avez-vous été ici ?
+Combien de temps avez-vous été en Amérique ?
+Combien de temps avez-vous habité ici ?
+Combien de temps avez-vous travaillé ici ?
+À quelle distance est-ce ?
+Combien de temps dure le vol ?
+Combien de temps il va supporter ?
+Combien de temps ça va durer ?
+Combien de temps resterez-vous ?
+Combien de temps allez-vous attendre ?
+Combien de frères avez-vous ?
+Combien d’enfants avez-vous ?
+Combien d’heures travaillez-vous par semaine ?
+Combien d’heures de conduite ?
+Combien de langues parlez-vous ?
+Combien de miles y a-t-il d’ici en Pennsylvanie ?
+Combien y a-t-il d’habitants à New York ?
+Combien de personnes vivent à New York ?
+Combien êtes-vous dans votre famille ?
+Combien de chambres y a-t-il dans la maison ?
+Combien de sœurs avez-vous ?
+Combien ?
+Combien le tout  ?
+Combien valent ces boucles d’oreille ?
+Combien je vous dois ?
+Combien ça coûte par jour ?
+Combien coûte ceci ?
+Combien ça coûte d’aller à Miami ?
+C’est combien ça ?
+Combien d’argent avez-vous sur vous ?
+Combien d’argent gagnez-vous ?
+Combien de riz y a-t-il là ?
+Combien est-ce que ça coûtera ?
+Combien aimerez-vous ?
+Tous les combien de temps allez-vous là-bas ?
 Quel âge avez-vous.
-Quel est votre âge ?
-Quel est votre taille ?
-Comment se présenter ?
-Comment était le film ?
-Comment était le voyage ?
-Comment est-ce que vous réussirez ?
-Comment sont les affaires ?
-Comment ça va avec le travail ?
-Dépêchez-vous !
+Quel est votre âge ?
+Quelle est votre taille ?
+Comment se présenter ?
+Comment était le film ?
+Comment était le voyage ?
+Comment est-ce que vous réussirez ?
+Comment sont les affaires ?
+Comment ça va avec le travail ?
+Dépêchez-vous !
 Je suis diplômé de B.E.
 Je suis une fille.
 Moi, je suis une fille.
@@ -5006,38 +5033,38 @@ Je suis diplômé en ingénierie.
 Je suis femme au foyer.
 Je suis originaire de Washington.
 Je fais une thèse de médecine.
-Je suis professeur d'anglais à l'université du Wisconsin.
-Je suis étudiant à l'université de St. Andrew.
+Je suis professeur d’anglais à l’université du Wisconsin.
+Je suis étudiant à l’université de Saint Andrew.
 Je vois toujours les choses du bon côté.
 Je suis ingénieur.
 Je suis un gars dégourdi.
 Je fais des affaires.
-Je vais bien et vous ?
+Je vais bien et vous ?
 Je vais bien.
 Je suis direct.
 Je suis une personne directe.
 Je suis une personne aimable.
 Je suis aimable.
 Je suis de Chicago.
-Je m'appelle Fulup.
-Moi, je m'appelle Fulup.
-J'y vais maintenant.
-J'y vais.
-Je m'appelle John.
-Je m'en vais pour Bangalore ce soir et je serai revenu dans 10 jours.
+Je m’appelle Fulup.
+Moi, je m’appelle Fulup.
+J’y vais maintenant.
+J’y vais.
+Je m’appelle John.
+Je m’en vais pour Bangalore ce soir et je serai revenu dans dix jours.
 Je pars à Salem demain soir.
 Je vis à Londres.
 Je cherche du travail.
-Je m'appelle Mary.
-Je suis Mlle Catherine.
-Je suis Mme Obama.
-Je ne suis pas un fille.
-Je suis en train d'ouvrir, je ne suis pas en train d'ouvrir.
+Je m’appelle Mary.
+Je suis mademoiselle Catherine.
+Je suis madame Obama.
+Je ne suis pas une fille.
+Je suis en train d’ouvrir, je ne suis pas en train d’ouvrir.
 Je suis content.
 Je suis plutôt timide.
 Je suis modeste par nature.
-J'habite à Londres.
-Je suis certain que ce n'était pas de voter faute et tout le monde le sait.
+J’habite à Londres.
+Je suis certain que ce n’était pas de votre faute et tout le monde le sait.
 Je vous suis très reconnaissant.
 Je suis très satisfait.
 Je suis extrêmement satisfait.
@@ -5049,20 +5076,20 @@ Je crois en vous.
 Je vous crois.
 Je suis de Brest.
 Je suis de Chennai.
-J'avais acheté une chemise hier.
-J'achète la lampe également.
-J'achète aussi la lampe.
+J’avais acheté une chemise hier.
+J’achète la lampe également.
+J’achète aussi la lampe.
 Je suis venu ensemble avec ma famille.
 Je peux nager.
 Je ne peux pas vous entendre de manière satisfaisante.
 Je ne peux pas vous entendre.
 Je viens de Chicago.
-J'ai fait mes études universitaires à Washington.
-J'ai été à l'école à Chicago.
-Je n'ai pas ouvert la porte ?
-Je ne veux par regarder la télévision.
-Je n'ouvre pas la porte.
-Je m'en fous.
+J’ai fait mes études universitaires à Washington.
+J’ai été à l’école à Chicago.
+Je n’ai pas ouvert la porte ?
+Je ne veux pas regarder la télévision.
+Je n’ouvre pas la porte.
+Je m’en fous.
 Je ne veux rien manger.
 Je ne veux pas sortir.
 Je ne veux parler à personne.
@@ -5070,455 +5097,449 @@ Je ne veux pas marcher vite.
 Je suis un peu mal foutu.
 Je ne trouve pas de mot pour vous remercier.
 Je ne vais pas.
-Je n'ai pas de petit ami.
-Je n'ai pas d'argent sur moi.
-Je n'ai pas d'argent.
-Je n'ai pas assez d'argent sur moi.
-Je n'ai pas assez d'argent.
-Je n'ai pas le temps là.
+Je n’ai pas de petit ami.
+Je n’ai pas d’argent sur moi.
+Je n’ai pas d’argent.
+Je n’ai pas assez d’argent sur moi.
+Je n’ai pas assez d’argent.
+Je n’ai pas le temps là.
 Je ne sais pas comment vous remercier.
-Je ne sais pas comment l'utiliser.
-Je ne sais pas !
+Je ne sais pas comment l’utiliser.
+Je ne sais pas !
 Ça ne me plait pas.
 Il ne me plait pas.
-Je ne parle pas l'anglais couramment.
+Je ne parle pas l’anglais couramment.
 Je ne parle pas couramment.
 Je ne pense pas.
 Je ne comprends pas ce que vous dites.
 Je ne comprends pas.
-Je ne veux pa ça.
+Je ne veux pas ça.
 Je ne veux pas vous déranger.
-J'ai de la fièvre.
+J’ai de la fièvre.
 Je suis étourdi.
 Je suis bien.
 Je me sens coupable.
-J'ai faim.
-J'ai du pouvoir.
+J’ai faim.
+J’ai du pouvoir.
 Je suis un peu timide.
-J'ai envie de dormir.
-J'ai soif.
-J'oublie.
-Je quitte le travail à 6h.
-Je me lève à 5h15.
-Je me lève à 6h30.
-J'arrête.
+J’ai envie de dormir.
+J’oublie.
+Je quitte le travail à six heures.
+Je me lève à cinq heures et quart.
+Je me lève à six heures et demi.
+J’arrête.
 Je prends le bus.
 Je vais en vélo.
 Je vais en vélomoteur.
 Je prends le train.
-Je vais me coucher à 10h30.
+Je vais me coucher à dix heures trente.
 Je vais.
-J'ai eu un accident.
-J'ai été scolarisé à Londres.
-J'ai un bol de soupe.
-J'ai une boîte d'allumettes.
+J’ai eu un accident.
+J’ai été scolarisé à Londres.
+J’ai un bol de soupe.
+J’ai une boîte d’allumettes.
 Je suis enrhumé.
 Je tousse.
-J'ai beaucoup d'eau.
-J'ai mal à la tête.
-J'ai beaucoup de riz.
-J'ai beaucoup de choses à manger.
-J'ai beaucoup de choses à faire.
-J'ai une paire de tasses de thé.
-J'ai une paire de ciseaux.
-J'ai une paire de chaussures.
-J'ai une paire de chaussons.
-J'ai un crayon et deux livres.
-J'ai un morceau de craie.
-Je veux vous poser une question / Est-ce que je veux vous demander quelque chose ?
-J'ai un crayon rouge.
+J’ai beaucoup d’eau.
+J’ai mal à la tête.
+J’ai beaucoup de riz.
+J’ai beaucoup de choses à manger.
+J’ai beaucoup de choses à faire.
+J’ai une paire de tasses de thé.
+J’ai une paire de ciseaux.
+J’ai une paire de chaussures.
+J’ai une paire de chaussons.
+J’ai un crayon et deux livres.
+J’ai un morceau de craie.
+Je veux vous poser une question.
+Est-ce que je veux vous demander quelque chose ?
+J’ai un crayon rouge.
 Ma place a été réservée.
-J'ai un morceau de pain.
-J'ai un sac de riz.
-J'ai été travailler, je n'ai pas ouvert.
-Je n'ai plus de patience.
-J'en ai fini avec ma M.S.
-J'ai fait mon B.S en ingénierie.
-J'ai des problèmes de cœur.
-J'ai des problèmes de foie.
-J'ai de l'argent.
+J’ai un morceau de pain.
+J’ai un sac de riz.
+J’ai été travailler, je n’ai pas ouvert.
+Je n’ai plus de patience.
+J’en ai fini avec ma M.S.
+J’ai fait mon B.S en ingénierie.
+J’ai des problèmes de cœur.
+J’ai des problèmes de foie.
+J’ai de l’argent.
 Je ne me souviens de rien.
-Je n'ai pas le temps de vous voir.
-J'en ai un dans ma voiture.
-Il ne me reste que quelques secondes pour vous rappeler que votre travail sur ces leçons n'est pas terminé, loin de là.
-J'ai ouvert, je n'ai pas ouvert. Est-ce que vous avez ouvert ?
-J'ai mal au bras.
-J'ai mal à la gorge.
-J'ai mal à l'estomac.
-J'ai étudié jusqu'à obtenir mon diplôme.
-J'ai trois frères et deux sœurs.
-J'ai trois enfants, deux filles et un gars.
-J'ai trois sœurs et deux frères.
+Je n’ai pas le temps de vous voir.
+J’en ai un dans ma voiture.
+Il ne me reste que quelques secondes pour vous rappeler que votre travail sur ces leçons n’est pas terminé, loin de là.
+J’ai ouvert, je n’ai pas ouvert.
+Est-ce que vous avez ouvert ?
+J’ai mal au bras.
+J’ai mal à la gorge.
+J’ai mal à l’estomac.
+J’ai étudié jusqu’à obtenir mon diplôme.
+J’ai trois frères et deux sœurs.
+J’ai trois enfants, deux filles et un gars.
+J’ai trois sœurs et deux frères.
 Je dois aller à la poste.
 Je dois y aller.
-Je dois l'amener à Kumbakonam.
+Je dois l’amener à Kumbakonam.
 Je dois laver mes vêtements.
-J'ai mal aux dents.
-J'ai deux frères et une sœur.
-J'ai deux paquets de sucre.
-J'ai deux sœurs et un frère.
-J'ai deux sœurs.
-Je n'ai pas de crayon rouge.
-Je n'ai pas de crayon jaune.
-Je n'ai rien entendu à son sujet depuis que vous m'avez écrit il y a un mois.
-Je n'y ai pas été.
-Je n'ai pas fini de manger.
-Je n'ai pas encore déjeuné.
-J'espère qu'ils seront vainqueurs.
-J'espère que vous aurez, vous et votre femme, un voyage agréable.
-J'ai lu les titres rapidement.
-Je sais.
-Je m'en vais à 9h15.
-J'aime l'anglais.
-Ça me plaît.
-J'aime ça.
-J'aime la nourriture italienne.
-J'aime regarder la télévision.
-J'habite (aux États-Unis/en France).
-J'habite en Californie.
-J'ai perdu ma montre.
-Je vous aime !
+J’ai mal aux dents.
+J’ai deux frères et une sœur.
+J’ai deux paquets de sucre.
+J’ai deux sœurs et un frère.
+J’ai deux sœurs.
+Je n’ai pas de crayon rouge.
+Je n’ai pas de crayon jaune.
+Je n’ai rien entendu à son sujet depuis que vous m’avez écrit il y a un mois.
+Je n’y ai pas été.
+Je n’ai pas fini de manger.
+Je n’ai pas encore déjeuné.
+J’espère qu’ils seront vainqueurs.
+J’espère que vous aurez, vous et votre femme, un voyage agréable.
+J’ai lu les titres rapidement.
+Je m’en vais à neuf heures quinze.
+J’aime l’anglais.
+Ça me plait.
+J’aime ça.
+J’aime la nourriture italienne.
+J’aime regarder la télévision.
+J’habite aux États-Unis ou en France.
+J’habite en Californie.
+J’ai perdu ma montre.
+Je vous aime !
 Je vous aime.
-J'ai fait une erreur.
-J'ai commis une erreur.
-C'est moi qui ait fait ce gâteau.
+J’ai fait une erreur.
+J’ai commis une erreur.
+C’est moi qui ais fait ce gâteau.
 Vous me manquez énormément.
-J'ai besoin de voir un médecin.
-J'ai besoin d'une autre clef.
-J'ai besoin de matériels.
-J'ai besoin de ça pour y aller demain.
+J’ai besoin de voir un médecin.
+J’ai besoin d’une autre clef.
+J’ai besoin de matériels.
+J’ai besoin de ça pour y aller demain.
 Tu dois changer de vêtements.
 Je dois aller à la maison.
 Je dois y aller maintenant.
 Je dois parler anglais plus souvent.
 Je dois parler français plus souvent.
-Je n'ai que 5 dollars sur moi.
+Je n’ai que cinq dollars sur moi.
 Un peu de nourriture me suffira sans plus.
-J'ouvre la porte.
-J'ouvre, je n'ouvre pas (ça n'ouvre pas), et vous ouvrez.
-J'avais ouvert la porte.
-J'avais ouvert, je n'avais pas ouvert, et vous aviez ouvert
+J’ouvre la porte.
+J’ouvre, je n’ouvre pas, ça n’ouvre pas, et vous ouvrez.
+J’avais ouvert la porte.
+J’avais ouvert, je n’avais pas ouvert, et vous aviez ouvert.
 Je lis le Times.
 Ça me plait vachement.
 Je me souviens.
-Je reviens à la maison à 6h30.
+Je reviens à la maison à six heures et demi.
 Je parle un peu anglais.
 Je parle deux langues.
 Il me reste encore beaucoup de choses à acheter.
-J'ai encore beaucoup de choses à faire.
+J’ai encore beaucoup de choses à faire.
 Je dois encore me brosser les dents et prendre ma douche.
-Je n'ai pas encore décidé.
+Je n’ai pas encore décidé.
 Je prends dix minutes pour y aller.
 Je pense que je dois aller voir un médecin.
-Je pense qu'il a bon goût.
-Je pense qu'il pleuvra aujourd'hui.
-C'est très bien, je pense.
+Je pense qu’il a bon goût.
+Je pense qu’il pleuvra aujourd’hui.
+C’est très bien, je pense.
 Je pense.
 Je trouve que ces chaussures sont belles.
 Je pense que vous avez trop de vêtements.
-Je pense que vous avez trop d'habits.
-Je pensais qu'il avait dit quelque chose.
+Je pense que vous avez trop d’habits.
+Je pensais qu’il avait dit quelque chose.
 Je pensais que les vêtements étaient meilleur marché.
 Je comprends maintenant.
 Je comprends.
 Le plus souvent je bois du café au petit déjeuner.
 Je veux acheter quelque chose.
-J'ai envie d'acheter quelque chose.
+J’ai envie d’acheter quelque chose.
 Je veux entrer en relation avec notre ambassade.
 Je veux vous donner un cadeau.
 Je veux envoyer ce paquet aux États-Unis.
-J'ai envie de vous montrer quelque chose.
-J'étais sur le point de quitter le restaurant quand mes amis sont arrivés.
-J'étais en train d'aller à la bibliothèque.
-J'étais à la bibliothèque.
-J'ai été au supermarché et ensuite au magasin d'informatique.
+J’ai envie de vous montrer quelque chose.
+J’étais sur le point de quitter le restaurant quand mes amis sont arrivés.
+J’étais en train d’aller à la bibliothèque.
+J’étais à la bibliothèque.
+J’ai été au supermarché et ensuite au magasin d’informatique.
 Je reviens tout de suite.
 Je viendrai vous chercher.
-Je n'oublierai jamais le temps que vous m'avez consacré pour m'aider.
-Je n'ouvrirai pas la porte.
-J'ouvrirai la porte. Je devrais ouvrir la porte.
-J'ouvrirai, je n'ouvrirai pas, est-ce que vous ouvrirez, qu'est-ce que vous ferez.
-Je t'y emmènerai un jour.
-J'aimerais en avoir une.
+Je n’oublierai jamais le temps que vous m’avez consacré pour m’aider.
+Je n’ouvrirai pas la porte.
+J’ouvrirai la porte.
+Je devrais ouvrir la porte.
+J’ouvrirai, je n’ouvrirai pas, est-ce que vous ouvrirez, qu’est-ce que vous ferez.
+Je t’y emmènerai un jour.
+J’aimerais en avoir une.
 Je ne téléphonerai pas à mon ami avant que Bob ne soit arrivé.
 Je ne dirai rien du tout avant que tu lui dises.
-Je travaille comme (traducteur / homme d'affaires).
-Je pendrai une soupe.
-Je resterai ici jusqu'à ce que tu sois revenu.
-J'ai peur.
+Je travaille comme traducteur et homme d’affaires.
+Je prendrai une soupe.
+Je resterai ici jusqu’à ce que tu sois revenu.
+J’ai peur.
 Je suis pressé maintenant.
-J'ai huit ans.
-J'aime.
+J’ai huit ans.
+J’aime.
 Je suis intéressé par ce livre.
-Il n'est pas en train d'ouvrir la porte ?
-Il est en train d'ouvrir la porte.
+Il n’est pas en train d’ouvrir la porte ?
+Il est en train d’ouvrir la porte.
 Je suis prêt à déjeuner.
 Tu me plais beaucoup comme ami.
-J'aimerais avoir un plan de ville.
+J’aimerais avoir un plan de ville.
 Je voudrais une chambre non fumeur.
-Je voudrais avoir une chambre avec deux lits s'il vous plaît
+Je voudrais avoir une chambre avec deux lits s’il vous plait.
 Je voudrais avoir une chambre.
 Je voudrais avoir une chambre seule.
-J'aimerais avoir une table près de la fenêtre.
-J'aimerais aussi avoir un verre d'eau, s'il vous plaît.
-Je voudrais avoir le numéro de l'hôtel Hilton, s'il vous plaît.
-Je voudrais acheter une bouteille d'eau s'il vous plaît.
+J’aimerais avoir une table près de la fenêtre.
+J’aimerais aussi avoir un verre d’eau, s’il vous plait.
+Je voudrais avoir le numéro de l’hôtel Hilton, s’il vous plait.
+Je voudrais acheter une bouteille d’eau s’il vous plait.
 Je voudrais acheter une carte de téléphone.
 Je voudrais acheter quelque chose.
 Je voudrais téléphoner aux États-Unis.
-Je voudrais manger au restaurant de la 5è rue.
+Je voudrais manger au restaurant de la cinquième rue.
 Je voudrais échanger celui-ci contre des dollars.
-J'aimerais aller promener.
-J'aimerais aller à la maison.
-J'aimerais faire du shopping.
-J'aimerais aller au magasin.
-J'aimerais téléphoner.
+J’aimerais aller promener.
+J’aimerais aller à la maison.
+J’aimerais faire du shopping.
+J’aimerais aller au magasin.
+J’aimerais téléphoner.
 Je veux réserver une place.
 Je veux louer une voiture.
-J'aimerais envoyer un fax.
+J’aimerais envoyer un fax.
 Je veux envoyer ça en Amérique.
-J'aimerais parler à M. Smith s'il vous plaît.
-J'aimerais utiliser l'Internet.
-J'aimerais aller en Espagne un jour.
-Si ça te plaît je peux acheter plus.
-Si vous avez besoin d'être aidé, dites le moi.
+J’aimerais parler à monsieur Smith s’il vous plait.
+J’aimerais utiliser l’Internet.
+J’aimerais aller en Espagne un jour.
+Si ça te plait je peux acheter plus.
+Si vous avez besoin d’être aidé, dites-le-moi.
 Je rappellerai plus tard.
 Je vous téléphonerai vendredi.
 Je vous téléphonerai quand je partirai.
 Je reviendrai plus tard.
 Je vous téléphonerai.
-Je prendrai une tasse de thé s'il vous plaît.
-Je prendrai un verre d'eau s'il vous plaît.
+Je prendrai une tasse de thé s’il vous plait.
+Je prendrai un verre d’eau s’il vous plait.
 Je prendrai la même chose.
 Je paierai mon dîner.
 Je paierai les tickets.
 Je paierai.
-Je l'attraperai.
+Je l’attraperai.
 Je le prendrai aussi.
-Je l'attraperai aussi.
-Je vous emmènerai à l'arrêt de bus.
+Je l’attraperai aussi.
+Je vous emmènerai à l’arrêt de bus.
 Je parlerai avec vous sous peu.
 Je vous apprendrai.
 Je lui dirai que vous avez téléphoné.
-Je suis (américain).
-J'ai (vingt, trente…) ans.
-J'ai 26 ans.
-J'ai 32 ans.
-Je fais 6'2 en taille.
+J’ai vingt, trente ans.
+J’ai vingt-six ans.
+J’ai trente-deux ans.
+Je fais six pieds deux en taille.
 Je suis en première année.
-Ma taille c'est 8.
+Ma taille c’est huit.
 Je suis professeur.
 Je suis allergique aux fruits de mer.
 Je suis Américain.
-Je m'ennuie.
+Je m’ennuie.
 Je suis en train de nettoyer ma chambre.
-J'ai froid.
+J’ai froid.
 Je viens tout de suite.
 Je viens vous prendre.
-Je suis bien, et vous ?
-Je suis bien, merci !
-Je viens (des États-Unis, d'Espagne).
-Je viens d'Amérique.
+Je suis bien, et vous ?
+Je suis bien, merci !
+Je viens des États-Unis et d’Espagne.
+Je viens d’Amérique.
 Je suis plein.
 Je suis Fulup.
 Je suis prêt à sortir.
-Je suis content d'entendre vos bonnes nouvelles.
-Je retourne à la maison dans 4 jours.
-J'irai en Amérique dans un an.
+Je suis content d’entendre vos bonnes nouvelles.
+Je retourne à la maison dans quatre jours.
+J’irai en Amérique dans un an.
 Je vais dormir.
 Je vais dîner.
 Je partirai.
 Je suis ici pour affaires.
-J'ai faim/soif.
+J’ai faim et soif.
 Je fais une blague, sans plus.
 Je regarde, sans plus.
-Je m'en irai demain.
-Je m'en vais.
+Je m’en irai demain.
+Je m’en vais.
 Je cherche John.
 Je cherche la poste.
 Je suis perdu.
 Je suis marié.
-Je n'ai pas peur.
-Je ne suis pas américain.
+Je n’ai pas peur.
+Je ne suis pas Américain.
 Je ne suis pas pressé.
 Je ne suis pas marié.
 Je ne suis pas encore prêt.
 Je ne suis pas sûr.
-Je suis en train d'écouter. (téléphone).
+Je suis en train d’écouter.
 Je suis prêt.
 Je suis mon propre employé.
-Excusez-moi (si vous n'entendez pas quelque chose).
+Excusez-moi si vous n’entendez pas quelque chose.
 Je suis désolé, il est épuisé.
 Excusez-moi.
 Je suis certain.
-J'ai beaucoup de travail.
-J'ai beaucoup de travail. Je n'ai pas le temps maintenant.
+J’ai beaucoup de travail.
+Je n’ai pas le temps maintenant.
 Je vais très bien, merci.
 Je suis en train de vous attendre.
 Je suis préoccupé aussi.
-Dans 30 minutes.
-Le matin/L'après-midi/Le soir.
-Quelqu'un d'autre doit venir ?
-Ashwin est en train d'enseigner ?
-Chitra est en train d'appeler Priya ?
-Tout va bien ?
-Gayathri est en train de vous attendre ?
-Il est professeur ?
-Il est à la maison ?
-Il est en train de couvrir un livre ?
-Il est en train d'amener un fichier ?
-Il est en train d'acheter des fruits ?
-Il est en train de donner un livre ?
-Il apprend l'anglais ?
-Il est en train de payer les frais ?
-Il est en train de courir ?
-Il est en train de prendre votre téléphone portable ?
-C'est votre entraîneur ?
-C'est un parent à vous ?
-C'est fermé ?
-Il fait froid dehors ?
-Il est loin d'ici ?
-C'est chaud ?
-C'est Jolarpet ?
-C'est à proximité ?
-C'est le numéro 17 ?
-C'est possible ?
-Il pleut ?
-Il est en train de pleuvoir ?
-C'est prêt ?
-Il n'est pas censé pleuvoir demain ?
-C'est vrai ?
-Ça vaut la peine ?
-C'est la première fois que vous venez à Chennai ?
-John est là ?
-John est là s'il vous plaît ?
-Mala est en train de raconter une histoire ?
-Maran est en train de prendre votre crayon ?
-M. Smith est américain ?
-Ravi est en train de chanter une chanson ?
-Elle est en train de vous appeler ?
-Elle est en train d'appeler sa sœur ?
-Il est en train de couper un arbre ?
-Il va à Delhi ?
-Il est en train de lire une nouvelle ?
-Il est en train d'écrire une lettre ?
-C'est votre sœur ?
-C'est ici qu'habite Shyamala ?
-Est-ce que c'est un crayon ?
-C'est assez ?
-C'est bon comme ça ?
-La banque est loin ?
+Dans trente minutes.
+Le matin, l’après-midi, le soir.
+Quelqu’un d’autre doit venir ?
+Ashwin est en train d’enseigner ?
+Chitra est en train d’appeler Priya ?
+Tout va bien ?
+Gayathri est en train de vous attendre ?
+Il est professeur ?
+Il est à la maison ?
+Il est en train de couvrir un livre ?
+Il est en train d’amener un fichier ?
+Il est en train d’acheter des fruits ?
+Il est en train de donner un livre ?
+Il apprend l’anglais ?
+Il est en train de payer les frais ?
+Il est en train de courir ?
+Il est en train de prendre votre téléphone portable ?
+C’est votre entraineur ?
+C’est un parent à vous ?
+C’est fermé ?
+Il fait froid dehors ?
+Il est loin d’ici ?
+C’est chaud ?
+C’est Jolarpet ?
+C’est à proximité ?
+C’est le numéro dix-sept ?
+C’est possible ?
+Il pleut ?
+Il est en train de pleuvoir ?
+C’est prêt ?
+Il n’est pas censé pleuvoir demain ?
+C’est vrai ?
+Ça vaut la peine ?
+C’est la première fois que vous venez à Chennai ?
+John est là ?
+John est là s’il vous plait ?
+Mala est en train de raconter une histoire ?
+Maran est en train de prendre votre crayon ?
+Monsieur Smith est américain ?
+Ravi est en train de chanter une chanson ?
+Elle est en train de vous appeler ?
+Elle est en train d’appeler sa sœur ?
+Il est en train de couper un arbre ?
+Il va à Delhi ?
+Il est en train de lire une nouvelle ?
+Il est en train d’écrire une lettre ?
+C’est votre sœur ?
+C’est ici qu’habite Shyamala ?
+Est-ce que c’est un crayon ?
+C’est assez ?
+C’est bon comme ça ?
+La banque est loin ?
 Le bus est en train de tourner au coin.
-La machine fonctionne ?
-Le siège est libre ?
-Le magasin est ouvert ?
-Une demoiselle Lee vit-elle ici ?
-Il y a un cinéma à proximité ?
-Il y a une boîte de nuit en ville ?
-Il y a un restaurant dans l'hôtel ?
-Il y a un magasin à proximité ?
-La chambre est climatisée ?
-Il y a un guide anglophone ?
-Il y a un quelconque livre sur la table ?
-Il y a du courrier pour moi ?
-Il y a quelqu'un à l'intérieur ?
-Il n'y a rien de meilleur marché ?
-C'est un livre ça ?
-C'est une zone sûre ?
-C'est M. Smith ?
-Ce crayon est à vous ?
-C'est le bus pour New York ?
-C'est votre livre ?
-Votre père est à la maison ?
-Votre ami est à Londres ?
-Votre maison est identique à celle-ci ?
-Votre mari est de Boston également ?
-Votre mère est en train de préparer à manger ?
-Votre fils est là ?
-Votre femme travaille ?
-N'est-il pas ?
-Ça coûte 20 dollars de l'heure.
+La machine fonctionne ?
+Le siège est libre ?
+Le magasin est ouvert ?
+Une demoiselle Lee vit-elle ici ?
+Il y a un cinéma à proximité ?
+Il y a une boîte de nuit en ville ?
+Il y a un restaurant dans l’hôtel ?
+Il y a un magasin à proximité ?
+La chambre est climatisée ?
+Il y a un guide anglophone ?
+Il y a un quelconque livre sur la table ?
+Il y a du courrier pour moi ?
+Il y a quelqu’un à l’intérieur ?
+Il n’y a rien de meilleur marché ?
+C’est un livre ça ?
+C’est une zone sûre ?
+C’est Monsieur Smith ?
+Ce crayon est à vous ?
+C’est le bus pour New York ?
+C’est votre livre ?
+Votre père est à la maison ?
+Votre ami est à Londres ?
+Votre maison est identique à celle-ci ?
+Votre mari est de Boston également ?
+Votre mère est en train de préparer à manger ?
+Votre fils est là ?
+Votre femme travaille ?
+N’est-il pas ?
+Ça coûte vingt dollars de l’heure.
 Ça dépend du temps.
-Ce n'est pas important.
-C'est pas grave.
-C'est pas important.
-C'est pareil.
+Ce n’est pas important.
+C’est pas grave.
+C’est pas important.
+C’est pareil.
 Ça me fait mal ici.
-C'est à 300 km de Chennai environ.
-Il est déjà 8h30, je ne pense pas qu'ils viendront.
+C’est à trois cents kilomètres de Chennai environ.
+Il est déjà huit heures et demi, je ne pense pas qu’ils viendront.
 Il y a toujours du soleil là-bas.
-C'est difficile.
-C'est rigolo.
+C’est difficile.
+C’est rigolo.
 Il est sept heures.
 Il est temps que vous vous leviez.
-C'est super.
+C’est super.
 Il doit être sept heures.
-Il a plu a torrent aujourd'hui.
-Il y a 2 heures de route en voiture.
-C'était gentil de votre part de tout arranger sur le moment.
-Pourquoi êtes-vous préoccupé ?
-Ce n'était pas la faute de personne.
+Il a plu à torrent aujourd’hui.
+Il y a deux heures de route en voiture.
+C’était gentil de votre part de tout arranger sur le moment.
+Pourquoi êtes-vous préoccupé ?
+Ce n’était pas la faute de personne.
 Il sera là sous peu.
-Il est 10 heures.
+Il est dix heures.
 Il fait un froid de canard.
 Il fera froid ce soir.
-Il est 10 heures. Il est 19h00.
-Il est 23h30.
-C'est 17 dollars.
-Il est 6h du matin.
-Il est 8h45.
-Il est 7 heures moins le quart.
-Il y a environ 7 heures de voyage par la route.
-Nous sommes le 25 août.
-Il fait froid.
-C'est un régal !
-C'est loin d'ici.
-C'est marrant.
-Il fait chaud aujourd'hui.
-Il va neiger aujourd'hui.
-Il est 11 heures et demi.
-C'est ici.
+Il est dix heures.
+Il est dix-neuf heures.
+Il est vingt-trois heures trente.
+C’est dix-sept dollars.
+Il est six heures du matin.
+Il est huit heures quarante-cinq.
+Il est sept heures moins le quart.
+Il y a environ sept heures de voyage par la route.
+Nous sommes le vingt-cinq août.
+C’est un régal !
+C’est loin d’ici.
+C’est marrant.
+Il fait chaud aujourd’hui.
+Il va neiger aujourd’hui.
+Il est onze heures et demi.
 Il est chaud.
-C'est chaud
-Il fait chaud.
+C’est chaud.
 Il est neuf heures moins le quart.
-C'est moins que 5 dollars.
-C'est plus long que 2 miles.
-C'est à moi.
-C'est plus que 5 dollars.
+C’est moins que cinq dollars.
+C’est plus long que deux miles.
+C’est à moi.
+C’est plus que cinq dollars.
 Il est à côté du supermarché.
 Il est au nord.
-Il n'est pas censé pleuvoir aujourd'hui.
-Il n'est pas trop loin.
-C'est pas trop cher.
-C'est bon.
-Il est dans la 7è rue.
-C'est par ici.
-Il pleut.
-C'est brûlant.
+Il n’est pas censé pleuvoir aujourd’hui.
+Il n’est pas trop loin.
+C’est pas trop cher.
+Il est dans la septième rue.
+C’est par ici.
+C’est brûlant.
 Il fait extrêmement chaud.
-Il est plus court que 3 miles.
+Il est plus court que trois miles.
 Il est censé pleuvoir demain.
-Il est ici.
-C'est trop tard.
+C’est trop tard.
 Il fait très froid.
-C'est très important.
-Il y a du vent.
-C'est tiède.
-Je l'ai déjà vu.
+C’est très important.
+C’est tiède.
+Je l’ai déjà vu.
 Il y a deux jours que je suis ici.
-J'apprends l'anglais depuis un mois.
-J'y ai été.
-J'ai entendu que le Texas était beau.
-Je n'ai jamais fait ça encore.
-Je n'ai jamais vu ça encore.
-Je l'ai vu.
-J'y ai travaillé pendant cinq ans.
-3 juin.
+J’apprends l’anglais depuis un mois.
+J’y ai été.
+J’ai entendu que le Texas était beau.
+Je n’ai jamais fait ça encore.
+Je n’ai jamais vu ça encore.
+Je l’ai vu.
+J’y ai travaillé pendant cinq ans.
+Trois juin.
 Un petit peu sans plus.
 Un petit moment sans plus.
-Va donc !
-Allez donc !
+Va donc !
+Allez donc !
 Gardez la monnaie.
 Tenez votre parole.
 Tenir sa parole est une chose que nous devrions tous faire.
@@ -5527,145 +5548,149 @@ Je vais vérifier.
 Je réfléchirai à ce sujet.
 Allons jeter un œil.
 Allons.
-Nous nous verrons en face de l'hôtel.
+Nous nous verrons en face de l’hôtel.
 Parlons anglais.
 Répartissons les choses.
-Vivre c'est plus que souffrir.
+Vivre c’est plus que souffrir.
 Fermez la porte.
-Fermez !
-Regardez. Il n'y a pas de quoi se préoccuper.
+Fermez !
+Regardez.
+Il n’y a pas de quoi se préoccuper.
 Notez ça.
-Garçon ou fille ?
-Votre nom, s'il vous plait ?
-Est-ce qu'il peut parler à Mlle Smith, sil vous plait ?
-Moi/Toi. Lui/Elle.
+Garçon ou fille ?
+Votre nom, s’il vous plait ?
+Est-ce qu’il peut parler à mademoiselle Smith, s’il vous plait ?
+Moi ou toi.
+Lui et elle.
 Retrouvez-moi demain.
 Rencontrez-les vous-même.
-Joyeux noël !
+Joyeux noël !
 Manger du lait est bon pour vous.
-C'est bon de manger du lait.
+C’est bon de manger du lait.
 Attention aux marches.
 Prenez garde aux marches.
 Ça ne vous regarde pas.
 Gardez votre langue.
 De plus en plus de gens le font.
 De plus en plus de gens font ça.
-Plus que 200 miles.
+De plus en plus.
+Plus que deux cents miles.
 Plus que ça.
 Surtout idlis, parfois dosa ou pongal.
-M…/Mlle…/Mme…
-Mon anniversaire tombe le 27 août.
+Monsieur, mademoiselle, madame.
+Mon anniversaire tombe le vingt-sept août.
 Mon frère est très raide.
 Ma voiture ne fonctionne pas.
-Ma voiture a été frappé par une autre voiture.
+Ma voiture a été frappée par une autre voiture.
 Mon téléphone portable ne capte pas les ondes.
 Mon téléphone ne fonctionne pas.
-Ma fille n'est pas ici.
-Je parle mal l'anglais.
+Ma fille n’est pas ici.
+Je parle mal l’anglais.
 Mon père y a été.
 Mon père est avocat.
-Mon père n'est pas dans son bureau.
+Mon père n’est pas dans son bureau.
 Mon père est très honnête.
 Mon père, ma mère, mon grand-père, ma grand-mère, ma sœur et moi.
 Mon ami est américain.
 On peut se fier à mon ami.
 Mon amie Surya va se marier dans un mois.
-Ma mère est décédée l'année dernière.
+Ma mère est décédée l’année dernière.
 Ma maison est à côté de la banque.
-Ma valise s'est perdue.
+Ma valise s’est perdue.
 Ma mère est très affectueuse.
-Je m'appelle…
-Je m'appelle John Smith.
-Je m'appelle Raja.
+Je m’appelle…
+Je m’appelle John Smith.
+Je m’appelle Raja.
 Je suis originaire de la ville de Chicago.
 Ma sœur a une tasse.
 Ma sœur est très crédule.
-Mon fils étudie l'informatique.
+Mon fils étudie l’informatique.
 Mon fils.
-J'ai mis ma montre.
+J’ai mis ma montre.
 À côté de la banque.
 Il ne marque pas.
 La prochaine fois.
 Dans une semaine mon cousin de Bombay viendra.
-C'est un plaisir de faire connaissance avec vous.
-C'est un plaisir de faire votre connaissance.
-Pas de problème !
+C’est un plaisir de faire connaissance avec vous.
+C’est un plaisir de faire votre connaissance.
+Pas de problème !
 Pas de problème.
 Non, je suis américain.
 Non merci.
-Non, c'est la première fois.
+Non, c’est la première fois.
 Non.
-Non. Mon emploi du temps est surchargé le matin.
+Mon emploi du temps est surchargé le matin.
 Personne ne nous aidera.
-Il n'y a personne là-bas pour le moment.
-Personne n'y croira.
-Follie.
+Il n’y a personne là-bas pour le moment.
+Personne n’y croira.
+Folie.
 Le plus souvent je bois du thé le matin.
 Pas récemment.
 Pas encore.
-Notez l'adresse.
-On ne peut rien réussir lorsque l'on est préoccupé comme ça.
-Rien d'autre.
-Ça n'arrivera plus jamais. Ne vous préoccupez pas.
+Notez l’adresse.
+On ne peut rien réussir lorsque l’on est préoccupé comme ça.
+Rien d’autre.
+Ça n’arrivera plus jamais.
+Ne vous préoccupez pas.
 Pas beaucoup.
-Maintenant ou plus tard ?
-22 octobre.
+Maintenant ou plus tard ?
+Vingt-deux octobre.
 Bien sûr.
-Vas-t-en !
-Allez-vous en !
-Part !
-Partez !
-Ah, c'est bon !
+Va-t-en !
+Allez-vous-en !
+Pars !
+Partez !
+Ah, c’est bon !
 Ah, bon.
 Bien, déballe les choses.
 À gauche.
 À droite.
 Au second étage.
-L'un est fort, l'autre est faible.
+L’un est fort, l’autre est faible.
 Un comme ça.
-Un petit moment s'il vous plaît.
-Un billet pour New York s'il vous plaît.
-Un aller ou un voyage aller-retour ?
+Un petit moment s’il vous plait.
+Un billet pour New York s’il vous plait.
+Un aller ou un voyage aller-retour ?
 Un, deux, trois.
 Ouvrez la porte.
 Ouvrez la fenêtre.
 Nos enfant sont aux USA.
-Notre famille est une famille associé.
+Notre famille est une famille associée.
 Notre famille est une famille large.
 Notre famille est une famille associée large.
 Notre famille est une famille moderne aux idées larges.
 Notre famille est une petite famille.
 Notre famille est une famille très classique.
-En dehors de l'hôtel.
+En dehors de l’hôtel.
 Par ici.
 Par là.
 Payez la note.
 Les gens parlent tamoul.
 Ramassez vos vêtements.
-Appelez-moi s'il vous plaît
-Téléphonez-moi s'il vous plaît.
-Entrez s'il vous plaît.
+Appelez-moi s’il vous plait.
+Téléphonez-moi s’il vous plait.
+Entrez s’il vous plait.
 Contez ça pour moi.
 Comptez ça pour moi.
 Remplissez ce formulaire.
-Asseyez-vous s'il vous plait.
-Parlez en anglais s'il vous plait.
-Parlez plus lentement s'il vous plait.
-Emmenez-moi à l'aéroport.
+Asseyez-vous s’il vous plait.
+Parlez en anglais s’il vous plait.
+Parlez plus lentement s’il vous plait.
+Emmenez-moi à l’aéroport.
 Emmenez-moi à cette adresse.
-Enlevez-vos chaussures s'il vous plaît.
+Enlevez vos chaussures s’il vous plait.
 Dites-lui que John a téléphoné.
-Dites-moi s'il vous plaît.
-Attendez-moi s'il vous plaît.
-Écrivez-ça s'il vous plaît.
-S'il vous plaît.
+Dites-moi s’il vous plait.
+Attendez-moi s’il vous plait.
+Écrivez ça s’il vous plait.
+S’il vous plait.
 Assez bien.
 Mettez votre chemise.
-Qu'il pleuve ou qu'il fasse soleil, je serai là pour vous.
+Qu’il pleuve ou qu’il fasse soleil, je serai là pour vous.
 Lisez autant de livres en anglais que vous le pourrez.
 Lisez-les à voix haute.
-Pour de vrai ?
-En vérité ?
+Pour de vrai ?
+En vérité ?
 Baissez le son.
 Rappelez-vous la date.
 Rappelez-moi.
@@ -5674,44 +5699,44 @@ Juste ici.
 Juste là.
 Enfuyez-vous.
 Saluez John de ma part.
-À tout à l'heure.
+À tout à l’heure.
 À la prochaine.
 À demain.
 À ce soir.
 Emmenez-le dehors.
 Sept, huit, neuf, dix.
-C'est une fille intelligente.
-C'est Barbara.
-C'est ma sœur ainée.
-C'est ma grand-mère.
-C'est ma mère.
-C'est ma petite sœur.
+C’est une fille intelligente.
+C’est Barbara.
+C’est ma sœur aînée.
+C’est ma grand-mère.
+C’est ma mère.
+C’est ma petite sœur.
 Elle veut savoir quand viendrez-vous.
-C'est une experte.
-Elle s'appelle Barbara.
+C’est une experte.
+Elle s’appelle Barbara.
 Il viendra avec moi demain.
 Il est plus âgé que moi.
-C'est plus vieux que moi.
+C’est plus vieux que moi.
 Elle est plus âgée que moi.
-C'est joli.
-Elle s'appelle Sandra.
-Je dois attendre ?
+C’est joli.
+Elle s’appelle Sandra.
+Je dois attendre ?
 Fais le tour de la ville avec lui.
 Résoudre un malentendu.
 Quelques livres.
-Quelqu'un fait ça pour moi.
-Quelqu'un vient.
-Parfois je vais dormir à 23h00, d'autres fois à 23h30.
-Excusez-moi (pour une erreur).
+Quelqu’un fait ça pour moi.
+Quelqu’un vient.
+Parfois je vais dormir à vingt-trois heures, d’autres fois à vingt-trois heures trente.
+Excusez-moi pour une erreur.
 Excusez-moi si je vous dérange.
 Excusez-moi, je ne vous ai pas bien entendu.
-Excusez-moi, je n'ai pas de crayon.
-Excusez-moi, je pense que j'ai le mauvais numéro.
-Excusez-nous, nous n'acceptons pas les cartes de crédit.
-Excusez-nous, nous n'avons aucunes vacances
-Excusez-nous, nous n'en avons aucun.
-Excusez-nous, nous n'acceptons que l'argent liquide.
-L'Espagne est un pays extraordinaire
+Excusez-moi, je n’ai pas de crayon.
+Excusez-moi, je pense que j’ai le mauvais numéro.
+Excusez-nous, nous n’acceptons pas les cartes de crédit.
+Excusez-nous, nous n’avons aucunes vacances.
+Excusez-nous, nous n’en avons aucun.
+Excusez-nous, nous n’acceptons que l’argent liquide.
+L’Espagne est un pays extraordinaire.
 Allumer la voiture.
 Marche.
 Étape.
@@ -5720,8 +5745,9 @@ Arrêtez de vous moquer de moi.
 Arrêtez de vous enfuir.
 Arrêtez de courir.
 Arrêtez de me dire ce que je dois faire et ne vous occupez pas de mes affaires.
-Ne vous préoccupez plus. Tout ira bien.
-Arrêtez !
+Ne vous préoccupez plus.
+Tout ira bien.
+Arrêtez !
 Éteignez le téléviseur.
 Faites un essai.
 Prenez-le dehors.
@@ -5732,17 +5758,15 @@ Prenez ces cachets pendant trois jours.
 Prenez ce médicament.
 On parle tamoul ici.
 Les larmes ne résolvent aucun problème.
-Dites-lui que j'ai besoin de lui parler.
+Dites-lui que j’ai besoin de lui parler.
 Dites-moi.
-Merci (beaucoup à vous) !
-Merci de me l'avoir rappelé.
+Merci beaucoup à vous !
+Merci de me l’avoir rappelé.
 Merci mademoiselle.
 Merci monsieur.
 Soyez-en remercié.
-Merci beaucoup.
 Je vous remercie beaucoup.
-Merci.
-Merci d'avoir appelé.
+Merci d’avoir appelé.
 Merci pour tout.
 Merci de votre aide.
 Cette voiture est pareille que la mienne.
@@ -5753,33 +5777,32 @@ Voilà un crayon.
 Voilà justement ce que nous souhaitons apprendre.
 Voilà justement ce que nous voulons apprendre.
 Cela est marrant.
-C'est amusant ça.
-Ça ce n'est pas un crayon.
-Ça c'est quelque choses alors.
-Elle a l'air en forme.
-Elle a l'air vieille.
+C’est amusant ça.
+Ça ce n’est pas un crayon.
+Ça c’est quelque choses alors.
+Elle a l’air en forme.
+Elle a l’air vieille.
 Voilà qui vaut amitié.
-Ce restaurant n'est pas cher.
+Ce restaurant n’est pas cher.
 Ça sent mauvais.
-C'est une belle idée.
-C'est très aimable de votre part.
-C'est une bonne école.
-C'est très bien.
-C'est assez.
-C'est juste.
+C’est une belle idée.
+C’est très aimable de votre part.
+C’est une bonne école.
+C’est très bien.
+C’est juste.
 Cela est amusant.
-C'est marrant ça.
-C'est son livre.
-Ce n'est pas assez.
-C'est pas juste.
-Ce n'est pas juste.
-C'est bien.
-C'est une pitié.
-C'est trop cher.
-C'est trop.
-C'est mauvais.
-L'accident est arrivé au carrefour.
-Le grand ou le petit ?
+C’est marrant ça.
+C’est son livre.
+Ce n’est pas assez.
+C’est pas juste.
+Ce n’est pas juste.
+C’est bien.
+C’est une pitié.
+C’est trop cher.
+C’est trop.
+C’est mauvais.
+L’accident est arrivé au carrefour.
+Le grand ou le petit ?
 Le livre est derrière la table.
 Le livre est devant la table.
 Le livre est à côté de la table.
@@ -5798,19 +5821,19 @@ La maison est vaste.
 La maison est spacieuse.
 La majorité des gens sont des agriculteurs.
 La maison neuve est très confortable.
-L'avion démarre à 17h30.
+L’avion démarre à dix-sept heures trente.
 Les routes sont glissantes.
 Le téléviseur est cassé.
 Le verbe être.
-L'eau est dure.
-L'eau est molle.
+L’eau est dure.
+L’eau est molle.
 Le temps est chaud.
 Le temps est assez chaud.
-Alors, pourquoi m'avez-vous demandé de venir ?
-Alors, pourquoi m'aviez-vous téléphoné ?
+Alors, pourquoi m’avez-vous demandé de venir ?
+Alors, pourquoi m’aviez-vous téléphoné ?
 On est huit dans notre famille.
 Il y a beaucoup de monde ici.
-Il n'y a aucun crayon dans ma boîte.
+Il n’y a aucun crayon dans ma boîte.
 Il y a sept jours dans une semaine.
 Il y a quelques pommes dans le réfrigérateur.
 Il y a quelques livres sur la table.
@@ -5818,24 +5841,24 @@ Il y a deux crayons dans ma boîte.
 Il y a.
 Il y a eu un accident de voiture.
 Il y a un livre sur la table.
-Il y a un puits mais l'eau est saumâtre.
+Il y a un puits mais l’eau est saumâtre.
 Chaque problème a toujours sa solution.
-Ce n'est pas la peine d'être préoccupé.
-Il n'y a aucun problème d'eau.
-Il n'y a aucun livre sur la table.
-Il y a de l'eau en quantité.
-On manque d'eau.
+Ce n’est pas la peine d’être préoccupé.
+Il n’y a aucun problème d’eau.
+Il n’y a aucun livre sur la table.
+Il y a de l’eau en quantité.
+On manque d’eau.
 Il y en a.
 Ça doit être.
 Il y avait.
 Il y en avait.
 Il y en aura.
-Il n'y aura pas beaucoup de professeurs à aller à la fête.
+Il n’y aura pas beaucoup de professeurs à aller à la fête.
 Il y en aurait.
 Il y a un appel téléphonique pour vous.
 Il y a un livre sous la table.
 Il y a un restaurant pas loin.
-Il y a un restaurant là-bas, mais je ne crois pas qu'il soit très bon.
+Il y a un restaurant là-bas, mais je ne crois pas qu’il soit très bon.
 Il y a plein de temps.
 Ceux-là sont des livres.
 Voilà mes amis.
@@ -5849,11 +5872,11 @@ Ils sont très connus.
 Ils sont extrêmement connus.
 Ils sont super connus.
 Ils sont arrivés hier.
-Ça coûte 26 dollars par jour.
+Ça coûte vingt-six dollars par jour.
 Ils ne se sont pas encore rencontrés.
 Ils vivent à Paris, en France.
 Ils parlent tamoul.
-Ils ne m'écouteront pas.
+Ils ne m’écouteront pas.
 Je ne serai pas confondu avec eux.
 Ils reviennent tout de suite.
 Ils pensent venir dans un an.
@@ -5864,29 +5887,30 @@ Ils nous attendent.
 Ça ne fonctionne pas.
 Cette maison est très grande.
 Voici un livre.
-Ça c'est marrant
-Voilà Mme. Smith.
+Ça c’est marrant.
+Voilà madame Smith.
 Voilà ma fille qui entre dans la pièce.
 Voilà ma mère.
 Voilà mon frère cadet.
-Ceci n'est pas un livre.
+Ceci n’est pas un livre.
 Voilà donc quelque chose.
-C'est la première fois que je viens ici.
-C'est très difficile.
+C’est la première fois que je viens ici.
+C’est très difficile.
 Cette chambre est sens dessus dessous.
-Ce jardin est plein d'enfants.
-Ceci/Cela. Ici/Là.
+Ce jardin est plein d’enfants.
+Ceci ou cela.
+Ici et là.
 Ceux-ci ne sont pas des crayons gris.
 Ceux-ci sont des crayons gris.
 Ces gars-là sont en train de parler anglais.
 Peu importe ce qui se passera, je serai là pour vous.
 Jetez-le dehors.
 Être ou ne pas être, là est la question.
-Il n'est pas question de faire comme vous proposez.
+Il n’est pas question de faire comme vous proposez.
 Manger.
-Souhaiter quelque chose à quelqu'un.
-Aujourd'hui/Maintenant.
-Demain/Hier.
+Souhaiter quelque chose à quelqu’un.
+Aujourd’hui et maintenant.
+Demain ou hier.
 Essayez-le.
 Cherchez.
 Essayez de le dire.
@@ -5895,412 +5919,416 @@ Tournez à gauche.
 Tournez à droite.
 Très bien, merci.
 Très bien.
-Serveur !
+Serveur !
 Attends dehors.
-Serveuse !
+Serveuse !
 Réveille-la.
 Réveille-le.
 Nous sommes connus.
 Nous, nous sommes connus.
 Nous vivons au Wisconsin.
-Nous sommes six personnes à la maison. Mon père, ma mère, mes deux sœurs et un frère en plus de moi-même.
+Nous sommes six personnes à la maison.
+Mon père, ma mère, mes deux sœurs et un frère en plus de moi-même.
 Nous sommes six personnes.
 Nous sommes deux frères et une sœur à la maison.
-Nous pouvons manger de la nourriture de Chine ou d'Italie.
+Nous pouvons manger de la nourriture de Chine ou d’Italie.
 Nous avons une voiture.
 Nous avons deux fils et une fille.
 Nous avons deux garçons et une fille.
-Ça nous plaît énormément.
-Bienvenue (pour saluer quelqu'un)
-Deux verres d'eau s'il vous plait.
+Ça nous plait énormément.
+Bienvenue.
+Pour saluer quelqu’un.
+Deux verres d’eau s’il vous plait.
 Nous sommes de Californie.
 Nous avons du retard.
 Nous sommes en retard.
-Il y a eu un problème ?
-Vous étiez à la bibliothèque hier ?
-Êtes-vous devenu fou pour faire quelque chose comme ça ?
-Qu'est-ce qu'il y a dans votre boîte ?
-C'est quoi ceux-là ?
-C'est quoi ceux-ci ?
-Qu'est-ce que vous allez faire après ?
-Qu'est-ce que vous allez faire ce soir ?
-Qu'est-ce que vous allez faire ?
-Qu'est-ce que vous prendrez ?
-Qu'est-ce que vous êtes en train d'ouvrir ?
-À quoi pensez-vous ?
-De quoi parlez-vous ?
-Quel métier avez-vous ?
-Quel métier exercez-vous ?
-Qu'est-ce que vous êtes ?
-À quoi passez-vous votre temps ?
-Avec quoi vous divertissez-vous ?
-Qu'est-ce que je peux faire pour vous ?
-De quelle couleur est cette voiture ?
-Quel est la date d'aujourd'hui ?
-Quel jour doivent-ils venir faire un tour ?
-Quel jour on est aujourd'hui ?
-Quel jour est-on ?
-Quel jour de le semaine est-on ?
-Qu'est-ce qu'il vous a demandé ?
-Qu'est-ce qu'elle vous a demandé ?
-Qu'est-ce que vous avez acheté ?
-Qu'avez-vous fait la nuit passée ?
-Qu'est-ce que vous aviez fait hier ?
-Qu'est-ce que vous avez fait ?
-Qu'avez-vous ouvert ?
-Qu'est-ce que vous avez dit ?
-Qu'est-ce que vous en avez pensé ?
-Que font les gens à Los Angeles pendant l'été le plus souvent ?
-Que font les gens ici ?
-Qu'est-ce qu'ils étudient ?
-Comment gagnez-vous votre vie ?
-Quel travail faites-vous ?
-Qu'est-ce que vous faites dimanche ?
-Qu'est-ce que vous faites le dimanche.
-Quel métier faites-vous ?
-Qu'est-ce que vous faites ?
-Qu'est-ce que vous prenez pour le déjeuner ?
-Que prenez-vous le matin ? Café ou thé ?
-Qu'avez-vous ?
-Qu'est-ce que vous avez ?
-Qu'ouvrez-vous ?
-Que recommandez-vous ?
-Quelles études faites-vous ?
-Qu'est-ce que vous étudiez ?
-Que pensez-vous de lui ?
-Que pensez-vous de ces chaussures ?
-Qu'est-ce que vous pensez ?
-Qu'est-ce que tu penses ?
-Qu'en penses-tu ?
-Qu'en pensez-vous ?
-Qu'est-ce que vous voulez faire ?
-Que voulez-vous faire ?
-Que voulez-vous ?
-Qu'est-ce que vous voulez ?
-Qu'est-ce qu evous aurez ?
-Quels métiers font vos parents ?
-Quel métier fait-il ?
-Qu'est-ce que ça veut dire ?
-Que dit cette chose ?
-Que signifie ce mot ?
-Quelle est la profession de votre père ?
-Quelle est le métier de votre père ?
-Qu'est-ce qui s'est passé ?
-Qu'avez-vous décidé ?
-Ce qu'il a dit signifie quelque chose.
-Qu'est-ce qu'il est ?
-Quel est son nom ?
-C'est quoi ça ?
-C'est quoi cette chose ?
-Quel est le code du secteur ?
-Quel est le travail principal des gens là-bas ?
-Quel est le travail principal des gens ?
-Quel est le nom de cette fille ?
-Comment s'appelle cette fille ?
-Qu'est-ce qu'il y a là sur la table ?
-Quel est cette chose dans l'image ?
-Qu'est que c'est que ça ?
-Le combien sommes-nous aujourd'hui ?
-Où habitez-vous ?
-Quel but avez-vous dans la vie ?
-Quel diplôme avez-vous ?
-Que fait votre père ?
-À quoi occupez-vous votre temps libre ?
-Quel nom avez-vous ?
-Que pensez-vous ?
-Quelle formation avez-vous ?
-Comment s'appelle votre sœur ?
-Quel type de musique aimez-vous ?
-Quelle langue parlez-vous là-bas ?
-Quelle langue parle-t-on ici ?
-Quelle langue parle-t-on là-bas ?
-À quelle école êtes-vous allé ?
-Qu'est-ce que je devrais mettre ?
-C'est quelle taille ça ?
-Quelle taille ?
-C'est quel arrêt ?
-Que diable êtes-vous en train de faire ici ?
-Que diable voulez-vous ?
-À quelle heure ils arrivent ?
-À quelle heure allez-vous à la gare routière ?
-À quelle heure vous êtes-vous levé ?
-À quelle heure étiez-vous allés dormir ?
-À quelle heure vous êtes-vous réveillés ?
-À quelle heure ça commence ?
-À quelle heure commence le film ?
-À quelle heure ouvre le magasin ?
-À quelle heure doit-on être dehors ?
-Quel genre de personne êtes-vous ?
-Comment sera le temps demain ?
-Qu'est-ce que vous ferez ?
-Qu'est-ce que vous ouvrirez ?
-Qu'est-ce que vous allez boire ?
-Qu'est-ce que vous mangerez ?
-Quoi ? Où ?
+Il y a eu un problème ?
+Vous étiez à la bibliothèque hier ?
+Êtes-vous devenu fou pour faire quelque chose comme ça ?
+Qu’est-ce qu’il y a dans votre boîte ?
+C’est quoi ceux-là ?
+C’est quoi ceux-ci ?
+Qu’est-ce que vous allez faire après ?
+Qu’est-ce que vous allez faire ce soir ?
+Qu’est-ce que vous allez faire ?
+Qu’est-ce que vous prendrez ?
+Qu’est-ce que vous êtes en train d’ouvrir ?
+À quoi pensez-vous ?
+De quoi parlez-vous ?
+Quel métier avez-vous ?
+Quel métier exercez-vous ?
+Qu’est-ce que vous êtes ?
+À quoi passez-vous votre temps ?
+Avec quoi vous divertissez-vous ?
+Qu’est-ce que je peux faire pour vous ?
+De quelle couleur est cette voiture ?
+Quel est la date d’aujourd’hui ?
+Quel jour doivent-ils venir faire un tour ?
+Quel jour on est aujourd’hui ?
+Quel jour est-on ?
+Quel jour de le semaine est-on ?
+Qu’est-ce qu’il vous a demandé ?
+Qu’est-ce qu’elle vous a demandé ?
+Qu’est-ce que vous avez acheté ?
+Qu’avez-vous fait la nuit passée ?
+Qu’est-ce que vous aviez fait hier ?
+Qu’est-ce que vous avez fait ?
+Qu’avez-vous ouvert ?
+Qu’est-ce que vous avez dit ?
+Qu’est-ce que vous en avez pensé ?
+Que font les gens à Los Angeles pendant l’été le plus souvent ?
+Que font les gens ici ?
+Qu’est-ce qu’ils étudient ?
+Comment gagnez-vous votre vie ?
+Quel travail faites-vous ?
+Qu’est-ce que vous faites dimanche ?
+Qu’est-ce que vous faites le dimanche ?
+Quel métier faites-vous ?
+Qu’est-ce que vous faites ?
+Qu’est-ce que vous prenez pour le déjeuner ?
+Que prenez-vous le matin ? Café ou thé ?
+Qu’avez-vous ?
+Qu’est-ce que vous avez ?
+Qu’ouvrez-vous ?
+Que recommandez-vous ?
+Quelles études faites-vous ?
+Qu’est-ce que vous étudiez ?
+Que pensez-vous de lui ?
+Que pensez-vous de ces chaussures ?
+Qu’est-ce que vous pensez ?
+Qu’est-ce que tu penses ?
+Qu’en penses-tu ?
+Qu’en pensez-vous ?
+Qu’est-ce que vous voulez faire ?
+Que voulez-vous faire ?
+Que voulez-vous ?
+Qu’est-ce que vous voulez ?
+Qu’est-ce que vous aurez ?
+Quels métiers font vos parents ?
+Quel métier fait-il ?
+Qu’est-ce que ça veut dire ?
+Que dit cette chose ?
+Que signifie ce mot ?
+Quelle est la profession de votre père ?
+Quelle est le métier de votre père ?
+Qu’est-ce qui s’est passé ?
+Qu’avez-vous décidé ?
+Ce qu’il a dit signifie quelque chose.
+Qu’est-ce qu’il est ?
+Quel est son nom ?
+C’est quoi ça ?
+C’est quoi cette chose ?
+Quel est le code du secteur ?
+Quel est le travail principal des gens là-bas ?
+Quel est le travail principal des gens ?
+Quel est le nom de cette fille ?
+Comment s’appelle cette fille ?
+Qu’est-ce qu’il y a là sur la table ?
+Quel est cette chose dans l’image ?
+Qu’est que c’est que ça ?
+Le combien sommes-nous aujourd’hui ?
+Où habitez-vous ?
+Quel but avez-vous dans la vie ?
+Quel diplôme avez-vous ?
+Que fait votre père ?
+À quoi occupez-vous votre temps libre ?
+Quel nom avez-vous ?
+Que pensez-vous ?
+Quelle formation avez-vous ?
+Comment s’appelle votre sœur ?
+Quel type de musique aimez-vous ?
+Quelle langue parlez-vous là-bas ?
+Quelle langue parle-t-on ici ?
+Quelle langue parle-t-on là-bas ?
+À quelle école êtes-vous allé ?
+Qu’est-ce que je devrais mettre ?
+C’est quelle taille ça ?
+Quelle taille ?
+C’est quel arrêt ?
+Que diable êtes-vous en train de faire ici ?
+Que diable voulez-vous ?
+À quelle heure ils arrivent ?
+À quelle heure allez-vous à la gare routière ?
+À quelle heure vous êtes-vous levé ?
+À quelle heure étiez-vous allés dormir ?
+À quelle heure vous êtes-vous réveillés ?
+À quelle heure ça commence ?
+À quelle heure commence le film ?
+À quelle heure ouvre le magasin ?
+À quelle heure doit-on être dehors ?
+Quel genre de personne êtes-vous ?
+Comment sera le temps demain ?
+Qu’est-ce que vous ferez ?
+Qu’est-ce que vous ouvrirez ?
+Qu’est-ce que vous allez boire ?
+Qu’est-ce que vous mangerez ?
+Quoi ? Où ?
 Ce qui doit arriver arrivera.
-Qu'est-ce qu'il y a dedans ?
-Quoi de neuf ?
-Comment ça se dit en breton ?
-Comment ça se dit en anglais ?
-Comment ça se dit en français ?
-C'est quelle adresse ?
-Combien coûte la nuit ? (hôtel)
-À combien se monte le taux de change pour le dollar ?
-À combien se monte le taux de change ?
-Pour quelle entreprise travaillez-vous ?
-C'est quel numéro de téléphone ?
-Quel est le prix de la chambre ?
-À combien se monte la température ?
-Il y a quelque chose qui ne va pas ?
-Quelle est voter adresse ?
-Quel est votre adresse électronique ?
-Quelle est votre nourriture préférée ?
-Quelle est votre plat préféré ?
-Quel est votre film préféré ?
-Quel est votre nom de famille ?
-Quel nom as-tu ?
-Quel est votre nom ?
-Quelle est votre religion ?
-Quand viennent-ils ?
-Quand revenez-vous ?
-Quand terminez-vous votre stage d'informatique ?
-Quand aurez-vous fini votre travail ?
-Quand aurez-vous terminé votre travail ?
-Quand est-ce que vous y allez ?
-Quand est-ce que tu y vas ?
-Quand est-ce que vous irez à Delhi ?
-Pour quand est le mariage ?
-Quand devez-vous emporter votre ami ?
-Quand allez-vous vider la maison ?
-Quand partez-vous ?
-Quand pars-tu ?
-Quand partiras-tu à Madurai ?
-Quand allez-vous déménager dans la nouvelle maison ?
-Quand allez-vous déménager ?
-Quand était-il venu ?
-Quand est-ce que c'est arrivé ?
-Quand êtes-vous arrivé à Boston ?
-Quand avez-vous rejoint cette course ?
-Quand vous étiez-vous vu en dernier ?
-Quand avez-vous ouvert la porte ?
-Quand êtes-vous rentré de Bombay ?
-À quelle heure arrivons-nous ?
-Quand partons-nous ?
-Quand arrivez-vous aux USA ?
-À quelle heure finissez-vous votre travail ?
-Quand vas-tu ?
-Quand allez-vous ?
-À quelle heure tu vas te coucher ?
-À quelle heure partiras-tu pour aller travailler ?
-Quand ouvrez-vous la porte ?
-Quand rentrez-vous chez vous ?
-Quand rentrez-vous à la maison ?
-Quand commencez-vous votre travail ?
-Quand arrive-t-il ?
-Quand ouvre la porte ?
-À quelle heure ouvrira-t-il la porte ?
-À quelle heure arrive-t-il ?
-À quelle heure ouvre la banque ?
-À quelle heure part le bus ?
-Quand arrive l'avion ?
-Quand il viendra je l'amènerai ici.
-Quand j'ai été au magasin, ils n'avaient pas de pommes.
-Quand tombe son anniversaire ?
-Quand tombe mon anniversaire ?
-Quand tombe notre anniversaire ?
-Quand est-ce que l'administrateur revient de Quimperlé ?
-Dans combien de temps est le prochain car pour Philadelphia ?
-Dans combien de temps est le prochains train ?
-Quand tombe ton anniversaire ?
-Quand tombe votre anniversaire ?
-Quand l'aviez-vous vue en dernier ?
-Quand aviez-vous parlé à votre mère en dernier ?
-Quand reviendra-t-il ?
-Quand est-ce que je viendrai ?
-Quand cela sera-t-il prêt ?
-Quand serez-vous prêt ?
-Quand iras-tu ?
-Quand irez-vous ?
-Quand ouvrirez-vous la porte ?
+Qu’est-ce qu’il y a dedans ?
+Quoi de neuf ?
+Comment ça se dit en breton ?
+Comment ça se dit en anglais ?
+Comment ça se dit en français ?
+C’est quelle adresse ?
+Combien coûte la nuit ?
+À combien se monte le taux de change pour le dollar ?
+À combien se monte le taux de change ?
+Qu’est-ce qui se passe ?
+Pour quelle entreprise travaillez-vous ?
+C’est quel numéro de téléphone ?
+Quel est le prix de la chambre ?
+À combien se monte la température ?
+Il y a quelque chose qui ne va pas ?
+Quelle est votre adresse ?
+Quelle est votre adresse électronique ?
+Quelle est votre nourriture préférée ?
+Quel est votre plat préféré ?
+Quel est votre film préféré ?
+Quel est votre nom de famille ?
+Quel nom as-tu ?
+Quel est votre nom ?
+Quelle est votre religion ?
+Quand viennent-ils ?
+Quand revenez-vous ?
+Quand terminez-vous votre stage d’informatique ?
+Quand aurez-vous fini votre travail ?
+Quand aurez-vous terminé votre travail ?
+Quand est-ce que vous y allez ?
+Quand est-ce que tu y vas ?
+Quand est-ce que vous irez à Delhi ?
+Pour quand est le mariage ?
+Quand devez-vous emporter votre ami ?
+Quand allez-vous vider la maison ?
+Quand partez-vous ?
+Quand pars-tu ?
+Quand partiras-tu à Madurai ?
+Quand allez-vous déménager dans la nouvelle maison ?
+Quand allez-vous déménager ?
+Quand était-il venu ?
+Quand est-ce que c’est arrivé ?
+Quand êtes-vous arrivé à Boston ?
+Quand avez-vous rejoint cette course ?
+Quand vous étiez-vous vu en dernier ?
+Quand avez-vous ouvert la porte ?
+Quand êtes-vous rentré de Bombay ?
+À quelle heure arrivons-nous ?
+Quand partons-nous ?
+Quand arrivez-vous aux USA ?
+À quelle heure finissez-vous votre travail ?
+Quand vas-tu ?
+Quand allez-vous ?
+À quelle heure tu vas te coucher ?
+À quelle heure partiras-tu pour aller travailler ?
+Quand ouvrez-vous la porte ?
+Quand rentrez-vous chez vous ?
+Quand rentrez-vous à la maison ?
+Quand commencez-vous votre travail ?
+Quand arrive-t-il ?
+Quand ouvre la porte ?
+À quelle heure ouvrira-t-il la porte ?
+À quelle heure arrive-t-il ?
+À quelle heure ouvre la banque ?
+À quelle heure part le bus ?
+Quand arrive l’avion ?
+Quand il viendra je l’amènerai ici.
+Quand j’ai été au magasin, ils n’avaient pas de pommes.
+Quand tombe son anniversaire ?
+Quand tombe mon anniversaire ?
+Quand tombe notre anniversaire ?
+Quand est-ce que l’administrateur revient de Quimperlé ?
+Dans combien de temps est le prochain car pour Philadelphie ?
+Dans combien de temps est le prochain train ?
+Quand tombe ton anniversaire ?
+Quand tombe votre anniversaire ?
+Quand l’aviez-vous vue en dernier ?
+Quand aviez-vous parlé à votre mère en dernier ?
+Quand reviendra-t-il ?
+Quand est-ce que je viendrai ?
+Quand cela sera-t-il prêt ?
+Quand serez-vous prêt ?
+Quand iras-tu ?
+Quand irez-vous ?
+Quand ouvrirez-vous la porte ?
 Quand voulez-vous que nous nous voyions.
-Où sont les livres ?
-Où sont les tee-shirts ?
-Où achetez-vous les légumes ?
-D'où venez-vous ?
-D'où êtes-vous ?
-Où vas-tu ?
-Où irez-vous ?
-Où êtes-vous maintenant ?
-Où travaillez-vous ?
-Où est-ce que je peux acheter des tickets ?
-Où pourrais-je échanger des dollars USA .
-Où pourrais-je trouver un hôpital ?
-Où pourrais-je poster ça ?
-Où pourrais-je louer une voiture ?
-Où a-t-il été ?
-Où avait-il été ?
-Où est-ce arrivé ?
-Où avez-vous été ?
-Où avez-vous été à l'école ?
-Où avez-vous appris l'anglais ?
-Où avez-vous appris ça ?
-Où l'avez-vous connu ?
-Où l'avez-vous connue ?
-Où l'avez-vous mis ?
-Où travailliez-vous avant de travailler ici ?
-Où habitent-ils ?
-Où avez-vous acheté les légumes ?
-D'où viens-tu ?
-Où habites-tu ?
-Où est-ce que j'habite ?
-Où voulez-vous aller ?
-Où travailles-tu ?
-Où habite-t-il ?
-Où travaille-t-il ?
-Où avez-vous mal ?
-Où travaille votre femme ?
-Où avez-vous mis le livre ?
-Où y aurait-il un métro ?
-D'où est-il ?
-Où travaille t-il maintenant ?
-Où c'est ?
-Où est la rue principale ?
-Où est ma chemise ?
-D'où est-elle ?
-Où est l'aéroport ?
-Où est la salle de bains ?
-Où est la librairie ?
-Où est la gare routière ?
-Où y aurait-il un médecin qui parle anglais ?
-Où y aurait-il un distributeur de billets ?
-Où est votre frère maintenant ?
-Où étiez-vous ?
-Où voulez-vous que nous nous rencontrions ?
-Où est le restaurant le plus proche ?
-Où est la boîte à lettres ?
-Où est l'hôpital le plus proche ?
-Où est la pharmacie ?
-Où est la poste ?
-Quel bus va à Time Square ?
-Quel jeu aimez-vous, le cricket ou le tennis ?
-Qu'est-ce qui est mieux, les spaghetti ou la salade poulet ?
-Lequel est mieux ?
-Laquelle est la meilleure ?
-Lequel est votre sac ?
-De quelle ville êtes-vous ?
-De quelle ville êtes-vous originaire ?
-Dans quelle ville êtes-vous né ?
-Quel journal lisez-vous ?
-Lequel veux-tu ?
-Lequel voulez-vous ?
-Lequel est le meilleur marché ?
-Lequel est le meilleur ?
-Quel chemin devrais-je prendre ?
-À quelle école va-t-il ?
-T'es qui ?
-Tu es qui ?
-Vous êtes qui ?
-Qui êtes-vous pour me donner des ordres ?
-Qui vous l'a demandé ?
-Qui vous a téléphoné ?
-Qui c'est ?
-Qui est la personne debout là-bas ?
-Qui avait dit ?
-Qui a expédié cette lettre ?
-Qui a éteint la lumière ?
-Qui vous a appris ça ?
-Avec qui l'avez-vous appris ?
-Qui vous l'a dit ?
-Qui vous a dit que ce n'était pas bien ?
-Qui était-ce ?
-Qui était votre professeur ?
-Qui vous portera secours ?
-Qui l'a emporté ?
-À qui voulez-vous parler ?
-Avec qui étiez-vous venu ?
-Qui est soupçonné selon vous ?
-Qui est en train de téléphoner ?
-Qui est cet homme, là-bas ?
-À qui est ce livre ?
-De qui est cette écriture ?
-C'est la faute de qui ?
-Pourquoi me le demandez-vous ?
-Pourquoi s'emporter sans raison ?
-Pourquoi êtes-vous en retard ?
-Pourquoi êtes-vous en train de rire ?
-Pourquoi êtes-vous en train de hurler comme ça ?
-Pourquoi est-ce que vous me regardez comme ça ?
-Pourquoi me dites-vous tout ça ?
-Pourquoi n'y allez-vous pas ?
-Pourquoi est-il venu ici ?
-Pourquoi est-il venu ?
-Pourquoi l'avez-vous frappé ?
-Pourquoi êtes-vous mal poli ?
-Pourquoi avez-vous fait ça ?
-Pourquoi y êtes-vous allé ?
-Pourquoi avez-vous démissionné de votre travail ?
-Pourquoi avez-vous dit ça ?
-Pourquoi avez-vous gaspillé tout l'argent.
-Pourquoi n'avez-vous pas postulé à ce poste de travail ?
-Pourquoi ne m'avez-vous pas informé ?
-Pourquoi portez-vous toujours des chemises bleues ?
-Pourquoi êtes-vous gêné ?
-Pourquoi avoir peur quand je suis avec vous ?
-Pourquoi avoir peur puisque je suis là ?
-Pourquoi est-ce ennuyeux ?
-Pourquoi le train est-il en retard ?
-Pourquoi pas ?
-Est-ce qu'il va pleuvoir aujourd'hui ?
-Y aura-t-il une fête d'anniversaire à la maison ?
-Viendront-ils jusqu'ici ?
-Appelez-moi un taxi s'il vous plaît.
-Passez-moi une serviette s'il vous plaît.
-Ouvrirez-vous la porte ?
-Passez-moi le sel s'il vous plaît.
-Vous le mettrez  dans la voiture pour moi ?
-Vous me le rappellerez ?
-Vous me raccompagnerez chez moi ?
-Avec qui était-elle venu ?
-Qui l'accompagnait ?
-Qui vous accompagnait ?
-Pouvez-vous lui dire de me rappeler s'il vous plaît ?
-Pouvez-vous lui demander de venir ici ?
-Prendrez-vous un verre d'eau.
-Prendrez-vous du café ou du thé ?
-Un verre d'eau ?
-Voulez-vous un verre de vin ?
-Voulez-vous manger quelque chose ?
-Vous souhaiteriez l'acheter ?
-Que diriez-vous d'aller faire une promenade ?
-Que diriez-vous de dîner avec moi ?
-Vous voulez louer un film ?
-Vous voulez regarder la télévision ?
-Vous aurez de l'eau ou du café ?
-Pouvez-vous prendre un message s'il vous plaît ?
-Notez par écrit, s'il vous plaît.
+Où sont les livres ?
+Où sont les tee-shirts ?
+Où achetez-vous les légumes ?
+D’où venez-vous ?
+D’où es-tu ?
+D’où êtes-vous ?
+Où vas-tu ?
+Où irez-vous ?
+Où êtes-vous maintenant ?
+Où travaillez-vous ?
+Où est-ce que je peux acheter des tickets ?
+Où pourrais-je échanger des dollars USA ?
+Où pourrais-je trouver un hôpital ?
+Où pourrais-je poster ça ?
+Où pourrais-je louer une voiture ?
+Où a-t-il été ?
+Où avait-il été ?
+Où est-ce arrivé ?
+Où avez-vous été ?
+Où avez-vous été à l’école ?
+Où avez-vous appris l’anglais ?
+Où avez-vous appris ça ?
+Où l’avez-vous connu ?
+Où l’avez-vous connue ?
+Où l’avez-vous mis ?
+Où travailliez-vous avant de travailler ici ?
+Où habitent-ils ?
+Où avez-vous acheté les légumes ?
+D’où viens-tu ?
+Où habites-tu ?
+Où est-ce que j’habite ?
+Où voulez-vous aller ?
+Où travailles-tu ?
+Où habite-t-il ?
+Où travaille-t-il ?
+Où avez-vous mal ?
+Où travaille votre femme ?
+Où avez-vous mis le livre ?
+Où y aurait-il un métro ?
+D’où est-il ?
+Où travaille-t-il maintenant ?
+Où c’est ?
+Où est la rue principale ?
+Où est ma chemise ?
+D’où est-elle ?
+Où est l’aéroport ?
+Où est la salle de bains ?
+Où est la librairie ?
+Où est la gare routière ?
+Où y aurait-il un médecin qui parle anglais ?
+Où y aurait-il un distributeur de billets ?
+Où est votre frère maintenant ?
+Où étiez-vous ?
+Où voulez-vous que nous nous rencontrions ?
+Où est le restaurant le plus proche ?
+Où est la boîte à lettres ?
+Où est l’hôpital le plus proche ?
+Où est la pharmacie ?
+Où est la poste ?
+Quel bus va à Time Square ?
+Quel jeu aimez-vous, le cricket ou le tennis ?
+Qu’est-ce qui est mieux, les spaghetti ou la salade poulet ?
+Lequel est mieux ?
+Laquelle est la meilleure ?
+Lequel est votre sac ?
+De quelle ville êtes-vous ?
+De quelle ville êtes-vous originaire ?
+Dans quelle ville êtes-vous né ?
+Quel journal lisez-vous ?
+Lequel veux-tu ?
+Lequel voulez-vous ?
+Lequel est le meilleur marché ?
+Lequel est le meilleur ?
+Quel chemin devrais-je prendre ?
+À quelle école va-t-il ?
+T’es qui ?
+Tu es qui ?
+Vous êtes qui ?
+Qui êtes-vous pour me donner des ordres ?
+Qui vous l’a demandé ?
+Qui vous a téléphoné ?
+Qui c’est ?
+Qui est la personne debout là-bas ?
+Qui avait dit ?
+Qui a expédié cette lettre ?
+Qui a éteint la lumière ?
+Qui vous a appris ça ?
+Avec qui l’avez-vous appris ?
+Qui vous l’a dit ?
+Qui vous a dit que ce n’était pas bien ?
+Qui était-ce ?
+Qui était votre professeur ?
+Qui vous portera secours ?
+Qui l’a emporté ?
+À qui voulez-vous parler ?
+Avec qui étiez-vous venu ?
+Qui est soupçonné selon vous ?
+Qui est en train de téléphoner ?
+Qui est cet homme, là-bas ?
+À qui est ce livre ?
+De qui est cette écriture ?
+C’est la faute de qui ?
+Pourquoi me le demandez-vous ?
+Pourquoi s’emporter sans raison ?
+Pourquoi êtes-vous en retard ?
+Pourquoi êtes-vous en train de rire ?
+Pourquoi êtes-vous en train d’hurler comme ça ?
+Pourquoi est-ce que vous me regardez comme ça ?
+Pourquoi me dites-vous tout ça ?
+Pourquoi n’y allez-vous pas ?
+Pourquoi est-il venu ici ?
+Pourquoi est-il venu ?
+Pourquoi l’avez-vous frappé ?
+Pourquoi êtes-vous malpoli ?
+Pourquoi avez-vous fait ça ?
+Pourquoi y êtes-vous allé ?
+Pourquoi avez-vous démissionné de votre travail ?
+Pourquoi avez-vous dit ça ?
+Pourquoi avez-vous gaspillé tout l’argent ?
+Pourquoi n’avez-vous pas postulé à ce poste de travail ?
+Pourquoi ne m’avez-vous pas informé ?
+Pourquoi portez-vous toujours des chemises bleues ?
+Pourquoi êtes-vous gêné ?
+Pourquoi avoir peur quand je suis avec vous ?
+Pourquoi avoir peur puisque je suis là ?
+Pourquoi est-ce ennuyeux ?
+Pourquoi le train est-il en retard ?
+Pourquoi pas ?
+Est-ce qu’il va pleuvoir aujourd’hui ?
+Y aura-t-il une fête d’anniversaire à la maison ?
+Viendront-ils jusqu’ici ?
+Appelez-moi un taxi s’il vous plait.
+Passez-moi une serviette s’il vous plait.
+Ouvrirez-vous la porte ?
+Passez-moi le sel s’il vous plait.
+Vous le mettrez dans la voiture pour moi ?
+Vous me le rappellerez ?
+Vous me raccompagnerez chez moi ?
+Avec qui était-elle venu ?
+Qui l’accompagnait ?
+Qui vous accompagnait ?
+Pouvez-vous lui dire de me rappeler s’il vous plait ?
+Pouvez-vous lui demander de venir ici ?
+Prendrez-vous un verre d’eau.
+Prendrez-vous du café ou du thé ?
+Un verre d’eau ?
+Voulez-vous un verre de vin ?
+Voulez-vous manger quelque chose ?
+Vous souhaiteriez l’acheter ?
+Que diriez-vous d’aller faire une promenade ?
+Que diriez-vous de dîner avec moi ?
+Vous voulez louer un film ?
+Vous voulez regarder la télévision ?
+Vous aurez de l’eau ou du café ?
+Pouvez-vous prendre un message s’il vous plait ?
+Notez par écrit, s’il vous plait.
 Oui, tout à fait.
 Oui.
-Oui. J'en ai.
-Oui/Non.
-Vous vous plaignez toujours au sujet d'une chose ou l'autre.
-Vous êtes en train d'ouvrir la porte.
+Oui. J’en ai.
+Oui ou non.
+Vous vous plaignez toujours au sujet d’une chose ou l’autre.
+Vous êtes en train d’ouvrir la porte.
 Tu es Sheila.
 Toi, tu es Sheila.
 Vous vous appelez Sheila.
 Vous êtes Sheila.
 Vous êtes la bienvenue.
-À quel lieu êtes-vous attaché ?
-Vous avez un très belle voiture.
-Vous m'avez beaucoup aidé.
+À quel lieu êtes-vous attaché ?
+Vous avez une très belle voiture.
+Vous m’avez beaucoup aidé.
 Attendez ici.
-Cela vous plaît ?
+Cela vous plait ?
 Vous ressemblez à ma sœur.
-Vous avez l'air fatigué.
+Vous avez l’air fatigué.
 Vous parlez breton couramment.
 Vous parlez anglais couramment.
 Vos enfants sont bien élevés.
 Votre fille.
-Votre prénom, s'il vous plaît ?
+Votre prénom, s’il vous plait ?
 Votre maison est très agréable.
 Toutes vos affaires sont ici.
 Vous êtes beau.
@@ -6310,6 +6338,6 @@ Vous êtes plus perspicace que lui.
 Vous êtes très aimable.
 Vous êtes très gentil.
 Vous êtes une personne perspicace.
-De rien !
+De rien !
 Vous êtes le bienvenu.
-Combien de temps faut-il pour aller à la gare ?
+Combien de temps faut-il pour aller à la gare ?


### PR DESCRIPTION
This is based on PR #1139.
I took @Booteille 's commit, rebased it to master to resolve conflicts and added my own commit on top to:
 -  Fix other spelling/grammar errors
 -  Remove duplicates
 -  Cut long sentences
 -  Keep valid (but unusual) spelling according to the "rectifications orthographiques du français en 1990"
 -  Add missing punctuation
 -  Add capital letter at the start of sentences
 -  Convert numbers to words
 -  Remove parenthesises and slashes

@lissyx if you want to have a look at it before @mikehenrty merges it.
When this is merged, PR #1139 can be closed.