### PR TITLE
Automatically add hyphens on contribution cards

### DIFF
--- a/web/src/components/pages/contribution/contribution.css
+++ b/web/src/components/pages/contribution/contribution.css
@@ -259,6 +259,9 @@
             box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.05);
             overflow: auto;
             word-wrap: break-word;
+            -ms-hyphens: auto;
+            -webkit-hyphens: auto;
+            hyphens: auto;
 
             opacity: 1;
             transition: transform var(--transition-duration-slow) var(--easing),


### PR DESCRIPTION
Beware: I tested this only on voice.mozilla.org by using the inspector.

Before:
![firefox_2018-07-12_23-52-34](https://user-images.githubusercontent.com/5685512/42661594-f7f5d4f8-862e-11e8-83da-93803675ba52.png)

After:
![firefox_2018-07-12_23-52-39](https://user-images.githubusercontent.com/5685512/42661600-fc2d54c4-862e-11e8-9224-66297fa934b9.png)

What do you think?

https://caniuse.com/#feat=css-hyphens
https://developer.mozilla.org/docs/Web/CSS/hyphens