### PR TITLE
decrease contribution banner font size

### DIFF
--- a/web/src/components/index.css
+++ b/web/src/components/index.css
@@ -773,6 +773,7 @@ a.small, .small a, .text-button.small {
     & h1 {
         background-image: linear-gradient(to right, #f89096, #b1b4e5);
         color:transparent;
+        font-size: 1.71rem;
         background-clip: text;
         -webkit-background-clip: text;
 


### PR DESCRIPTION
The way the text broke due to the font size on my smartphone looked kinda ugly, so I adjusted the font size:

Before:
![firefox_2018-07-17_21-39-48](https://user-images.githubusercontent.com/5685512/42841798-84349136-8a0b-11e8-89da-774473aeb651.png)
After:
![firefox_2018-07-17_21-39-28](https://user-images.githubusercontent.com/5685512/42841801-85551cb6-8a0b-11e8-9c37-78dd2b399f6b.png)

I'm using Firefox on a 1080x1920 screen, Firefox seems to use 400x660 as the size/aspect ratio for the view port

EDIT: I know this is only the case in german, but other languages don't look worse with this imo, so it should be ok.
French is also in 3 lines btw. but remains in 3 lines with this patch, but those 3 lines are filled with text

another success:
English fits on 3 lines instead of 4 on 320x480


# 
Another change that could be done:
.contribution-banner .open {
min-height: 120px;
}

instead of 150px would look better in English on 320x480 btw.
In german it doesn't make any difference (looks good both ways)

In french the bug report string is too long for both links to be pushed into one line