### PR TITLE
[fr] add French sentences from addresses

### DIFF
--- a/server/data/fr/addresses-01.csv
+++ b/server/data/fr/addresses-01.csv
@@ -1,0 +1,70 @@
+deux cent dix-sept route de Collonges, zéro un, cinq cent cinquante Pougny
+deux mille soixante-neuf rue de Pitegny, zéro un, cent soixante-dix, Gex
+deux cent soixante-quinze route de Roulave, zéro un, six cent trente à Saint-Jean-de-Gonville
+Grande Rue, zéro un, six cents Reyrieux
+Route de Marboz, zéro un, quatre cent quarante Viriat
+Rue du Village, Villebois
+Rue de la Laiterie à Marlieux
+un rue Tour du Lac
+Rue des Ormes au numéro dix-huit
+trois cent quatre-vingt-trois A chemin des Lazaristes, zéro un, zéro zéro zéro Saint-Denis-lès-Bourg
+seize impasse des Fontanettes, zéro un, cent quatre-vingt-dix, Boz
+cent quarante-huit rue des Frênes, zéro un, cinq cent quatre-vingts à Izernore
+Rue de la Cîme, zéro un, cent cinquante Leyment
+Rue Nationale, zéro un, cent dix Hauteville-Lompnes
+Rue de Montfort, Treffort-Cuisiat
+Lotissement Domaine de la Tour à Montmerle-sur-Saône
+vingt-trois rue Principale
+Rue Pascal au numéro quarante-huit
+cent soixante et onze rue Saint-Clair, zéro un, quatre cent trente Maillat
+neuf cent cinquante-neuf chemin Chamberthaud, zéro un, six cents, Saint-Didier-de-Formans
+soixante-douze route de Flies, zéro un, cent soixante-dix à Crozet
+Allée du Vierre, zéro un, trois cent quatre-vingts Saint-Cyr-sur-Menthon
+Chemin des Dares, zéro un, sept cents Neyron
+Route du Corbet, Saint-André-sur-Vieux-Jonc
+Place Saint-Vincent de Paul à Châtillon-sur-Chalaronne
+huit cent dix-neuf rue des Charmilles
+Chemin de Charluat au numéro cent quatorze
+un rue Charles Guillon, zéro un, deux cent cinquante Ceyzériat
+cent trente et un route de Pommerette, zéro un, trois cent quarante, Foissiat
+soixante-dix-neuf rue des Terreaux, zéro un, cent soixante-dix à Gex
+Place Redavalle, zéro un, cent cinquante Vaux-en-Bugey
+Chemin de Tanvol, zéro un, quatre cent quarante Viriat
+Allée de Noaillat, Cormoranche-sur-Saône
+Chemin de Chateland à Lagnieu
+quatre-vingt-neuf impasse de la Moline
+Quai du Rhône au numéro neuf cent trente-cinq
+quarante-sept lotissement Clos de Champ-Vrillard, zéro un, cent soixante-dix Cessy
+cinq rue des Battoirs, zéro un, sept cent dix, Thoiry
+cent onze rue de la Poste, zéro un, quatre cent trente à Vieu-d'Izenave
+Rue de Dortan, zéro un, cent Oyonnax
+Rue du Loyat, zéro un, huit cents Charnoz-sur-Ain
+Allée Gruel, Viriat
+Rue du Cordier à Bourg-en-Bresse
+dix-neuf lotissement Les Peupliers
+Rue Char de Ban au numéro vingt-huit
+cinquante et un allée Lumière, zéro un, six cents Massieux
+deux cent trente-neuf chemin du Trève de Galle, zéro un, cent quarante, Garnerans
+quinze lotissement Les Thiards, zéro un, neuf cent soixante à Servas
+Rue des Tartines, zéro un, trois cent quatre-vingts Saint-André-de-Bâgé
+Rue du Champ de l'Épine, zéro un, deux cent dix Ornex
+Rue Centrale, Tenay
+Rue des Crêts à Saint-Genis-Pouilly
+douze rue de l'Arbepin
+Rue de la Fabrique au numéro huit
+cent cinquante-cinq les Plantées, zéro un, cent vingt Dagneux
+cinquante-trois rue des Frères Lumière, zéro un, deux cent quarante, Saint-Paul-de-Varax
+quarante-trois boulevard Victor Hugo, zéro un, zéro zéro zéro à Bourg-en-Bresse
+Rue du Plat, zéro un, cinq cents Ambronay
+Chemin de Roncheveux, zéro un, six cents Saint-Didier-de-Formans
+Route des Sauges, Charix
+Rue du Vernay à Pont-d'Ain
+neuf cent douze route de Chevroux
+Lotissement Les Érables au numéro deux
+dix-sept impasse des Marronniers, zéro un, quatre cent quatre-vingts Chaleins
+six B rue Georges Guynemer, zéro un, zéro zéro zéro, Bourg-en-Bresse
+quatre-vingt-dix-neuf rue de la Côte du Moralay, zéro un, cent soixante-dix à Cessy
+Avenue du huit Mai mille neuf cent quarante-cinq, zéro un, trois cents Belley
+Sentier de la Léchère, zéro un, trois cent quatre-vingts Saint-Cyr-sur-Menthon
+Chemin du Gourd, Montagnat
+Rue de Champnovaz à Challex

--- a/server/data/fr/addresses-02.csv
+++ b/server/data/fr/addresses-02.csv
@@ -1,0 +1,70 @@
+trois chemin de la Belle Idée, zéro deux, six cents Villers-Cotterêts
+un BIS rue de la Croutelle, zéro deux, deux cents, Acy
+onze rue des Paveurs, zéro deux, deux cents à Soissons
+Avenue de la Grande Armée, zéro deux, sept cents Tergnier
+Rue Bénezet, zéro deux, cent Saint-Quentin
+Rue de Chambry, Aulnois-sous-Laon
+Impasse Dessous l'Urmois à Pasly
+dix-sept rue du Maréchal de Lattre de Tassigny
+Rond-Point du Daguet au numéro neuf
+trente-deux boulevard Savart, zéro deux, huit cent trente Saint-Michel
+neuf BIS rue de Verdun, zéro deux, cent quatre-vingt-dix, Juvincourt-et-Damary
+cinquante-cinq rue d'Amiens, zéro deux, cent à Saint-Quentin
+Rue Misery, zéro deux, cent dix Bohain-en-Vermandois
+Place Paul Doumer, zéro deux, huit cents La Fère
+Rue d'Enfer, La Ferté-Chevresis
+Rue de la Brasserie à Molain
+neuf rue du Gite
+Rue de Constantine au numéro soixante
+un route d'Aquitaine, zéro deux, cent Lesdins
+huit rue Vauban, zéro deux, huit cents, La Fère
+deux cent soixante-cinq rue du Voisin, zéro deux, deux cents à Billy-sur-Aisne
+Résidence Les Plantes, zéro deux, huit cent quatre-vingts Terny-Sorny
+Rue Saint-André, zéro deux, cent Saint-Quentin
+Rue de Reuil, Saint-Quentin
+Rue Frédéric Lenglet à Homblières
+trois rue Flamande
+Rue des Gards au numéro douze
+vingt-sept rue Sainte-Benoite, zéro deux, deux cent quarante Brissy-Hamégicourt
+six rue de Montmorency, zéro deux, cent, Saint-Quentin
+deux rue Louis Mennessier, zéro deux, deux cent cinquante à Thiernu
+Rue Poniatowski, zéro deux, deux cent vingt Mont-Notre-Dame
+Rue Sainte-Preuve, zéro deux, trois cent cinquante Bucy-lès-Pierrepont
+Rue des Houppeux, Saint-Nicolas-aux-Bois
+Rue du Jury à Acy
+soixante-six rue de Reims
+Ruelle de la Petite Cense au numéro trois BIS
+vingt-neuf rue Porte Crouy, zéro deux, deux cents Soissons
+soixante-seize rue de la Hurée, zéro deux, zéro zéro zéro, Laon
+quatre rue René Licette, zéro deux, deux cent cinquante à Housset
+Résidence Soleil Levant, zéro deux, cent Morcourt
+Rue de Villermont, zéro deux, quatre cents Nesles-la-Montagne
+Rue du sept e Bataillon de Chasseurs Alpins, Pinon
+Rue du Poulain à Billy-sur-Aisne
+treize rue Jacques Fourrier
+Rue de la Chenée au numéro sept
+quatre-vingt-neuf rue Louis Blanc, zéro deux, trois cents Chauny
+cent quinze boulevard de Bad Kostritz, zéro deux, trois cents, Chauny
+deux rue du Cimetière, zéro deux, cent soixante à Bourg-et-Comin
+Rue d'Hirson, zéro deux, cinq cent cinquante Origny-en-Thiérache
+Rue Dornemberger, zéro deux, cent Saint-Quentin
+Rue du Pleu, Villers-Cotterêts
+Rue Blanqui à Saint-Quentin
+soixante-dix-sept rue d'Alger
+Rue Potier au numéro dix
+seize rue Robert de Massy, zéro deux, cent Saint-Quentin
+cinq rue du Clos des Forges, zéro deux, trois cent dix, Pavant
+quatre-vingt-seize rue de la Fère, zéro deux, cent à Saint-Quentin
+Route de Guise, zéro deux, cent quarante Vervins
+Route de Fressancourt, zéro deux, quatre cent dix Saint-Gobain
+Place de la Victoire, Hirson
+Rue de la Piscine à Aulnois-sous-Laon
+trois cent trente rue Alain Langlet
+Rue Maurice Brugnon au numéro quinze
+trente-deux rue Rose, zéro deux, trois cent vingt Lizy
+quatre-vingt-six boulevard Gambetta, zéro deux, cent, Saint-Quentin
+cinq rue des Tranchées, zéro deux, deux cents à Soissons
+Rue de la Vallée, zéro deux, deux cents Pommiers
+Rue de Crécy, zéro deux, huit cents Charmes
+Rue de Laon, Corbeny
+Rue Fernand Pinal à Saint-Gengoulph

--- a/server/data/fr/addresses-03.csv
+++ b/server/data/fr/addresses-03.csv
@@ -1,0 +1,70 @@
+huit boulevard de Courtais, zéro trois, zéro zéro zéro Moulins
+cent soixante-sept route de Vendat (tracé Modifié), zéro trois, cent dix, Espinasse-Vozelle
+quatre rue de Bresnay, zéro trois, deux cent quarante à Treban
+Route de Decize, zéro trois, zéro zéro zéro Avermes
+Rue des Grands Nauds, zéro trois, trois cents Molles
+Route de la Viale, Lignerolles
+Rue de l'Escalier à Bourbon-l'Archambault
+cinquante-trois route de Saint-Priest
+Rue Porte Saint-Pierre au numéro cinq
+quarante-quatre rue de Pasquis, zéro trois, cent Montluçon
+quatorze rue Jean Treyve, zéro trois, quatre cents, Yzeure
+quinze chemin des Boudaises, zéro trois, quatre cent dix à Domérat
+Rue Andre Messager, zéro trois, sept cents Bellerive-sur-Allier
+Impasse de la Croix du Retz, zéro trois, quatre cents Yzeure
+Rue de Vendat, Saint-Rémy-en-Rollat
+Rue des Planchards à Yzeure
+soixante-dix-neuf rue Armand Gobert
+Chemin du Désert au numéro quarante-huit
+cinq rue des Grèzes, zéro trois, quatre cent trente Cosne-d'Allier
+dix-neuf rue de la Réunion, zéro trois, cent, Montluçon
+deux rue des Reclos, zéro trois, huit cents à Charmes
+Impasse des Martinets, zéro trois, sept cents Bellerive-sur-Allier
+Route de Montluçon, zéro trois, trois cent quatre-vingts Quinssaines
+Rue du Champ Bagnolet, Voussac
+Avenue de Bressolles à Domérat
+vingt et un boulevard Jean Lafaure
+Rue de Montfand au numéro trente-trois
+vingt-cinq boulevard des Mouillères, zéro trois, cent soixante Bourbon-l'Archambault
+vingt-neuf rue de Serbie, zéro trois, zéro zéro zéro, Moulins
+vingt rue Albert Rondreux, zéro trois, cent soixante à Bourbon-l'Archambault
+Rue de la Boise, zéro trois, deux cent quatre-vingt-dix Diou
+Rue Damiette, zéro trois, cent Montluçon
+Rue de la Verne, Molinet
+Rue des Tanneurs à Charroux
+quatre-vingt-huit avenue Gilbert Roux
+Rue des Petites Chaumes au numéro trois
+cinquante-trois rue des Maussangs, zéro trois, sept cents Brugheas
+quatre TER rue Louis Bonjon, zéro trois, cent cinquante, Varennes-sur-Allier
+soixante-six avenue de Vichy, zéro trois, sept cents à Bellerive-sur-Allier
+Allée du Champ des Nôtes, zéro trois, sept cents Bellerive-sur-Allier
+Rue de la Boisselée, zéro trois, cent Montluçon
+Impasse du Stade, Périgny
+Rue du Pied de Fourche à Bourbon-l'Archambault
+dix-neuf rue Edmond Bourges
+Rue du Montais au numéro cinquante-cinq
+deux rue de Billonnière, zéro trois, cinq cents Contigny
+dix route de Corgenay, zéro trois, zéro zéro zéro, Neuvy
+sept rue Léopold Chabassière, zéro trois, quatre cents à Yzeure
+Rue du Plan d'Eau, zéro trois, trois cent quatre-vingts Quinssaines
+Allée du Chambon, zéro trois, zéro zéro zéro Moulins
+Rue de la Font Saint-Georges, Étroussat
+Lotissement Les Blondats à Neuvy
+seize rue Max Durand Fardel
+Rue du Roty au numéro vingt-deux
+deux lotissement des Prés Juliards, zéro trois, huit cents Gannat
+dix rue Grenet, zéro trois, deux cents, Vichy
+sept rue Desbrest, zéro trois, deux cents à Vichy
+Route de La Ferté, zéro trois, trois cent quarante Bessay-sur-Allier
+Rue de la Font Neuve, zéro trois, cent quarante Chantelle
+Rue du Capitaine Lafond, Lurcy-Lévis
+Clos des Vergers à Désertines
+six rue de la Goutte Morte
+Rue de l'Enfer au numéro huit BIS
+onze rue de la Jonchère, zéro trois, huit cents Poëzat
+vingt-quatre route de Souvigny, zéro trois, deux cent quarante, Cressanges
+neuf rue de la Malgarnie, zéro trois, cinq cents à Cesset
+Allée des Écoles, zéro trois, six cents Malicorne
+Rue du Sénateur Gacon, zéro trois, deux cents Vichy
+Place du huit Mai, Varennes-sur-Allier
+Route de Vozelle à Espinasse-Vozelle

--- a/server/data/fr/addresses-04.csv
+++ b/server/data/fr/addresses-04.csv
@@ -1,0 +1,70 @@
+mille neuf cent dix-huit route d'Apt, zéro quatre, cent Manosque
+vingt-six BIS avenue Saint-Lazare, zéro quatre, cent, Manosque
+un avenue Alphonse Daudet, zéro quatre, huit cent soixante à Pierrevert
+Rue Auguste Brun, zéro quatre, sept cents Oraison
+Traverse Couleto, zéro quatre, sept cents Oraison
+Montée de Sainte-Roustagne, Manosque
+Chemin des Mélanes à Oraison
+un rue de Gérant
+Chemin du Marquis au numéro vingt-sept
+sept mille deux cent quatre-vingt-neuf rue du Cigaloun, zéro quatre, cent trente Volx
+quarante-six impasse de la Musardière, zéro quatre, cent, Manosque
+sept rue Paul Rouit, zéro quatre, zéro zéro zéro à Digne-les-Bains
+Avenue des Trois Frères Arnaud, zéro quatre, quatre cents Barcelonnette
+Rue Joseph Gassendy Tartonne, zéro quatre, zéro zéro zéro Digne-les-Bains
+Lotissement Isabelle, Oraison
+Rue Sainte-Claire Deville à Château-Arnoux-Saint-Auban
+onze rue Francis Drouhard
+Rue Antoine Fondrini au numéro sept mille cent dix-neuf
+trente-neuf chemin du Mourvenc, zéro quatre, cent Manosque
+sept mille sept cent six chemin de Brunet, zéro quatre, sept cents, Oraison
+quatorze avenue Gaston-Boyer, zéro quatre, zéro zéro zéro à Digne-les-Bains
+Rue du Mitan, zéro quatre, cent vingt Castellane
+Chemin d'Aubignosc, zéro quatre, deux cents Peipin
+Rue Felix Esclangon, Sainte-Tulle
+Chemin de Pimoutier à Manosque
+huit place Joseph Coutel
+Avenue des Farigoules au numéro sept mille deux cent dix
+trois chemin du Pesquier, zéro quatre, cinq cent dix Aiglun
+cent trente et un chemin de la Crête, zéro quatre, cent soixante, Château-Arnoux-Saint-Auban
+trente-six boulevard Elémir Bourges, zéro quatre, cent à Manosque
+Rue Paul Arène, zéro quatre, zéro zéro zéro Digne-les-Bains
+Boulevard de la Plaine, zéro quatre, cent Manosque
+Rue Mercadier, Digne-les-Bains
+Route de Champtercier à Digne-les-Bains
+quatre-vingt-seize avenue d'Arsonval
+Rue du Nène au numéro un
+vingt-six boulevard Martin Bret, zéro quatre, cent Manosque
+sept mille soixante-douze chemin de la Rhôde, zéro quatre, sept cents, Oraison
+cinq rue Arnaud de Trian, zéro quatre, huit cents à Gréoux-les-Bains
+Lotissement Peyralines, zéro quatre, quatre cents Barcelonnette
+Avenue Jean Giono, zéro quatre, trois cents Forcalquier
+Rue des Martels, Manosque
+Avenue des Frères Bonnet à Oraison
+trois cent seize montée de l'Ubac
+Rue Joseph Latil au numéro un
+six rue Charles Bouffier, zéro quatre, sept cents Oraison
+neuf avenue de Parrin, zéro quatre, huit cent soixante, Pierrevert
+dix lotissement du Chazelas, zéro quatre, quatre cents à Barcelonnette
+Lotissement de la Pommeraie, zéro quatre, cent trente Volx
+Rue de la Belugue, zéro quatre, zéro zéro zéro Digne-les-Bains
+Rue Alphonse Richard, Digne-les-Bains
+Rue Daniel Reynaud à Reillanne
+trente-six rue Colonel Fabien
+Avenue Henri Jaubert au numéro soixante-sept
+vingt-trois chemin de L'Adrech de Saint-Véran, zéro quatre, zéro zéro zéro Digne-les-Bains
+trois cent cinquante-trois boulevard Saint-Joseph, zéro quatre, cent, Manosque
+cinq cent vingt chemin de la Combe d'Azard, zéro quatre, cent quatre-vingts à Villeneuve
+Allée des Coustelines, zéro quatre, sept cents Oraison
+Place du Moulin Saint-Martin, zéro quatre, cent Manosque
+Montée des Genêts, Manosque
+Rue Émile Boyoud à Château-Arnoux-Saint-Auban
+mille quarante et un voie Impériale
+Rue Marcelin Delaye au numéro sept
+huit allée Bachagha Boualem, zéro quatre, cent Manosque
+dix rue Chapeau de Gendarme, zéro quatre, quatre cents, Barcelonnette
+trois avenue Sainte-Félicie, zéro quatre, huit cent soixante à Pierrevert
+Rue Barboise, zéro quatre, huit cents Gréoux-les-Bains
+Rue de la Côte Belle, zéro quatre, cent trente Volx
+Boulevard des Combes, Manosque
+Lotissement La Clé des Champs à Oraison

--- a/server/data/fr/addresses-05.csv
+++ b/server/data/fr/addresses-05.csv
@@ -1,0 +1,70 @@
+neuf avenue de la Flamenche, zéro cinq, sept cents Serres
+trois avenue du Dauphiné, zéro cinq, cent, Briançon
+cinquante-cinq route des Fauvins, zéro cinq, zéro zéro zéro à Gap
+Rue Varanfrain, zéro cinq, sept cents Serres
+Rue des Cellettes, zéro cinq, deux cent trente La Bâtie-Neuve
+Chemin Dès Boeres, Gap
+Rue de L'Auche à Serres
+trois rue du Pont d'Asfeld
+Rue Docteur Caral au numéro un
+neuf rue Palluel, zéro cinq, deux cents Embrun
+dix-sept rue de la Clarée, zéro cinq, zéro zéro zéro, Gap
+trente-huit rue Henri Peuzin, zéro cinq, sept cents à Serres
+Rue du Lys des Alpes, zéro cinq, cent vingt L'Argentière-la-Bessée
+Route de Valserres, zéro cinq, zéro zéro zéro Gap
+Route de Chabanas, Gap
+Rue Gabrielle Massot à Veynes
+quarante-sept avenue Émile Didier
+Rue des Metiers au numéro vingt-trois
+deux rue Mauzan, zéro cinq, zéro zéro zéro Gap
+sept allée Fleurie, zéro cinq, zéro zéro zéro, Gap
+huit rue Santos Dumont, zéro cinq, zéro zéro zéro à Gap
+Avenue Napoléon, zéro cinq, cent dix La Saulce
+Rue du Souffle, zéro cinq, deux cent trente La Bâtie-Neuve
+Chemin de Champ Lagier, Saint-Bonnet-en-Champsaur
+Chemin de Beauvoir et Bellerots à Laragne-Montéglin
+vingt-sept C route des Prés
+Rue des Colonnes au numéro sept
+huit ancienne Route de Veynes, zéro cinq, zéro zéro zéro Gap
+douze avenue des Pins, zéro cinq, sept cents, Serres
+un rue de la Manutention, zéro cinq, cent à Briançon
+Rue du Guil, zéro cinq, zéro zéro zéro Gap
+Rue de la Guisane, zéro cinq, zéro zéro zéro Gap
+Rue sous Puymaure, Gap
+Chemin de Mas de Blais à Briançon
+treize chemin Dès Noisetiers
+Rue du Roure au numéro dix-huit
+deux rue Marius Meyère, zéro cinq, sept cents Serres
+trois place du Peyssier, zéro cinq, cinq cents, Saint-Bonnet-en-Champsaur
+six mille six cent soixante-six rue Jacques Isoard, zéro cinq, quatre cents à Veynes
+Rue Joseph Mathieu, zéro cinq, six cents Guillestre
+Rue de la Robéyère, zéro cinq, deux cents Embrun
+Rue de la Bise, La Bâtie-Neuve
+Avenue de la Source à Serres
+neuf impasse Gallice Bey
+Rue Clair Site au numéro douze
+quatorze rue du Sirac, zéro cinq, zéro zéro zéro Gap
+cinquante-quatre avenue de Monteglin, zéro cinq, trois cents, Laragne-Montéglin
+deux cent quarante-quatre rue de Chabrière, zéro cinq, deux cent trente à La Bâtie-Neuve
+Place Barthelon, zéro cinq, deux cents Embrun
+Rue Général Rostolland, zéro cinq, cent Briançon
+Avenue du onze Novembre, Tallard
+Chemin de la Serre à Embrun
+quinze chemin Dès Chênes
+Cours du Vieux Moulin au numéro douze
+cinquante route de la Luye, zéro cinq, zéro zéro zéro Gap
+neuf allée Dès Hautes Plaines, zéro cinq, zéro zéro zéro, Gap
+onze rue du Granit de Pelvoux, zéro cinq, cent vingt à L'Argentière-la-Bessée
+Route de la Justice, zéro cinq, zéro zéro zéro Gap
+Rue Albert Blanc, zéro cinq, zéro zéro zéro Gap
+Rue Souveraine, Tallard
+Chemin de Châteauvieux à Veynes
+quatre-vingt-quatorze rue de l'Avance
+Chemin du Soleil-Levant au numéro trois D
+deux impasse des Dahlias, zéro cinq, zéro zéro zéro Gap
+dix rue des Quatre Traverses, zéro cinq, deux cents, Embrun
+vingt-neuf rue Jean Bayle, zéro cinq, cent à Villar-Saint-Pancrace
+Rue du Pré Galland, zéro cinq, zéro zéro zéro Gap
+Route de Chaudefeuille, zéro cinq, zéro zéro zéro Gap
+Route de Treschâtel, Gap
+Rue Cyprien Chaix à Gap

--- a/server/data/fr/addresses-06.csv
+++ b/server/data/fr/addresses-06.csv
@@ -1,0 +1,70 @@
+soixante-quinze chemin du Loup, zéro six, trois cent trente Roquefort-les-Pins
+neuf avenue du Docteur Raymond Picaud, zéro six, cent cinquante, Cannes
+soixante-cinq boulevard Louis Icard, zéro six, cent trente à Grasse
+Route de Saint-Martin de Peille, zéro six, quatre cent quarante Peille
+Rue de la Baragne, zéro six, cinq cent dix Conségudes
+Avenue du Bosquet, Mougins
+Place des Moneghetti à Beausoleil
+mille deux cent quatre-vingt-trois route de la Fènerie
+Rue Henri Charpentier au numéro cinq
+vingt-deux avenue Mont-Joli, zéro six, cent dix Le Cannet
+trois cent quatre-vingt-onze chemin des Guichards, zéro six, cinq cent trente, Spéracèdes
+cent soixante-dix avenue du Loubet, zéro six, deux cent soixante-dix à Villeneuve-Loubet
+Avenue Regina, zéro six, deux cent cinquante Mougins
+Chemin du Collet de Bellon, zéro six, zéro zéro zéro Nice
+Chemin du Suye, Peymeinade
+Chemin cinq G Guyon de Pampelonne à Tourrette-Levens
+mille deux cent trente-neuf corniche des Ciappes de Castellar
+Rue du Docteur Moriez au numéro trente-quatre
+quatre rue des Serbes, zéro six, cent cinquante Cannes
+cinq cent soixante-huit boulevard d'Arlésie, zéro six, deux cent dix, Mandelieu-la-Napoule
+douze H avenue Denis Semeria, zéro six, deux cent trente à Saint-Jean-Cap-Ferrat
+Rue de l'Agachon, zéro six, cinq cent trente Cabris
+Avenue Antoine de Saint-Exupéry, zéro six, cent trente Grasse
+Route de la Colle, Saint-Paul-de-Vence
+Chemin de Pierrenchon à Auribeau-sur-Siagne
+six rue Brève
+Rue Marguerite au numéro dix
+vingt-six rue Marco del Ponte, zéro six, cent cinquante Cannes
+cinq cent cinquante-cinq chemin de la Prouveiresse, zéro six, cinq cent trente, Cabris
+six avenue du Clos, zéro six, deux cent soixante-dix à Villeneuve-Loubet
+Route de Valbonne, zéro six, cent dix Le Cannet
+Avenue de la Croix des Gardes, zéro six, cent cinquante Cannes
+Avenue Marie Henriette, Roquebrune-Cap-Martin
+Avenue du Petit Juas à Cannes
+cent soixante-sept chemin des Hautes Bréguières
+Avenue de Fréjus au numéro mille cinq cent quatre-vingts
+mille sept cent vingt-sept route de la Zone Artisanale, zéro six, cinq cent dix Carros
+quarante-neuf avenue de Féric, zéro six, zéro zéro zéro, Nice
+cinq place Le Courredou, zéro six, sept cent quarante à Châteauneuf-Grasse
+Chemin des Soullieres, zéro six, quatre cent dix Biot
+Chemin des Brusquets, zéro six, cent soixante Antibes
+Chemin de Fontvieille, Grasse
+Avenue du Vert Coteau à Cannes
+un rue Jacques Barraja
+Avenue Général Maizière au numéro trente
+dix rue du Viguier, zéro six, trois cent quatre-vingts Sospel
+cinquante-cinq chemin des Chênes Saint-Jacques, zéro six, cent trente, Grasse
+trois cent cinquante-sept chemin du Baou, zéro six, cinq cent soixante à Valbonne
+Avenue de la Concorde, zéro six, cent soixante Antibes
+Route du Pont Charles Albert, zéro six, cinq cent dix Le Broc
+Route de la Badine, Antibes
+Avenue Louis Cauvin à Grasse
+deux mille cinq cent quatre-vingts route du Col de Brouis
+Avenue Aimé Bourreau au numéro trente-quatre
+cent quatre boulevard du Midi, zéro six, cent cinquante Cannes
+un A place Dei Tubans, zéro six, sept cent dix, Thiéry
+quatre place Saint-Eloi, zéro six, quatre cent dix à Biot
+Route de Pégomas, zéro six, cent trente Grasse
+Chemin des Terriers, zéro six, cent soixante Antibes
+Avenue du Camp Long, Cannes
+Rue Barthélémy à Cannes
+quatre cent cinquante-deux boulevard des Horizons
+Avenue Saint-Louis au numéro vingt-sept
+cent neuf avenue des Baumettes, zéro six, deux cent soixante-dix Villeneuve-Loubet
+seize petite Rue Saint-Antoine, zéro six, cent cinquante, Cannes
+un allée de la Gardiole, zéro six, deux cent soixante-dix à Villeneuve-Loubet
+Traverse du Suye, zéro six, cinq cent trente Peymeinade
+Avenue Auguste Renoir, zéro six, cent trente Grasse
+Chemin de Bestagne, Roquebrune-Cap-Martin
+Avenue de la Californie à Nice

--- a/server/data/fr/addresses-07.csv
+++ b/server/data/fr/addresses-07.csv
@@ -1,0 +1,70 @@
+huit cent vingt-cinq route d'Annonay, zéro sept, trois cent quarante Talencieux
+cent cinquante-cinq chemin des Grads, zéro sept, cent soixante-dix, Lavilledieu
+cinq cent onze route des Célestins, zéro sept, trois cent quarante à Saint-Désirat
+Impasse Émile Junique, zéro sept, trois cents Tournon-sur-Rhône
+Allée de la Magnanerie, zéro sept, trois cents Tournon-sur-Rhône
+Route du Pont de Lignon, Roiffieux
+Rue des Perriers à Glun
+quatre cent cinquante et un rue des Prés Château
+Chemin de Rouveure au numéro cent cinquante
+mille quarante route de l'Échelette, zéro sept, cent soixante-dix Lussas
+vingt et un place Seignobos, zéro sept, deux cent soixante-dix, Lamastre
+cinq cent cinq chemin de Geny, zéro sept, cent trente à Soyons
+Route de la Roche Péréandre, zéro sept, cent Annonay
+Rue Bertraud, zéro sept, huit cents La Voulte-sur-Rhône
+Allée de la Mûre, Peaugres
+Chemin des Lèches à Soyons
+quatre cent dix route de Beaumarais
+Place Mayol au numéro deux
+neuf rue de Georgie, zéro sept, trois cent trente Thueyts
+six chemin de la Roche Noire, zéro sept, deux cents, Aubenas
+cinquante-cinq chemin du Bâteau, zéro sept, sept cents à Saint-Just-d'Ardèche
+Chemin de Saint-Martin des Ollières, zéro sept, deux cents Aubenas
+Chemin de Montleviere, zéro sept, trois cents Étables
+Chemin du Sourbier, Champis
+Allée François Mansard à Guilherand-Granges
+cinq cent quarante chemin de Côte Rôtie
+Rue des Chanterelles au numéro cent quatre-vingt-deux
+deux rue Radal, zéro sept, deux cents Aubenas
+cent huit route de Samoyas, zéro sept, cent, Boulieu-lès-Annonay
+cent chemin des Arceaux, zéro sept, deux cents à Saint-Étienne-de-Fontbellon
+Boulevard Docteur François Bourret, zéro sept, zéro zéro zéro Privas
+Impasse Suzanne Lenglen, zéro sept, cinq cents Guilherand-Granges
+Boulevard Saint-Didier, Aubenas
+Rue du Moulin de l'Aure à Toulaud
+cent soixante-quinze chemin des Cedres
+Allée des Poinsettias au numéro cinq
+quatre-vingt-onze rue du Minerai, zéro sept, trois cent quarante Brossainc
+trois cent dix chemin de Liffrand, zéro sept, deux cents, Lachapelle-sous-Aubenas
+huit passage de l'Étang, zéro sept, trois cents à Tournon-sur-Rhône
+Route Boissy d'Anglas, zéro sept, cent Roiffieux
+Rue Henri Baudson, zéro sept, cent trente Saint-Péray
+Route de la Syrah, Saint-Désirat
+Rue Rémy Roure à Saint-Péray
+trois cents rue René Palix
+Allée de la Chênaie au numéro cent quarante
+cinq cents route de Barjac, zéro sept, cent cinquante Salavas
+cent quarante avenue Olivier de Serres, zéro sept, cent trente, Soyons
+trois cent soixante-dix QUATER chemin du Silhol, zéro sept, cent vingt à Saint-Alban-Auriolles
+Chemin de Palisson, zéro sept, six cent dix Sécheras
+Route de Rochessauve, zéro sept, deux cent dix Alissas
+Route de Tauzuc, Saint-Sauveur-de-Montagut
+Rue Bertranne à Bourg-Saint-Andéol
+cinq cent quinze rue Claude Constant
+Avenue Hélène de Tournon au numéro six TER
+trois place des Masseguisses, zéro sept, cent quarante Les Vans
+mille six cent quatre-vingt-cinq route de la Chiéze, zéro sept, trois cent soixante, Les Ollières-sur-Eyrieux
+dix rue Fombarlet, zéro sept, huit cents à La Voulte-sur-Rhône
+Route des Bords d'Ardèche, zéro sept, trois cent quatre-vingts Pont-de-Labeaume
+Rue des Colibris, zéro sept, cent trente Cornas
+Chemin de la Fontaine de Cheyron, Aubenas
+Rue de Champel au Cheylard
+trente-quatre avenue de Nîmes
+Chemin de Chalencon au numéro trois
+trente-deux montée de Celles, zéro sept, huit cents La Voulte-sur-Rhône
+quarante et un montée des Aygas, zéro sept, cent, Annonay
+trente et un rue Vincent Touchet, zéro sept, quatre cents au Teil
+Route de Combes, zéro sept, cent trente Saint-Romain-de-Lerps
+Route des Mines, zéro sept, zéro zéro zéro Privas
+Route de Bréchignac, Ucel
+Rue de Tournon à Annonay

--- a/server/data/fr/addresses-08.csv
+++ b/server/data/fr/addresses-08.csv
@@ -1,0 +1,70 @@
+onze rue Cécilia Gazanière, zéro huit, quatre cent trente Launois-sur-Vence
+dix rue Octave Delalucque, zéro huit, trois cent cinquante, Vrigne-Meuse
+vingt et un rue Arthur Habary, zéro huit, cent quarante à Francheval
+Rue Wolfgang Doeblin, zéro huit, six cents Givet
+Rue de la Corvée, zéro huit, cent vingt Bogny-sur-Meuse
+Rue du Docteur de Fisson, Bogny-sur-Meuse
+Rue de Theline à Vouziers
+sept cent vingt-six A rue des Pâquis
+Rue de Nouzonville au numéro quatre-vingt-neuf B
+six ruelle des Hêtres, zéro huit, deux cents Sedan
+trente-trois faubourg du Fond de Givonne, zéro huit, deux cents, Sedan
+quatorze rue Eugène Marquigny, zéro huit, trois cents à Rethel
+Rue du quarante-six e R.un., zéro huit, cent quatre-vingt-dix Asfeld
+Route de la Scierie, zéro huit, cent soixante Élan
+Avenue Vincent Auriol, Revin
+Rue Roger Renard à Hierges
+onze rue Camille Corot
+Rue d'Etion au numéro cent quarante-trois
+neuf rue de Paternotte, zéro huit, zéro zéro zéro Les Ayvelles
+six A rue du vingt-quatre Août, zéro huit, cent soixante-dix, Haybes
+vingt et un rue de la Budille, zéro huit, deux cents à Sedan
+Rue du Pré d'Haurs, zéro huit, six cents Fromelennes
+Rue du Général Dubois, zéro huit, deux cents Sedan
+Ruelle des Fourches, Sedan
+Place de Levrézy à Bogny-sur-Meuse
+treize rue de la Hobette
+Rue Georges Muriot au numéro quatre
+quinze rue Raymond et Clodomir Lamber, zéro huit, six cents Givet
+quarante-huit rue des trois Fourchettes, zéro huit, six cents, Givet
+cinq rue de la Machère, zéro huit, trois cent cinquante à Noyers-Pont-Maugis
+Rue de Rome, zéro huit, trois cents Rethel
+Rue du Ménil, zéro huit, deux cents Sedan
+Chaussée de Sedan, Charleville-Mézières
+Rue de Fleuranges à Sedan
+dix rue du Grand Châtelet
+Rue Tanton-Bechefer au numéro seize
+trente-cinq BIS avenue des Martyrs de la Résistance, zéro huit, zéro zéro zéro Charleville-Mézières
+vingt route d'Arreux, zéro huit, zéro quatre-vingt-dix, Houldizy
+trois rue du Petit Châtelet, zéro huit, quatre cents à Vouziers
+Avenue de Montcy-Notre-Dame, zéro huit, zéro zéro zéro Charleville-Mézières
+Rue Fernand Sueur, zéro huit, cinq cents Revin
+Promenade des Bertholet, Warcq
+Ruelle de la Dohette à Messincourt
+douze rue des Marizys
+Rue du Drapeau au numéro dix-sept
+vingt-cinq rue Bahut, zéro huit, zéro zéro zéro Charleville-Mézières
+seize BIS rue des Eparus, zéro huit, cent vingt, Bogny-sur-Meuse
+sept rue Lucien Drapier, zéro huit, trois cents à Rethel
+Ruelle Quentin, zéro huit, trois cent dix Machault
+Rue des Pépinières, zéro huit, zéro zéro zéro Charleville-Mézières
+Rue de la Queue des Prés, Bogny-sur-Meuse
+Rue Marguerite Fontaine à Revin
+vingt-deux cité Joliot-Curie
+Avenue du Général Margueritte au numéro vingt-cinq
+trois chemin du Chantrenne, zéro huit, cent cinquante Renwez
+douze avenue du Docteur Abd El Nour, zéro huit, cent quarante, Bazeilles
+trente-trois BIS avenue du quatre-vingt-onze e Régiment d'Infanterie, zéro huit, zéro zéro zéro à Charleville-Mézières
+Rue du Potay, zéro huit, cent soixante-dix Fumay
+Route de Warnecourt, zéro huit, zéro zéro zéro Prix-lès-Mézières
+Rue du Petit Chooz, Chooz
+Ruelle Tisserand à Sedan
+un rue du Pont Royal
+Rue de la Vieille Ville au numéro dix-sept
+cinquante-sept rue Roland Lambert, zéro huit, zéro zéro zéro Charleville-Mézières
+un rue Mon Plaisir, zéro huit, six cents, Givet
+dix-huit rue des Gros Chênes, zéro huit, cent soixante-dix à Hargnies
+Rue du Fourneau, zéro huit, cent soixante Boutancourt
+Route de Launois, zéro huit, zéro quatre-vingt-dix Warnécourt
+Rue du Clos Barrois, Les Ayvelles
+Rue René Gouverneur à Vivier-au-Court

--- a/server/data/fr/addresses-09.csv
+++ b/server/data/fr/addresses-09.csv
@@ -1,0 +1,70 @@
+neuf chemin de la Gourgue, zéro neuf, quatre cents Arignac
+treize promenade de l'Ariège, zéro neuf, quatre cents, Tarascon-sur-Ariège
+cent trente route de Saint-Amans, zéro neuf, cent à Bonnac
+Rue de Loumet, zéro neuf, cent Pamiers
+Hameau de la Digue, zéro neuf, sept cents Saint-Quirc
+Rue Monseigneur de Cambon, Mirepoix
+Rue du Bout de Paris à Lorp-Sentaraille
+quatre avenue du Pareage
+Rue Alamans au numéro neuf
+quatorze lotissement de l'Estaut, zéro neuf, cent La Tour-du-Crieu
+quatre-vingt-un chemin d'Arrout, zéro neuf, huit cents, Audressein
+quinze A cours Colonel Petitpied, zéro neuf, cinq cents à Mirepoix
+Rue Malbec, zéro neuf, cent Pamiers
+Chemin Las Clotes, zéro neuf, cent quatre-vingt-dix Gajan
+Rue Pablo Casals, Foix
+Rue Astronome Vidal à Mirepoix
+cinq avenue de Lavelanet
+Rue Rives de l'Hers au numéro cent quarante-neuf
+quinze A avenue Louis Siret, zéro neuf, cent vingt Varilhes
+quatre-vingt-quatorze place del Faouré, zéro neuf, trois cent dix, Aston
+quinze rue Lieutenant Paul Delpech, zéro neuf, zéro zéro zéro à Foix
+Route de Limoux, zéro neuf, cinq cents Moulin-Neuf
+Avenue de Montségur, zéro neuf, cinq cents Manses
+Rue de la Barguillère, Foix
+Quartier de la Gaillarde à Ornolac-Ussat-les-Bains
+vingt-quatre chemin d'Armeilhac
+Chemin de Fount Laouzert au numéro quatre A
+seize rue Longué Docteur Suzanne Noël, zéro neuf, zéro zéro zéro Foix
+sept D avenue de la Halte, zéro neuf, trois cent quarante, Verniolle
+cinq résidence de Lestang, zéro neuf, zéro zéro zéro à Ferrières-sur-Ariège
+Rue Jean Jacques Delescazes, zéro neuf, zéro zéro zéro Foix
+Avenue des Pyrénées, zéro neuf, trois cent trente Montgaillard
+Promenade des Maquisards, Pamiers
+Place de Vidalat à Saurat
+neuf BIS chemin Isabelle Sandy
+Boulevard du Sud au numéro vingt-deux
+cinq rue Saint-Valier, zéro neuf, deux cents Saint-Girons
+dix A avenue du Couserans, zéro neuf, trois cent quarante, Verniolle
+neuf cent quatre-vingt-treize A route de Gaudiès, zéro neuf, deux cent soixante-dix à Mazères
+Rue de l'Abbé Forgues, zéro neuf, cent quatre-vingt-dix Lorp-Sentaraille
+Chemin de Lestrade, zéro neuf, six cents Aigues-Vives
+Rue de l'Espinet, Foix
+Rue Roger Deumié à Ferrières-sur-Ariège
+quinze TER avenue Boulbonne
+Route de Toulouse au numéro dix
+deux cent quarante chemin de la Caze, zéro neuf, quatre cents Mercus-Garrabet
+six rue des Pas Perdus, zéro neuf, six cents, Laroque-d'Olmes
+cinq rue du Pousadou, zéro neuf, trois cent cinquante à Campagne-sur-Arize
+Avenue Irénée Cros, zéro neuf, cent Pamiers
+Chemin du Bûcher, zéro neuf, cent La Tour-du-Crieu
+Rue de Montgauzy, Foix
+Place de l'Allée à Seix
+soixante-huit rue du Cammas
+Cité le Soularac au numéro trois
+un impasse du Garrel, zéro neuf, trois cent quarante Verniolle
+douze rue du Coustou, zéro neuf, cent dix, Ax-les-Thermes
+deux impasse de la Bergerie, zéro neuf, quatre cents à Mercus-Garrabet
+Rue Boulbonne, zéro neuf, deux cent soixante-dix Mazères
+Route de Croquié, zéro neuf, quatre cents Mercus-Garrabet
+Rue du Rempart, Verdun
+Rue de la Papeterie à Pamiers
+vingt-huit rue Piconnières
+Rue d'Embonnel au numéro douze
+quatre-vingt-trois rue des Gouzis, zéro neuf, deux cent quatre-vingt-dix Le Mas-d'Azil
+sept rue de l'Agasse, zéro neuf, cent, Pamiers
+seize route de Rieux, zéro neuf, cent vingt à Varilhes
+Route de Verniolle, zéro neuf, cent vingt Varilhes
+Quartier de la Baquo, zéro neuf, trois cents L'Aiguillon
+Rue de Cassagne, Vernajoul
+Impasse Saint-Bernard à Pamiers

--- a/server/data/fr/addresses-10.csv
+++ b/server/data/fr/addresses-10.csv
@@ -1,0 +1,70 @@
+un rue Louis Auger, dix mille cent vingt Saint-André-les-Vergers
+un impasse de la Guerarde, dix, zéro zéro zéro, Troyes
+onze rue Robert Graumer, dix, cent à Romilly-sur-Seine
+Rue Étienne Pedron, dix mille Troyes
+Rue Gaston Checq, dix, zéro zéro zéro Troyes
+Rue Georges Seurat, Troyes
+Rue d'Aube à Magnicourt
+trente-cinq rue Louis Desprez
+Rue Bodié Pouard au numéro sept
+dix-neuf villa Rothier, dix mille Troyes
+quatre route d'Auxon, dix, cent trente, Avreuil
+cinq rue Louis Maison, dix, zéro zéro zéro à Troyes
+Autoroute Acinq Melun Langres, dix mille cent quatre-vingt-dix Palis
+Route d'Arsonval, dix, deux cents Montier-en-l'Isle
+Passage La Planche Verbale, Saint-André-les-Vergers
+Route des Lacs à Maupas
+huit route de Villemorien
+Rue Lucien Morel-Payen au numéro quatre W
+huit rue Berthelin de Rosières, dix mille quatre cent trente Rosières-près-Troyes
+neuf D rue Édmé Boursault, dix, zéro zéro zéro, Troyes
+cinq rue des Bûchettes, dix, deux cent vingt à Géraudot
+Chemin de la Tomelle, dix mille deux cent trente Mailly-le-Camp
+Rue Léon Gauthier, dix, cent quatre-vingts Saint-Lyé
+Rue Hugues de Payns, Payns
+Rue Billot à Rilly-Sainte-Syre
+trois sentier des Pelletières
+Rue Huguier au numéro dix-sept F
+six le Verger des Noëls, dix mille Troyes
+onze rue du Grand-Air, dix, quatre cent quarante, Torvilliers
+vingt-quatre route de Chaast, dix, cent quatre-vingt-dix à Messon
+Rue Quennedey, dix mille Troyes
+Chemin de Cachereine, dix, quatre cents Périgny-la-Rose
+Impasse de la Visitation, Troyes
+Rue Aux Moines à Troyes
+six rue des Milliottes
+Rue des Bas Trévois au numéro trente-trois
+neuf rue Fontenelle, dix mille huit cents Saint-Julien-les-Villas
+six rue des Trois Ormes, dix, zéro zéro zéro, Troyes
+un rue Georges Herelle, dix, zéro zéro zéro à Troyes
+Rue de Courmononcle, dix mille cent soixante Paisy-Cosdon
+Chemin de l'Avenir, dix, trois cent dix Bayel
+Rue Henri Rodin, Saint-Lyé
+Rue Suchetet à Vendeuvre-sur-Barse
+cinq rue Marcellin Pajot
+Rue des Bonnetiers au numéro quatre
+dix-neuf voie de Pontoise, dix mille cent Romilly-sur-Seine
+deux rue des Fossés Tanrot, dix, cent quarante, Vendeuvre-sur-Barse
+vingt-deux rue Julian Grimau, dix, cent à Romilly-sur-Seine
+Rue des Herbuates, dix mille huit cents Buchères
+Rue Mergez, dix, sept cents Arcis-sur-Aube
+Rue Plaine des Gardes, Sainte-Savine
+Rue Chevalier à Mergey
+cinquante-six rue Adolphe Thiers
+Rue Eugène Léger au numéro huit
+un allée des Herbues, dix mille huit cents Moussey
+trente-quatre rue Jean Renoir, dix, trois cents, Sainte-Savine
+dix route de Gélannes, dix, cent à Crancey
+Rue du Grand Véon, dix mille Troyes
+Rue Voltaire-Sellières, dix, cent Romilly-sur-Seine
+Rue du Maréchal Franchet d'Esperey, Sainte-Savine
+Rue de la Cote Fleurie à Pont-Sainte-Marie
+quarante-six BIS rue de Cervet
+Rue Champeaux au numéro quarante
+soixante-dix-neuf rue de Lignol, dix mille deux cents Voigny
+quatre rue de la Ferme de la Planche, dix, huit cents, Rouilly-Saint-Loup
+trente A avenue Auguste Terrenoire, dix, huit cents à Saint-Julien-les-Villas
+Rue des Cornuattes, dix mille cent Gélannes
+Avenue des Martyrs du vingt-quatre Août mille neuf cent quarante-quatre, dix, huit cents Buchères
+Rue René Breton, Thieffrain
+Rue Maison Dieu de Ricey Bas aux Riceys

--- a/server/data/fr/addresses-11.csv
+++ b/server/data/fr/addresses-11.csv
@@ -1,0 +1,70 @@
+sept rue de la Lande, onze mille Carcassonne
+vingt et un rue de la Foun d'en Peyre, onze, deux cents, Conilhac-Corbières
+dix rue des Lucquies, onze, cinq cent dix à Caves
+Chemin de Saint-- Hillaire, onze mille cent vingt Argeliers
+Rue Esclarmonde, onze, trois cents Limoux
+Ancien Chemin Royal, Lasbordes
+Rue André Le Nôtre à Carcassonne
+trois impasse du Serpent
+Chemin de Canastelle au numéro quatre
+vingt-quatre route de Festes, onze mille trois cents Bouriège
+dix-neuf boulevard des Carriers, onze, zéro zéro zéro, Carcassonne
+deux rue Étienne Moulinié, onze, zéro zéro zéro à Carcassonne
+Avenue de Béziers, onze mille cinq cent quatre-vingt-dix Cuxac-d'Aude
+Chemin du Cauquillat, onze, cent vingt Saint-Nazaire-d'Aude
+Rue du Pont de l'Hers, Chalabre
+Avenue de la Promenade à Moussan
+cent soixante-dix rue du Prao
+Chemin de Ratequats au numéro six
+quinze rue du Lauragais, onze mille cent soixante-dix Villesèquelande
+cinq cent quatre-vingt-six rue du Théron, onze, sept cents, Azille
+vingt-cinq rue Mosaïque, onze, cent à Narbonne
+Rue de Catalogne, onze mille cent Narbonne
+Avenue de San Brancat, onze, quatre cent quatre-vingts La Palme
+Avenue de la Côte Rêvée, Leucate
+Clos du Millepertuis à Narbonne
+quarante-sept lotissement Jean Moulin
+Rue Barbès au numéro deux BIS
+deux chemin du Rampaillou, onze mille deux cent quatre-vingt-dix Alairac
+treize lotissement L'Anse du Soleil, onze, trois cent soixante-dix, Leucate
+un rue de la Caramagne, onze, zéro zéro zéro à Carcassonne
+Cite Le Soleil d'Oc, onze mille cent vingt Pouzols-Minervois
+Rue des Roussettes, onze, cinq cent soixante Fleury
+Avenue de Narbonne, Saint-Laurent-de-la-Cabrerisse
+Rue du Mont Alaric à Narbonne
+seize rue du Père Clément
+Rue du Clédat au numéro quatre
+dix-huit lotissement Le Clos des Lys, onze mille cent vingt Moussan
+dix-huit rue Jean Piglowski, onze, cent, Narbonne
+vingt-sept los Garrabiers, onze, cinq cent soixante-dix à Palaja
+Rue de la Cabane de Bacou, onze mille six cent vingt Villemoustaussou
+CD cent seize, onze, quatre cents Laurabuc
+Rue Res La Chapelle, Rustiques
+Rue du Rodier à Saint-Martin-Lalande
+six route de l'Orbieu
+Avenue des Auberges au numéro trente-neuf
+onze rue de la Cayrolle, onze mille cinq cents Quillan
+trente-trois avenue du Minervois, onze, cent soixante, Villeneuve-Minervois
+quarante-huit chemin de Carliqui, onze, trois cents à Limoux
+Avenue de Carcassonne, onze mille deux cent soixante Espéraza
+Rue du Carignan, onze, huit cents Marseillette
+Avenue de la Montagne Noire, Laure-Minervois
+Impasse du Carcassès à Pezens
+cent treize chemin de la Rivière des Pierres
+Promenade de Rigal au numéro douze BIS
+seize résidence Les Graves, onze mille deux cent quatre-vingt-dix Arzens
+un rue de l'Ancienne Porte Neuve, onze, cent, Narbonne
+un rue des Cathares, onze, huit cents à Trèbes
+Allée des Carrières, onze mille cent soixante Caunes-Minervois
+Rue Joseph Sicard, onze, cent soixante Caunes-Minervois
+Impasse du Portanel, Saint-André-de-Roquelongue
+Chemin de la Piboule à Villemoustaussou
+dix-neuf rue Antoine Armagnac
+Rue Maraussan au numéro vingt
+neuf rue Maurice Chauvet, onze mille cent Narbonne
+dix-huit avenue Saint-Chinian, onze, cinq cent quatre-vingt-dix, Ouveillan
+cinq rue du Moulin Cros, onze, quatre cents à Fendeille
+Rue des Mattes, onze mille trois cent soixante-dix Leucate
+Promenade du Ruisseau de Bousquet, onze, zéro zéro zéro Carcassonne
+Rue de la Pérouse, Sigean
+Boulevard Albert Premier à Lézignan-Corbières

--- a/server/data/fr/addresses-12.csv
+++ b/server/data/fr/addresses-12.csv
@@ -1,0 +1,70 @@
+trente-deux rue André Balitrand, douze mille cent Millau
+trente chemin de la Parro, douze, six cent trente, Agen-d'Aveyron
+un route des Janenques, douze, trois cent quatre-vingt-dix à Mayran
+Rue du Ségala, douze mille cent soixante-dix Réquista
+Route d'Albi, douze, cent soixante Baraqueville
+Avenue de Lodève, Cassagnes-Bégonhès
+Allée Beau-Soleil à Firmi
+onze rue de la Sécurité
+Rue François Fabié au numéro cinq cent cinquante-cinq
+huit rue de L'Église, douze mille deux cent soixante-dix Najac
+quinze cité des Camps Sarrats, douze, sept cent quarante, Sébazac-Concourès
+un impasse du Laboureur, douze, zéro zéro zéro au Monastère
+Rue du Boultou, douze mille cent Creissels
+Rue du Vieux Crès, douze, cent Millau
+Chemin de Sainte-Adèle, Villefranche-de-Rouergue
+Boulevard du Puits de Calès à Millau
+deux A rue Cantarane
+Avenue de Decazeville au numéro trente et un
+quatre-vingt-neuf avenue de Felix, douze mille deux cents Villefranche-de-Rouergue
+trente-sept boulevard du cent vingt-deux Eme Ri, douze, zéro zéro zéro, Rodez
+trente-sept lotissement La Marelle, douze, deux cent soixante à Villeneuve
+Lotissement les Genêts, douze mille deux cent quatre-vingt-dix Pont-de-Salars
+Avenue John F Kennedy, douze, cent Millau
+Rue Cité du Petit Nice, Rodez
+Avenue du Rouergue à Lanuéjouls
+douze rue de Pigue
+Route de Ségur au numéro huit cent quatre-vingt-quinze
+onze rue du Docteur Valentin, douze mille quatre cents Saint-Affrique
+neuf A route des Aumières, douze, cent, Millau
+deux cent soixante-dix route de la Prade, douze, trois cents à Flagnac
+Rue du Mas de Carreyrou, douze mille deux cent vingt Montbazens
+Boulevard de Bonald, douze, cent Millau
+Avenue de Laguiole, Estaing
+Avenue Édouard-Alfred Martel à Millau
+trois cent quatre-vingt-seize D chemin Fonvive Mas de Recouly
+Cité de Naujac au numéro huit
+treize rue du Docteur Gabriac, douze mille cinq cents Espalion
+sept cent quatre-vingt-cinq rue les Hauts du Vivier, douze, cent, Millau
+huit rue Adrien Vézinhet, douze, huit cent cinquante à Sainte-Radegonde
+Boulevard de la Capelle, douze mille cent Millau
+Rue du Pendelys, douze, trois cent dix Laissac
+Avenue de la Basilique, Calmont
+Place Du Quai à Saint-Geniez-d'Olt
+deux rue Raoul Cabrol
+Rue Adrien Rodat au numéro cinq
+trois rue Claux de Brousse, douze mille trois cent quarante Bozouls
+neuf avenue de Malvies, douze, trois cent trente, Marcillac-Vallon
+huit rue de la Muraille, douze, trois cent quatre-vingt-dix à Rignac
+Rue Amaury de Séverac, douze mille cent cinquante Sévérac-le-Château
+RUE DU GRAND FAUBOURG, douze, cent cinquante Sévérac-le-Château
+Sentier de l'Abbaye, Agen-d'Aveyron
+Chemin de Touloupy à Saint-Affrique
+trois cent quatre-vingt-quinze chemin de Rivaltes
+Avenue de la Salse au numéro cent quarante-cinq
+six rue de la Parra, douze mille quatre cent cinquante Luc-la-Primaube
+vingt-six avenue du Planhol, douze, deux cent vingt, Montbazens
+soixante-dix-huit la Mouline, douze, cinq cent dix à Olemps
+Rue du Pouzadou, douze mille deux cent trente Nant
+Avenue de Saint-Laurent, douze, cent trente Saint-Geniez-d'Olt
+Rue de Bourran, Sébazac-Concourès
+Route de Naujac à Luc-la-Primaube
+trois BIS rue des Barthètes
+Impasse des Fus de Sainte-Radegonde au numéro trois
+vingt et un avenue Etienne Soulie, douze mille deux cents Villefranche-de-Rouergue
+vingt-quatre allée des Hirondelles / Vergiès, douze, deux cent quarante, Rieupeyroux
+un côte de Moulines, douze, trois cent trente à Marcillac-Vallon
+Chemin de René Jayr, douze mille deux cents Villefranche-de-Rouergue
+Lotissement Le Bouyssou, douze, trois cent cinquante Lanuéjouls
+Place de la Capelle, Millau
+Avenue du Ségala à Villefranche-de-Rouergue

--- a/server/data/fr/addresses-13.csv
+++ b/server/data/fr/addresses-13.csv
@@ -1,0 +1,70 @@
+dix-huit BIS impasse Louis Bonnefoy, treize mille quinze Marseille
+deux boulevard Philippon, treize, zéro zéro quatre, Marseille
+quatre rue du Lac de Vens, treize, trois cent dix à Saint-Martin-de-Crau
+Impasse Marjolaine, treize mille quinze Marseille
+Lotissement La Bastide de Ravel, treize, zéro treize Marseille
+Chemin du Breuil, Boulbon
+Boulevard Hilarion Boeuf à Marseille
+trois cent trente avenue de la Touloubre
+Rue d'Arlatan au numéro six
+vingt et un avenue Paul Lafargue, treize mille sept cent soixante Saint-Cannat
+dix-sept impasse du Hameau de la Mer, treize, six cent vingt, Carry-le-Rouet
+trente-six rue de la Passe du Lièvre, treize, six cent quatre-vingts à Lançon-Provence
+Avenue des Romarins, treize mille six cent vingt Carry-le-Rouet
+Boulevard Lombard, treize, zéro quinze Marseille
+Avenue Etienne Rabattu, Les Pennes-Mirabeau
+Impasse Dupont à Marseille
+dix allée du Devenson
+Chemin de la Boulie au numéro trois cent douze
+mille chemin de la Sérignane, treize mille cinq cent trente Trets
+sept mille cent cinquante-quatre avenue Beausoleil, treize, trois cent vingt, Bouc-Bel-Air
+trois boulevard Carbonnel, treize, zéro dix à Marseille
+Chemin du Pas de Peycaî, treize mille cent neuf Simiane-Collongue
+Boulevard Chave, treize, zéro zéro cinq Marseille
+Boulevard Catacholi, Marseille
+Rue de la Capitale à Marseille
+quatre rue André-François Raffray
+Boulevard National au numéro trente-cinq
+cent soixante-huit allée du Miejour, treize mille cent soixante-dix Cabriès
+trois impasse Rivet, treize, zéro treize, Marseille
+quatre-vingt-huit chemin de la Commanderie, treize, zéro quinze à Marseille
+Rue Turcan, treize mille douze Marseille
+Rue d'Entrecasteaux, treize, zéro zéro neuf Marseille
+Rue Millet, Cabriès
+Boulevard de Lavaux à La Ciotat
+vingt-cinq cours Sextius
+Avenue des Pervenches au numéro cinq
+deux rue Boulouvard, treize mille cent quatre Arles
+soixante-quatorze avenue du Mugel, treize, six cents, La Ciotat
+douze traverse du Maroc, treize, zéro douze à Marseille
+Route des Milles, treize mille cinq cent dix Éguilles
+Lotissement la Germaine, treize, cinq cent quatre-vingts La Fare-les-Oliviers
+Chemin de la Gouiranne, Jouques
+Impasse du Grand Pin à Aubagne
+quatre-vingt-deux avenue de Saint-Louis
+Chemin du Pont Bardé au numéro quinze
+vingt rue de Palestine, treize mille dix Marseille
+mille quatre-vingt-quinze chemin de la Présidente, treize, zéro quatre-vingts, Aix-en-Provence
+quatre impasse Quentin de la Tour, treize, cent dix-sept à Martigues
+Avenue du Dauphine, treize mille cent quatre-vingts Gignac-la-Nerthe
+Rue du Pic Chabaud, treize, cent soixante Châteaurenard
+Impasse du Chaudron, Marseille
+Rue Saint-Léopold à Marseille
+quatorze traverse Picasso
+Impasse Denis Papin au numéro cinq
+cent quarante-sept boulevard de la Blancarde, treize mille quatre Marseille
+quatre-vingt-douze rue du Trou de Fourques, treize, cent quatre, Arles
+quarante-six impasse du Négron, treize, cent dix-huit à Istres
+Route de Pélissanne, treize mille trois cent trente La Barben
+Allée Françoise Rosay, treize, cent dix-sept Martigues
+Route de Bazarde, Orgon
+Rue du Lac de Naguille à Saint-Martin-de-Crau
+quatre rue Peyssonnel
+Rue Thieux au numéro dix-huit
+neuf square des Chardons Bleus, treize mille cent soixante-dix Cabriès
+cent vingt-deux chemin du Marinier, treize, zéro seize, Marseille
+cent trente-six chemin de la Pierre de Feu, treize, zéro quatre-vingts à Aix-en-Provence
+Rue du vingt-trois Aout mille neuf cent quarante-quatre, treize mille sept cent quarante Le Rove
+Chemin du Mozambique, treize, zéro seize Marseille
+Rue du Clos Marie, Arles
+Chemin du Plan de Lorgue à Saint-Marc-Jaumegarde

--- a/server/data/fr/addresses-14.csv
+++ b/server/data/fr/addresses-14.csv
@@ -1,0 +1,70 @@
+deux clos du Vert Vallon, quatorze mille quatre cents Vaucelles
+neuf rue de la Dronnière, quatorze, cent vingt-trois, Ifs
+huit B avenue Alfred Rousseau, quatorze, huit cents à Deauville
+Chemin des Pieux, quatorze mille cent trente Bonneville-la-Louvet
+Chemin du Rondel, quatorze, cent Firfol
+Rue Saint-Gerbold, Garcelles-Secqueville
+Rue Félicie Charles à Isigny-sur-Mer
+quarante-deux rue Fournet
+Avenue de la Terrasse au numéro quinze
+dix-neuf rue Marechal Foch, quatorze mille trois cent soixante-dix Argences
+quinze P rue Labbey, quatorze, cent, Lisieux
+vingt-cinq rue des Courtillages, quatorze, cent vingt-trois à Fleury-sur-Orne
+Rue de la Girotière, quatorze mille cent trente Saint-Gatien-des-Bois
+Voie Communale Bout des Vallées, quatorze, quatre cent quarante Plumetot
+Route de Martigny, Villers-Canivet
+Avenue du Havre à Merville-Franceville-Plage
+cinquante-quatre rue Victor Lépine
+Rue Roger Fossey au numéro trois
+huit BIS avenue Roger Deliencourt, quatorze mille huit cents Deauville
+deux impasse de l'Ancienne Ferme, quatorze, trois cent soixante, Trouville-sur-Mer
+six rue de la Chapelle Sainte-Anne, quatorze, quatre cents à Tour-en-Bessin
+Impasse des Deux Jardins, quatorze mille six cent dix Anisy
+Rue Robert Bothereau, quatorze, quatre cent soixante Colombelles
+Rue Julienne, Luc-sur-Mer
+Rue Croix aux Lyonnais à Orbec
+cinq rue des Carreaux
+Rue des Mesliers au numéro mille cinquante-sept
+dix-sept rue de la Passe Mary, quatorze mille sept cent cinquante Saint-Aubin-sur-Mer
+trois rue de Vaux-sur-Aure, quatorze, quatre cents, Bayeux
+trente et un rue Georges Auguste, quatorze, zéro zéro zéro à Caen
+Rue Cheneaux de Leyritz, quatorze mille trois cent soixante-dix Bellengreville
+Rue Marcel Lescène, quatorze, cent quarante Livarot
+Route des Loges, Cahagnes
+Rue de la Huitième Armée à Ver-sur-Mer
+vingt rue d'Hastings
+Route de Berville au numéro quinze BIS
+soixante-quinze rue de Cherbourg, quatorze mille deux cent trente Isigny-sur-Mer
+un chemin de la Herquerie, quatorze, deux cent quatre-vingt-dix, Courtonne-les-Deux-Églises
+onze rue Saint-Anne-des-Lacs, quatorze, six cents à Honfleur
+Rue des Épivas, quatorze mille cent vingt-trois Cormelles-le-Royal
+Rue des Longs Bosquets, quatorze, deux cent vingt Espins
+Chemin du Rotoir, Saint-Côme-de-Fresné
+Avenue Sainte-Therese à Cabourg
+douze BIS rue Saint-Malo
+Allée du Petit Clos au numéro deux
+deux rue des Schistes, quatorze mille trois cent vingt May-sur-Orne
+six rue du Lt Col Marc Dugarreau, quatorze, cinq cent quarante, Grentheville
+trente route de Croissanville, quatorze, deux cent soixante-dix à Cesny-aux-Vignes
+Rue du Stoke Canon, quatorze mille huit cent soixante Bavent
+Voie des Alliés, quatorze, quatre cent quarante Douvres-la-Délivrande
+Rue du Hottot, Basly
+Square Claude Monet à Lisieux
+douze allée de Madrid
+Square Léon Lecieux au numéro cinq
+trois allée du Saguenay, quatorze mille cent vingt-trois Ifs
+deux allée Jardin du Moulin, quatorze, trois cent vingt, Laize-la-Ville
+un route de l'Aure, quatorze, sept cent dix à Russy
+Avenue du six Juin, quatorze mille cent cinquante Ouistreham
+Route d'Harcourt, quatorze, trois cent vingt Saint-Martin-de-Fontenay
+La Platte Pierre, Urville
+Chemin Villeneuve à Rots
+quatre rue Abbé Anne
+Venelle Cauvet au numéro quatorze
+trente-sept boulevard Maritime, quatorze mille sept cent quatre-vingts Lion-sur-Mer
+dix-huit rue des Bisquines, quatorze, quatre cent soixante-dix, Courseulles-sur-Mer
+trente-deux chemin de la Croix Vautier, quatorze, neuf cent quatre-vingts à Rots
+Boulevard Charles cinq, quatorze mille six cents Honfleur
+Rue Branville, quatorze, zéro zéro zéro Caen
+Rue des Champs Saint-Georges, Falaise
+Avenue Charlotte Corday à Caen

--- a/server/data/fr/addresses-15.csv
+++ b/server/data/fr/addresses-15.csv
@@ -1,0 +1,70 @@
+trente-trois rue André Bertuit, quinze mille cent Saint-Flour
+un impasse Raymond Queneau, quinze, zéro zéro zéro, Aurillac
+un impasse du Garric, quinze, zéro zéro zéro à Aurillac
+Rue du Lac Glory, quinze mille trois cents Laveissière
+Rue des Cipières, quinze, deux cent cinquante Saint-Paul-des-Landes
+Avenue Jean Robic, Ytrac
+Rue du Puy Violent à Saint-Martin-Valmeroux
+un rue Antoine Richard
+Rue des Frères Géraud au numéro vingt-quatre
+onze route de Pesteils, quinze mille huit cents Polminhac
+douze route de Milly, quinze, cent trente, Arpajon-sur-Cère
+seize rue Sénateur Albert Baduel, quinze, cent à Saint-Flour
+Rue des Camisières, quinze mille Aurillac
+Rue des Olympiades, quinze, zéro zéro zéro Ytrac
+Rue Bernard Dejou, Vézac
+Montée du Cardi à Saint-Simon
+onze avenue du Quatre Septembre
+Avenue du Général Milhaud au numéro quarante-six
+huit rue de l'Impradine, quinze mille Ytrac
+dix route de Bort, quinze, cent quatre-vingt-dix, Condat
+vingt-quatre rue d'Espinchal, quinze, cinq cents à Massiac
+Rue du Pont de Lourseyre, quinze mille deux cent soixante-dix Champs-sur-Tarentaine-Marchal
+Place Louis Pasteur, quinze, cent trente Arpajon-sur-Cère
+Rue Cazaud, Aurillac
+Cité du Cayla à Arpajon-sur-Cère
+trente-trois rue du Général Gabriel Lacoste
+Rue Porte Saint-Esprit au numéro seize
+dix lotissement les Rochers, quinze mille cent trente Arpajon-sur-Cère
+quatre rue du Maréchal De Lattre De Tassigny, quinze, zéro zéro zéro, Aurillac
+deux rue du Puy Brunet, quinze, zéro zéro zéro à Ytrac
+Rue Jean Rieuf, quinze mille cinq cents Massiac
+IMP SAINT LUC, quinze, deux cents Mauriac
+Rue du Mas Marty Bas, Crandelles
+Rue de la Ribeyre à Massiac
+vingt-deux chemin de Colinette
+Rue des Monts Dore au numéro neuf cent soixante-seize
+deux impasse du Masseboeuf, quinze mille trois cents Laveissière
+huit impasse Paul Valery, quinze, zéro zéro zéro, Aurillac
+sept rue des Houx, quinze, cent trente à Arpajon-sur-Cère
+Cité du Buron, quinze mille deux cent cinquante Jussac
+Quartier de Fridières, quinze, cent Saint-Flour
+Rue de la Montade, Arpajon-sur-Cère
+Rue du Gué Bouliaga à Aurillac
+vingt-six rue Jean Lépine
+Boussac au numéro quatre
+dix cité Calcavy, quinze mille six cents Maurs
+vingt rue Federico Garcia Lorca, quinze, zéro zéro zéro, Aurillac
+vingt-six rue du Général Destaing, quinze, zéro zéro zéro à Aurillac
+Rue Henri Mondor, quinze mille deux cents Mauriac
+Chemin du Tour du Village, quinze, cent trente Saint-Simon
+Rue de la Vidalie, Sansac-de-Marmiesse
+Lotissement du Mazet Haut à Saint-Constant
+sept rue de la Martinelle
+Place des Bayadères au numéro quatre
+trente-deux rue Félix Ramond, quinze mille cent trente Arpajon-sur-Cère
+quatorze rue des Quatre Frères Laurent, quinze, quatre cents, Riom-ès-Montagnes
+deux impasse du Bois de Madame, quinze, cent soixante-dix à Neussargues-Moissac
+Rue de Picardel, quinze mille cent trente Sansac-de-Marmiesse
+Impasse d'Alembert, quinze, zéro zéro zéro Aurillac
+Chemin de Lagarigue, Cayrols
+Rue de Lavernière à Velzic
+cinq rue Louis Debrons
+Rue de l'Authre au numéro dix-neuf
+onze chemin du Patural, quinze mille cent trente Sansac-de-Marmiesse
+douze rue Jules Vedrines, quinze, cent, Saint-Flour
+vingt-deux rue Louis Farges, quinze, zéro zéro zéro à Aurillac
+Rue du Bon Secours, quinze mille trois cents Murat
+Rue des Gleviennes, quinze, deux cent cinquante Crandelles
+Rue du Puy de Seycheuse, Laveissière
+Hameau d'Escanis à Aurillac

--- a/server/data/fr/addresses-16.csv
+++ b/server/data/fr/addresses-16.csv
@@ -1,0 +1,70 @@
+soixante et un rue des Champs du Château, seize mille cent Cognac
+cinquante-trois faubourg Tête Noire, seize, cent dix, La Rochefoucauld
+un allée de la Cigogne, seize, zéro zéro zéro à Angoulême
+Rue du Grand Pas, seize mille cent trente Segonzac
+Rue Roger Favre, seize, cent Cognac
+Rue Romain Gary, Angoulême
+Rue des Chouettes à Champniers
+onze rue Goulbenèze
+Route de la Charente Limousine au numéro quatorze
+sept chemin des Dîmes, seize mille deux cent soixante-dix La Péruse
+quatre rue du Nige Chat, seize, quatre cents, La Couronne
+quarante rue de Jarnac, seize, cent à Cognac
+Route de Villegoureix, seize mille cent cinquante Chassenon
+Route de l'Age, seize, quatre cent trente Balzac
+Rue Fontaine de Pommeau, Confolens
+Rue du Franc Pineau à Châteauneuf-sur-Charente
+trois impasse Baïsa
+Route du Peux au numéro trente-sept
+trente rue de la Charente, seize mille Angoulême
+trois route Jean Chapelot, seize, quatre cent trente, Vindelle
+six rue des Chirons, seize, deux cent trente à Maine-de-Boixe
+Chemin de la Loge, seize mille quatre cents Vœuil-et-Giget
+Passage Bel Air, seize, quatre cent quarante Sireuil
+Rue de l'Épineuil, Saint-Yrieix-sur-Charente
+Impasse du Four A Pain à Empuré
+dix-sept rue de la Croix Brandet
+Allée des Glamots au numéro cinq
+dix-neuf boulevard des Petites Chenevières, seize mille deux cent trente Mansle
+cinq cent soixante et un route de la Mongerie, seize, cinq cent quatre-vingt-dix, Brie
+six allée Castaigne, seize, zéro zéro zéro à Angoulême
+Avenue de la Boixe, seize mille trois cent trente Montignac-Charente
+Rue des Paleines, seize, deux cent soixante-dix Roumazières-Loubert
+Rue Juan Lozano, Cognac
+Rue Gaudonne à Cognac
+huit chemin du Figuier
+Rue Port Poton au numéro trois
+trente-six rue Saint-Gelais, seize mille Angoulême
+six rue de la Fontaine Royal, seize, quatre cent vingt, Lesterps
+seize avenue de la Nouère, seize, sept cent trente à Linars
+Rue Millardet, seize mille cent Cognac
+Rue Andre Bouyer, seize, trois cent vingt Villebois-Lavalette
+Route des Fontaines Salées, Abzac
+Rue du Pont Sec à Angoulême
+sept rue de L'Atrie
+Avenue André Planchet au numéro quatorze
+six BIS rue de Lunesse, seize mille Angoulême
+vingt et un rue du Bois Personnier, seize, quatre cent soixante-dix, Saint-Michel
+un rue de la Vreloppe, seize, huit cents à Soyaux
+Rue de Limoges, seize mille deux cent vingt Montbron
+Rue François Albert, seize, sept cents Ruffec
+Rue de Clérac à Sillac, Angoulême
+Rue Edward Warin à Champniers
+vingt rue Raoul Verlet
+Rue de Barbezieux au numéro six
+dix rue Fernand Rivière, seize mille cent Cognac
+trois cent soixante et onze rue Chantefleur, seize, six cents, Ruelle-sur-Touvre
+vingt BIS rue Bir'Hakeim, seize, deux cent soixante à Chasseneuil-sur-Bonnieure
+Route de Gourville, seize mille cent soixante-dix Saint-Cybardeaux
+Rue des Remberges, seize, zéro zéro zéro Angoulême
+Rue Henri Fichon, Cognac
+Impasse du Maine à Balzac
+un chemin de l'Ecurie
+Rue des Métureauds au numéro quatre
+un rue Vérines, seize mille deux cent trente Mansle
+trente-neuf rue de Réparsac, seize, deux cents, Nercillac
+quatre cent vingt-deux rue Jean-Francois Cail, seize, sept cents à La Faye
+Rue Marcel Gaston Mercier, seize mille Angoulême
+Rue de la Croix de Quart, seize, trois cent vingt Villebois-Lavalette
+Impasse Fontchaudière, Angoulême
+Impasse du Moulin des Dames à Angoulême

--- a/server/data/fr/addresses-17.csv
+++ b/server/data/fr/addresses-17.csv
@@ -1,0 +1,70 @@
+douze rue des Pecheurs A Ors, dix-sept mille quatre cent quatre-vingts Le Château-d'Oléron
+sept impasse Laperouse, dix-sept, six cent quarante, Vaux-sur-Mer
+cinquante-deux route de l'Ilot, dix-sept, cinq cent soixante-dix à Saint-Augustin
+Rue de la Brousse, dix-sept mille cent vingt Cozes
+Rue du Parmeneau, dix-sept, quatre cent soixante-dix Saint-Georges-de-Longuepierre
+Rue Charles Alquier, La Rochelle
+Chemin des Mouettes au Bois-Plage-en-Ré
+dix-huit rue de Foncillon
+Chemin de Maillezais au numéro dix-neuf
+quatorze rue des Réaux, dix-sept mille quatre cent quarante Aytré
+cent cinquante-sept BIS avenue DENFERT ROCHEREAU, dix-sept, zéro zéro zéro, La Rochelle
+cent trois faubourg d'Aunis, dix-sept, quatre cents à Saint-Jean-d'Angély
+Avenue de Strasbourg, dix-sept mille trois cent quarante Châtelaillon-Plage
+Rue Teulère, dix-sept, deux cents Royan
+Rue de Chassiron Au Bourg, Saint-Denis-d'Oléron
+Chemin de la Conseillé à Saintes
+quarante-cinq BIS route de Saujon
+Rue Robert Velter au numéro un
+huit rue de la Pommeraie des Gaillards, dix-sept mille trois cent cinquante Port-d'Envaux
+dix-sept allée du Calme, dix-sept, cent dix, Saint-Georges-de-Didonne
+quatorze BIS rue de Maillezais, dix-sept, cent trente-sept à Nieul-sur-Mer
+Avenue DE ROMPSAY, dix-sept mille La Rochelle
+Chemin des Pommerais, dix-sept, deux cent quarante Mosnac
+Rue des Gds Maisons, Andilly
+Rue de la Tourasse à Échillais
+onze rue Jelu
+Chemin du Biscarot au numéro dix
+vingt-six petite Rue de la Garde, dix-sept mille quatre cent quatre-vingt-dix Beauvais-sur-Matha
+neuf TER rue des Coquilles, dix-sept, six cent quatre-vingt-dix, Angoulins
+douze rue des Ballangers, dix-sept, six cents à Saujon
+Rue DE LA MOULINETTE, dix-sept mille La Rochelle
+Allée du Mont, dix-sept, cent trente-deux Meschers-sur-Gironde
+Rue DES SPORTS, La Rochelle
+Rue Poitou à Saint-Sauveur-d'Aunis
+cinq rue Terre Noire
+Rue de la Basse Vergnée au numéro cinq
+cent trente-neuf route de la Sèvre, dix-sept mille cent soixante-dix Taugon
+vingt-six rue Daniel Daviaud, dix-sept, trois cent soixante, Saint-Aigulin
+quatorze rue Lacurie, dix-sept, cent à Saintes
+Route du Plessis, dix-sept mille six cent dix Chaniers
+Route d'Archiac, dix-sept, cinq cent vingt Jarnac-Champagne
+Allée du Cerisier, Échillais
+Rue de Touron à Cozes
+huit route des Oiseaux
+Rue Cité Puyvineux au numéro six
+vingt et un rue Amiral Juin, dix-sept mille quatre cent cinquante Fouras
+neuf A rue du Caviar, dix-sept, cent vingt, Chenac-Saint-Seurin-d'Uzet
+trente-six rue DU CORDOUAN, dix-sept, zéro zéro zéro à La Rochelle
+Route du Chateau de Clerbise, dix-sept mille huit cents Belluire
+Rue des Sartières, dix-sept, quatre cent quatre-vingts Le Château-d'Oléron
+Route des Chaignes, Sainte-Marie-de-Ré
+Chemin de l'Orme Vert à Courcelles
+un impasse du Chaillot
+Résidence de l'Aubrée au numéro neuf
+quatorze rue Charles Hervé, dix-sept mille sept cent cinquante Étaules
+neuf avenue du Docteur Charcot, dix-sept, deux cents, Royan
+vingt-cinq lotissement Les Brigannieres, dix-sept, quatre cent quatre-vingts au Château-d'Oléron
+Rue DE LA TROMPETTE, dix-sept mille La Rochelle
+Avenue DE STOCKHOLM, dix-sept, zéro zéro zéro La Rochelle
+Chemin de Rangeard, Saujon
+Impasse le Benjamin à Port-d'Envaux
+un rue Général Besson
+Rue du Rivraud au numéro vingt-trois
+deux impasse de Chez Piat, dix-sept mille quatre cent soixante Varzay
+huit rue de la Sibonnerie, dix-sept, trois cent quatre-vingt-dix, La Tremblade
+trois cent vingt rue de la Côte Sauvage, dix-sept, neuf cent quarante à Rivedoux-Plage
+Rue du Bois du Petit Chemin, dix-sept mille trois cent quatre-vingt-dix La Tremblade
+Rue RICHARD COEUR DE LION, dix-sept, zéro zéro zéro La Rochelle
+Place du général de Gaulle, Pont-l'Abbé-d'Arnoult
+Rue des Gillardeaux aux Gonds

--- a/server/data/fr/addresses-18.csv
+++ b/server/data/fr/addresses-18.csv
@@ -1,0 +1,70 @@
+neuf rue de la Fleur de Lys, dix-huit mille cent cinquante La Guerche-sur-l'Aubois
+quarante-cinq BIS route de Marmignolles, dix-huit, cinq cents, Marmagne
+un rue de Werentzhouse, dix-huit, cent dix à Vasselay
+Route de Menetou-Salon, dix-huit mille cent dix Vignoux-sous-les-Aix
+Allée du Beugnon, dix-huit, cent vingt Méreau
+Allée des Brigamilles, Trouy
+Rue Auguste Bougrat à Avord
+cinq avenue de l'Étang de Pin
+Rue Philippe Labbé au numéro vingt et un
+huit chemin des Passerelles, dix-huit mille trois cents Vinon
+seize avenue Nationale, dix-huit, trois cent quarante, Levet
+cinquante-quatre rue des Pieds Blancs, dix-huit, deux cent trente à Saint-Doulchard
+Impasse du Facteur, dix-huit mille huit cents Étréchy
+Impasse Pierre Michot, dix-huit, deux cent trente Saint-Doulchard
+Rue du Coulevra, Jussy-le-Chaudrier
+Route de Saint-Igny à Villabon
+six route de Méreau
+Route de Sainte-Montaine au numéro trente
+vingt-trois route des Aix, dix-huit mille cinq cent dix Menetou-Salon
+quarante-quatre route du Canal, dix-huit, trois cents, Ménétréol-sous-Sancerre
+un BIS avenue de Saint-Amand, dix-huit, cinq cent soixante-dix à Trouy
+Rue du Champ des Pierres, dix-huit mille deux cent dix Coust
+Place Jean-Marie Le Stanguennec, dix-huit, six cents Sancoins
+Rue Jean Girard, Bourges
+Petite Route de Concressault à Blancafort
+dix-huit rue Vincent Détharé
+Rue Ronald Charles Ostend Beazer au numéro trente-six
+vingt-trois quai de Loire Hervé Mhun, dix-huit mille trois cents Saint-Satur
+six ruelle de la Debine, dix-huit, trois cents, Ménétréol-sous-Sancerre
+trois cent quatre-vingt-quatre route de Charenton, dix-huit, deux cent dix à Charenton-du-Cher
+Rue du Champanet, dix-huit mille cent Vierzon
+Route de Saint-Martin d'Auxigny, dix-huit, cent dix Allogny
+Rue de la Pennerie, Ourouer-les-Bourdelins
+Chemin du Grand Fromangeux à Vignoux-sous-les-Aix
+six allée du Maréchal Juin
+Rue Émile Martin au numéro cinquante-quatre
+treize A rue du Docteur Léo Mérigot, dix-huit mille cent Vierzon
+quinze rue Béraud, dix-huit, zéro zéro zéro, Bourges
+quatorze impasse du Barreau Vert, dix-huit, zéro zéro zéro à Bourges
+Rue Charbon, dix-huit mille trois cent trente Neuvy-sur-Barangeon
+Route de Neuilly-en-Sancerre, dix-huit, trois cents Sens-Beaujeu
+Impasse de Vauvert, Bourges
+Chemin d'Arpheuilles à Saint-Amand-Montrond
+soixante-dix-huit avenue Jean Châtelet
+Avenue de Fontenay au numéro cinquante-quatre
+cent trente-trois rue de Mazières, dix-huit mille Bourges
+vingt-six avenue Henri Massicot, dix-huit, quatre cents, Saint-Florent-sur-Cher
+vingt et un E chemin de la Belle Croix, dix-huit, cinq cents à Mehun-sur-Yèvre
+Route de Reuilly, dix-huit mille cent vingt Quincy
+Impasse du Champ de la Cure, dix-huit, trois cent quarante Arçay
+Route de Cerbois, Lury-sur-Arnon
+Rue de la Renauderie à Sancoins
+deux cent vingt-sept rue de Chenevière
+Place F Perrusson au numéro onze
+cent soixante-dix-sept route de Puits Berteau, dix-huit mille cent Vierzon
+dix-neuf rue Le Ferty, dix-huit, cent quatre-vingt-dix, Vallenay
+douze chemin du Pied du Râteau, dix-huit, deux cent trente à Saint-Doulchard
+Rue du Bouillet, dix-huit mille Bourges
+Rue des Écoinçons, dix-huit, cinq cents Vignoux-sur-Barangeon
+Rue des Blessangis, Bourges
+Rue Sableuse à Brinon-sur-Sauldre
+deux impasse des Bois de Marmagne
+Allée Charles Meryon au numéro huit
+quatre le Chêne Vert, dix-huit mille deux cent soixante-dix Culan
+quatorze rue de Villatte, dix-huit, cent quarante, Herry
+vingt-quatre rue Jacques Fernault, dix-huit, zéro zéro zéro à Bourges
+Allée du Rang des Noyers, dix-huit mille cinq cents Mehun-sur-Yèvre
+Rue Ernest Masson, dix-huit, deux cent vingt Les Aix-d'Angillon
+Résidence de la Paille, Plaimpied-Givaudins
+Rue Albert Hervet à Bourges

--- a/server/data/fr/addresses-19.csv
+++ b/server/data/fr/addresses-19.csv
@@ -1,0 +1,70 @@
+cent vingt-huit route de Varetz, dix-neuf mille deux cent quarante Saint-Viance
+quinze boulevard Amiral Grivel, dix-neuf, cent, Brive-la-Gaillarde
+vingt-six route de Seigne, dix-neuf, zéro zéro zéro à Tulle
+Rue Toulzac, dix-neuf mille cent Brive-la-Gaillarde
+Rue du Cloître Sainte-Ursule, dix-neuf, quatre cents Argentat
+Rue Emile Magne, Brive-la-Gaillarde
+Résidence des Gardes à Meymac
+huit rue des Pelauds
+Boulevard de la Lunade au numéro dix-neuf
+quatre chemin des Vergnottes, dix-neuf mille sept cents Lagraulière
+quatre-vingt-seize rue Marcelin Roche, dix-neuf, cent, Brive-la-Gaillarde
+trente-deux rue Bon Accueil, dix-neuf, cent à Brive-la-Gaillarde
+Rue de Bondy, dix-neuf mille cent Brive-la-Gaillarde
+Boulevard Foch, dix-neuf, deux cents Ussel
+Rue Poncelet, Brive-la-Gaillarde
+Rue de la Bousseleygie à Lubersac
+quatre impasse André Malraux
+Rue des Bois Grands au numéro trente et un
+cinquante-six boulevard Général Koenig, dix-neuf mille cent Brive-la-Gaillarde
+cinq avenue de Bouriottes, dix-neuf, trois cent soixante, Malemort-sur-Corrèze
+vingt-neuf rue Émile Alain, dix-neuf, cent à Brive-la-Gaillarde
+Rue Marie de Ventadour, dix-neuf mille trois cents Égletons
+Rue Lachaume, dix-neuf, cent Brive-la-Gaillarde
+Route des Vergnes, Saint-Mexant
+Rue des Frères Deheille à Noailles
+vingt-trois rue des Bujoux
+Rue de la Barrussie au numéro vingt-cinq
+trente-deux avenue Marcel Jouhandeau, dix-neuf mille trois cent soixante Malemort-sur-Corrèze
+vingt-deux rue du Puy du Four, dix-neuf, deux cents, Ussel
+vingt-trois rue Guillaumet, dix-neuf, cent à Brive-la-Gaillarde
+Rue Bosche, dix-neuf mille cent Brive-la-Gaillarde
+Rue Ségéral Verninac, dix-neuf, cent Brive-la-Gaillarde
+Avenue Joseph Vachal, Argentat
+Rue Joseph Yernaux à Brive-la-Gaillarde
+seize rue Marcelle Tinayre
+Avenue Pierre Meyjonade au numéro trois cent vingt
+cent soixante-six avenue André Emery, dix-neuf mille cent Brive-la-Gaillarde
+sept cent vingt-huit route de Bridal, dix-neuf, cent trente, Objat
+un faubourg le Porche Vieux, dix-neuf, cent trente à Voutezac
+Rue Gabriel Malès, dix-neuf mille cent Brive-la-Gaillarde
+Rue du Vialmur, dix-neuf, cent Brive-la-Gaillarde
+Rue Victor Lacassin, Brive-la-Gaillarde
+Rue de l'Abbé Breuil à Brive-la-Gaillarde
+cinquante-cinq allée de Puymaret
+Rue Marie Laurent au numéro sept
+deux impasse de Boisse, dix-neuf mille trois cent soixante-dix Chamberet
+cinq route du Burg, dix-neuf, deux cent quarante, Saint-Viance
+un avenue du Theil, dix-neuf, deux cents à Ussel
+Avenue Capitaine Fernand Taurisson, dix-neuf mille trois cent soixante Malemort-sur-Corrèze
+Rue de Soudeilles, dix-neuf, trois cents Égletons
+Boulevard de Chadaux, Égletons
+Route de Blanchefort à Lagraulière
+quatorze rue Muzac
+Rue Hippolyte Leobardy au numéro trois
+cent onze avenue J Jacques Rousseau, dix-neuf mille cent Brive-la-Gaillarde
+treize rue Geoffroy Tête Noire, dix-neuf, trois cents, Égletons
+vingt-trois route de la Taulie, dix-neuf, trois cents à Rosiers-d'Égletons
+Rue de Ceyrat Montplaisir, dix-neuf mille deux cents Ussel
+Rue de Panazol, dix-neuf, deux cent cinquante Meymac
+Rue Daniel de Cosnac, Brive-la-Gaillarde
+Route des Chezes à Objat
+cinq quai Lestourgie
+route des Monédières au numéro cinq
+sept rue Juliette Adam, dix-neuf mille cent Brive-la-Gaillarde
+vingt et un rue Boussicot deux, dix-neuf, trois cent soixante, Malemort-sur-Corrèze
+quatorze rue Guy Bonjour, dix-neuf, cent à Brive-la-Gaillarde
+Le Bois de Jaleix, dix-neuf mille cent cinquante Ladignac-sur-Rondelles
+Rue Gaston et Albert Granet, dix-neuf, cent Brive-la-Gaillarde
+Rue Roger Pecheyrand, Brive-la-Gaillarde
+Rue du Maréchal Brune à Brive-la-Gaillarde

--- a/server/data/fr/addresses-21.csv
+++ b/server/data/fr/addresses-21.csv
@@ -1,0 +1,70 @@
+cinquante-trois chemin du Fort de la Motte Giron, vingt et un mille Dijon
+trente et un rue Aloysius Bertrand, vingt et un, zéro zéro zéro, Dijon
+onze rue Fyot de la Marche, vingt et un, zéro zéro zéro à Dijon
+Chemin du Routoir, vingt et un mille trois cent dix Mirebeau-sur-Bèze
+Route de Renève, vingt et un, deux cent soixante-dix Talmay
+Rue Jean-Jean Cornu, Dijon
+Rue Charlie Chaplin à Dijon
+un chemin de Raffenot
+Route de Messigny au numéro dix
+un rue du Vernoy, vingt et un mille cinq cent soixante Arc-sur-Tille
+seize rue Quentin, vingt et un, zéro zéro zéro, Dijon
+quarante-deux route des Grands Crus, vingt et un, deux cent vingt à Fixin
+Rue Pierre Bachelet, vingt et un mille huit cents Chevigny-Saint-Sauveur
+Rue de Champoint, vingt et un, deux cent soixante Selongey
+Rue des Huches, Quetigny
+Rue Poussière à Nicey
+dix-huit rue Paul Delouvrier
+Rue de l'Abbé Trapet au numéro cinq
+neuf rue de Vaudrin, vingt et un mille deux cent trente Voudenay
+vingt-deux rue Philippe Guignard, vingt et un, zéro zéro zéro, Dijon
+vingt et un rue Henry Berger, vingt et un, six cent dix à Fontaine-Française
+Chemin des Boussecailles, vingt et un mille deux cent quarante Talant
+Impasse des Poissenottes, vingt et un, sept cents Arcenant
+Rue Edouard Joly, Beaune
+Route de Citeaux à Aubigny-en-Plaine
+six rue Aux Chiens
+Rue de la Loyère au numéro onze
+dix petite Rue Franche, vingt et un mille trois cent quarante Nolay
+trois avenue de Chenonceaux, vingt et un, huit cents, Chevigny-Saint-Sauveur
+soixante-dix-huit rue Antoine Masson, vingt et un, cent trente à Auxonne
+Rue Saint-Ambrosinien, vingt et un mille cent vingt et un Fontaine-lès-Dijon
+Rue de Rainans, vingt et un, cent trente Auxonne
+Rue Jalhay, Nolay
+Rue de la Grand'Velle à Vosne-Romanée
+trois rue des Crais
+Ruelle de la Gare d'Eau au numéro cinq
+dix-huit rue Auguste Carré, vingt et un mille cinq cents Montbard
+trois cent quatre-vingt-douze rue de Brully, vingt et un, deux cents, Beaune
+trente BIS rue Charles Suisse, vingt et un, zéro zéro zéro à Dijon
+Parc du Petit Bois, vingt et un mille cent vingt Is-sur-Tille
+Rue Colette Renard, vingt et un, huit cents Chevigny-Saint-Sauveur
+Rue Valentin Guillemot, Arcenant
+Avenue Alain Savary à Dijon
+neuf rue des Puits-
+Cours du Général de Gaulle au numéro cinq
+treize route de Beaune, vingt et un mille cent quatre-vingt-dix Corpeau
+deux rue des Champs de Lormes (Cour, vingt et un, trois cent quatre-vingt-dix, Dompierre-en-Morvan
+six rue de la Rouerie, vingt et un, deux cent dix à Saulieu
+Rue des Champs Viaux, vingt et un mille cent vingt et un Daix
+Chemin d'Huchey, vingt et un, cent dix Genlis
+Rue des Cunisseres, Barbirey-sur-Ouche
+Rue de la Cras à Arc-sur-Tille
+un E rue des Cent Journaux
+Rue Guillaume Tell au numéro douze
+un impasse du Meix Jauney, vingt et un mille cent quatre-vingt-dix Merceuil
+huit rue du Pâtis de Bey, vingt et un, quatre cent quatre-vingt-dix, Saint-Julien
+cinquante-trois rue de Marsannay, vingt et un, trois cents à Chenôve
+Impasse de la Fontaine du Grand Pré, vingt et un mille cent dix Chambeire
+Rue de la Fauverge, vingt et un, cinq cents Montbard
+Rue de la Braux, Alise-Sainte-Reine
+Rue de Touillon à Touillon
+seize sentier des Morottes
+Rue Claude Bouchu au numéro vingt-quatre
+neuf rue de L'Ersotte, vingt et un mille huit cent cinquante Saint-Apollinaire
+onze rue de Beaune, vingt et un, quatre cent vingt, Bouilland
+un rue Alioune Blondin Beye, vingt et un, huit cents à Quetigny
+Impasse du Faubourg de la Tour, vingt et un mille cent vingt Is-sur-Tille
+Rue René Fleutelot, vingt et un, zéro zéro zéro Dijon
+Rue Pierre Guidot, Beaune
+Chemin de Bèze à Chazeuil

--- a/server/data/fr/addresses-22.csv
+++ b/server/data/fr/addresses-22.csv
@@ -1,0 +1,70 @@
+douze le Closset, vingt-deux mille neuf cent quatre-vingts Languédias
+huit rue des Goemoniers, vingt-deux, six cent dix, Pleubian
+neuf hent-Dall ar Vengleuz, vingt-deux, trois cents à Lannion
+Lotissement La Grande Tour, vingt-deux mille neuf cent quatre-vingts Languédias
+Rue de Plédran, vingt-deux, neuf cent cinquante Trégueux
+Rue de Montjoie, Goudelin
+Rue Abbé Fleury à Quintin
+trois cité de la Butte Boisée
+Rue Hutin Desgrees du Lou au numéro sept
+dix-huit rue Francois Martin, vingt-deux mille quatre cents Lamballe
+cinquante rue du Docteur Violette, vingt-deux, cent quatre-vingt-dix, Plérin
+cinq hent Crec'h Meur, vingt-deux, cinq cents à Paimpol
+Rue de Trefois, vingt-deux mille Saint-Brieuc
+Rue Geoffroy de Pontblanc, vingt-deux, trois cents Lannion
+Rue du Rhun, Ploubazlanec
+Rue des Madières à Quessoy
+cinq rue du Roquet
+Rue Frédéric et Irène Joliot-Curie au numéro vingt et un
+quatorze côte aux Goupils, vingt-deux mille cent soixante-dix Plouagat
+trois rue des Pierres Noires, vingt-deux, quatre cent trente, Erquy
+un route de Correc, vingt-deux, cinq cents à Kerfot
+Route de Kermélo, vingt-deux mille sept cents Louannec
+Rue Mansart, vingt-deux, zéro zéro zéro Saint-Brieuc
+Rue de Cornouaille, Pleslin-Trigavou
+Rue du Lattay à Broons
+quarante-sept rue d'Argoat
+Route de Goaleuc au numéro un
+un rue Roger Vercel, vingt-deux mille neuf cent soixante Plédran
+seize rue du Goëlo, vingt-deux, cent soixante-dix, Châtelaudren
+douze rue du Pretanne, vingt-deux, quatre cents à Morieux
+Rue du Docteur Lavergne, vingt-deux mille quatre cents Lamballe
+Rue Jean Dugay, vingt-deux, cinq cent quarante Pédernec
+Rue Théodore Botrel, Plérin
+Rue de Brondineuf à Broons
+seize rue Tiphaine de Raguenel
+Impasse de Kerguidoue au numéro six
+deux rue des Rompées, vingt-deux mille trois cent cinquante Saint-Jouan-de-l'Isle
+six mille trois cent soixante-dix-sept rue de Kerariou, vingt-deux, cinq cent soixante, Trébeurden
+trois cité Crech Bellec, vingt-deux, cinq cents à Paimpol
+Hent Toull Kroaz, vingt-deux mille cinq cent soixante Pleumeur-Bodou
+Rue du Pont Blanc, vingt-deux, trois cent dix Plestin-les-Grèves
+Rue Saint-Thurian, Quintin
+Allée de l'Alouette à Trégastel
+cent vingt-sept boulevard Hoche
+Rue de Guingamp au numéro dix
+trente-quatre côte des Rus, vingt-deux mille cent trente Languenan
+un allée des Chantoirs, vingt-deux, trois cent soixante-dix, Pléneuf-Val-André
+neuf chemin de la Fontaine du Roselier, vingt-deux, cent quatre-vingt-dix à Plérin
+Rue des Bergeons, vingt-deux mille quatre cent quarante Ploufragan
+Rue Conen de Prépéan, vingt-deux, cinq cent quatre-vingt-dix Pordic
+Rue des Herbelines, Perros-Guirec
+Rue René Le Magorec à Rostrenen
+dix-sept rue de Crec'h Tanet
+Rue des Frères Le Montréer au numéro un BIS
+quarante-six rue du Fros, vingt-deux mille quatre cent quarante Ploufragan
+vingt rue Jean-Marie Le Foll, vingt-deux, trois cents, Ploubezre
+onze rue Charles Le Goffic, vingt-deux, cent quatre-vingt-dix à Plérin
+Courses Godet, vingt-deux mille deux cent dix Plumieux
+Route de Quemperven, vingt-deux, trois cents Rospez
+Rue de Kersuguet, Loudéac
+Rue André Fauchet à Langourla
+quatorze route du Dossen
+Rue de Prat Blouch au numéro cinq
+huit rue de la Croix Pavée, vingt-deux mille quatre cent cinquante Kermaria-Sulard
+trois rue du Pont des Vignes, vingt-deux, neuf cent quatre-vingts, Vildé-Guingalan
+deux rue de Ker Rolland, vingt-deux, trois cent dix à Plestin-les-Grèves
+Chemin du Tertre au Breton, vingt-deux mille quatre cent dix Saint-Quay-Portrieux
+Rue de Landerval, vingt-deux, sept cents Perros-Guirec
+Rue de Joliet, Ploubalay
+Rue du Moulin Bily à Saint-Cast-le-Guildo

--- a/server/data/fr/addresses-23.csv
+++ b/server/data/fr/addresses-23.csv
@@ -1,0 +1,70 @@
+vingt-deux rue du Docteur Gigon, vingt-trois mille trois cents La Souterraine
+neuf rue Albert Blanchet, vingt-trois, trois cents, La Souterraine
+six rue du Tourniquet Saint-Jacques, vingt-trois, trois cents à La Souterraine
+Allée de la Buvette, vingt-trois mille trois cent vingt Saint-Vaury
+Place Courtaud, vingt-trois, cinq cents Felletin
+Chemin de L'Etang des Châtres, Guéret
+Rue des Sabots à Dun-le-Palestel
+vingt et un route de La Châtre
+Route de Gartempe au numéro deux
+un place Albert Giraud, vingt-trois mille cent cinquante Ahun
+quatre rue de Saint-Vincent, vingt-trois, cent trente, Peyrat-la-Nonière
+quinze rue de La Pradelle, vingt-trois, zéro zéro zéro à Saint-Victor-en-Marche
+Rue de l'Escarpe, vingt-trois mille deux cents Aubusson
+Avenue Auguste Lacote, vingt-trois, huit cents Dun-le-Palestel
+Rue des Ecureuils Coussières, Saint-Sulpice-le-Guérétois
+Rue André Desmoulins à Guéret
+neuf avenue Fayolle
+Route d'Aubusson au numéro trois BIS
+dix rue Saint-Silvain, vingt-trois mille cent cinquante Ahun
+quatre rue des trois Fontaines, vingt-trois, zéro zéro zéro, Guéret
+quatorze rue Eugène Mourioux, vingt-trois, trois cents à Saint-Maurice-la-Souterraine
+Place du Lion, vingt-trois mille cent trente Peyrat-la-Nonière
+Allée de la Fontaine de Villedaris, vingt-trois, deux cent dix Mourioux-Vieilleville
+Rue Amédée Lefaure, Vallière
+Route du Moutier à Ahun
+quatorze rue du Docteur Philippe Bridot
+Rue Détournée au numéro trois
+dix rue du Docteur Brésard, vingt-trois mille Guéret
+six passage des Fourjadeaux, vingt-trois, trois cent vingt, Saint-Vaury
+deux impasse des Crouzilles, vingt-trois, deux cent dix à Mourioux-Vieilleville
+Rue Léon Chagnaud, vingt-trois mille Guéret
+Rue Fernand Villard, vingt-trois, trois cents La Souterraine
+Rue Alengarde, Felletin
+Rue du Moulin du Champ à Saint-Sulpice-le-Guérétois
+quatre rue Paul Chaumanet
+Lotissement de la Magnane au numéro deux
+trente et un rue du Champ de Course Charsat, vingt-trois mille Sainte-Feyre
+dix-neuf avenue de la Marche, vingt-trois, deux cent vingt, Bonnat
+onze rue du Docteur Lavillatte, vingt-trois, zéro zéro zéro à Guéret
+Route d'Ahun, vingt-trois mille cent cinquante Lavaveix-les-Mines
+Rue Quinault, vingt-trois, cinq cents Felletin
+Rue de la Font aux Moines, La Souterraine
+Avenue Benjamin Bord à Dun-le-Palestel
+trois chemin des Tremardeix
+Impasse des Luchaudes au numéro deux
+six rue Alexandre Guillon, vingt-trois mille Guéret
+cinq rue de la Croix Marlière, vingt-trois, cent trente, Chénérailles
+vingt-quatre rue de la Nave, vingt-trois, zéro zéro zéro à Saint-Sulpice-le-Guérétois
+Route de Banize, vingt-trois mille quatre cent quatre-vingts Saint-Sulpice-les-Champs
+Rue René Ducros, vingt-trois, trois cents La Souterraine
+Passage de la Bonde, Dun-le-Palestel
+Rue du Bois de la Font à Masbaraud-Mérignat
+quatorze rue de la Croix Marchon
+Rue du Docteur Bretelle au numéro vingt
+trois route de Bujaleuf, vingt-trois mille quatre cents Saint-Moreil
+sept allée de Genétine, vingt-trois, deux cent cinquante, Pontarion
+sept avenue du Bourbonnais, vingt-trois, zéro zéro zéro à Guéret
+Rue du Rocher Fleuri, vingt-trois mille deux cent dix Mourioux-Vieilleville
+Faubourg Saint-Martial, vingt-trois, cent soixante-dix Chambon-sur-Voueize
+Avenue Martel, Mourioux-Vieilleville
+Rue Henry Delannoy à Guéret
+quatre-vingt-huit route de Puychauveau Charsat
+Faubourg Monneix au numéro vingt-sept
+un rue de la Signole Villettes, vingt-trois mille huit cents Naillat
+huit chemin des Rivailles, vingt-trois, cent cinquante, Lavaveix-les-Mines
+un BIS avenue du Docteur Manouvrier, vingt-trois, zéro zéro zéro à Guéret
+Rue de la Croix du Lac, vingt-trois mille Saint-Victor-en-Marche
+Place Varillas, vingt-trois, zéro zéro zéro Guéret
+Chemin de Breith Bridiers, La Souterraine
+Rue du Violon au Grand-Bourg

--- a/server/data/fr/addresses-24.csv
+++ b/server/data/fr/addresses-24.csv
@@ -1,0 +1,70 @@
+cent quinze rue Gabriel Lacueille, vingt-quatre mille Périgueux
+sept boulevard Charles Dessagne, vingt-quatre, huit cents, Thiviers
+cinquante-quatre rue Fustel de Coulanges, vingt-quatre, cent à Bergerac
+Rue Jean de la Salle, vingt-quatre mille cent cinquante Couze-et-Saint-Front
+Route de Pombonne, vingt-quatre, cent Creysse
+Rue Bertran de Born, Hautefort
+Rue Pierre Bouty à Brantôme
+un ruelle du Fronton
+Rue Saint-Front au numéro quatorze
+quarante-quatre BIS rue Couleau, vingt-quatre mille six cents Ribérac
+six cent quarante-huit chemin de la Vigne du Foussat, vingt-quatre, deux cents, Sarlat-la-Canéda
+deux allée du Saint-Nicolas, vingt-quatre, sept cent cinquante à Champcevinel
+Route de la Petite Église, vingt-quatre mille deux cent soixante-dix Savignac-Lédrier
+Rue Combe des Dames, vingt-quatre, zéro zéro zéro Périgueux
+Route de la Fargue Basse, Prigonrieux
+Impasse du Parc de Prompsault à Notre-Dame-de-Sanilhac
+trois boulevard Bertran de Born
+Allée Jean-Louis Sussat au numéro trois
+quinze route des Caties, vingt-quatre mille cinq cent soixante-dix Le Lardin-Saint-Lazare
+vingt-trois rue du Puy de Flory, vingt-quatre, trois cents, Nontron
+soixante-quatorze rue Raymond Raudier, vingt-quatre, zéro zéro zéro à Périgueux
+Rue Renaudie, vingt-quatre mille quatre cent quatre-vingts Le Buisson-de-Cadouin
+Rue Jules Theulier, vingt-quatre, huit cents Thiviers
+Route de la Croix du Treuil, Prigonrieux
+Rue de Gogeant à Saint-Vincent-sur-l'Isle
+cent sept route du Gueynaire
+Rue du Docteur Clament au numéro trois BIS
+cinquante-quatre rue Pierre de Bourdeille, vingt-quatre mille trois cent dix Brantôme
+un BIS rue du Gardou, vingt-quatre, quatre cent trente, Razac-sur-l'Isle
+deux rue du Pré Joli, vingt-quatre, cent à Bergerac
+Place des Deux Conils, vingt-quatre mille cent Bergerac
+Route de la Bourgatie, vingt-quatre, six cent quatre-vingts Lamonzie-Saint-Martin
+Rue de la Serve, Piégut-Pluviers
+Rue Jean Lannemajou à Périgueux
+quatre rue Lan Xang
+Rue Pechaud au numéro quatre
+vingt-six rue Onésime Reclus, trente-trois mille deux cent vingt Port-Sainte-Foy-et-Ponchapt
+trois cents route du Mausse, vingt-quatre, cent trente, Monfaucon
+quatre rue Merlet, vingt-quatre, six cent soixante à Notre-Dame-de-Sanilhac
+Rue Talleyrand Périgord, vingt-quatre mille Périgueux
+Rue du Tertre de Biron, vingt-quatre, quatre cent quatre-vingts Le Buisson-de-Cadouin
+Rue du Bas Trigonant, Antonne-et-Trigonant
+Hameau d'Excidoire à Montrem
+deux rue du Marquis de la Valette
+Place Saint-Astier au numéro quatorze
+treize rue Gaston Sarnel, vingt-quatre mille cent vingt Terrasson-Lavilledieu
+soixante-quinze avenue de Selves, vingt-quatre, deux cents, Sarlat-la-Canéda
+cinquante-cinq avenue de la Canéda, vingt-quatre, deux cents à Sarlat-la-Canéda
+Rue du Vieux Quartier, vingt-quatre mille deux cent soixante-dix Lanouaille
+Rue du Tounet, vingt-quatre, cent Bergerac
+Avenue de Monpazier, Beaumont-du-Périgord
+Impasse Bertrand de Goth au Fleix
+quarante et un BIS rue André Picaud
+Chemin du Sabotier au numéro quatre-vingt-quatre
+dix rue Maleville, vingt-quatre mille Périgueux
+cinquante-neuf route des Deux Villages, vingt-quatre, six cent quatre-vingts, Lamonzie-Saint-Martin
+trente rue de Séguinou, vingt-quatre, quatre cents à Mussidan
+Rue Lachambeaudie, vingt-quatre mille deux cent quatre-vingt-dix Montignac
+Chemin des Rocs, vingt-quatre, deux cent dix La Bachellerie
+Rue Guillaume Loiseau, Bergerac
+Rue Charles Mangold à Périgueux
+cinq rue Jean Dumas
+Rue du Colonel de Chadois au numéro dix
+quatorze rue Clairat, vingt-quatre mille cent Bergerac
+cent cinq rue Roger Barnalier, vingt-quatre, zéro zéro zéro, Périgueux
+quatorze place des Lauriers Roses, vingt-quatre, cent vingt à Terrasson-Lavilledieu
+Rue de La Chambeaudie, vingt-quatre mille deux cents Sarlat-la-Canéda
+Rue du Grenouillet, vingt-quatre, cent trente Le Fleix
+Route des Junies, Prigonrieux
+Rue Georges Campagnac à Coulounieix-Chamiers

--- a/server/data/fr/addresses-25.csv
+++ b/server/data/fr/addresses-25.csv
@@ -1,0 +1,70 @@
+deux chemin de la Plaine Fin, vingt-cinq mille cent dix Autechaux
+neuf chemin du Grand Saunier, vingt-cinq, quatre cent quarante, Charnay
+un impasse du Gelot, vingt-cinq, deux cent cinquante à L'Isle-sur-le-Doubs
+Rue de la Balistrerie, vingt-cinq mille deux cent cinquante L'Isle-sur-le-Doubs
+Rue du Banne, vingt-cinq, cent soixante-dix Jallerange
+Rue du Relais Postal, Noirefontaine
+Rue Longchamps à Guyans-Durnes
+vingt-deux rue Tridard
+Rue Sous Mouthier au numéro onze
+onze rue du Général Lecourbe, vingt-cinq mille Besançon
+trois rue de Badevel, vingt-cinq, quatre cent quatre-vingt-dix, Dampierre-les-Bois
+trente et un rue du Pré Jean, vingt-cinq, cent soixante à Vaux-et-Chantegrue
+Rue Gloria, vingt-cinq mille trois cent trente Lizine
+Rue de la Porte de Chaux, vingt-cinq, trois cent quarante Clerval
+Rue du Noyer Baillet, Saint-Vit
+Rue Suard à Besançon
+quatorze B avenue Fontaine-Argent
+Rue des Fords au numéro trente-deux
+treize le Grand Git et Estanguill, vingt-cinq mille deux cent quarante Chaux-Neuve
+sept rue des Fusillés de mille neuf cent quarante-quatre, vingt-cinq, deux cents, Montbéliard
+six le Champ Quaresse, vingt-cinq, cinq cents aux Combes
+Rue de Valentigney, vingt-cinq mille quatre cents Audincourt
+Rue de la Tanche, vingt-cinq, cinq cents Morteau
+Rue Louis Duplain, Besançon
+Rue Champ au Clerc à Vuillecin
+trente-deux rue Viette
+Rue du Clos Méry au numéro dix-huit
+onze A rue Champey, vingt-cinq mille sept cent soixante-dix Franois
+vingt et un place Combes Saint-Germain, vingt-cinq, sept cents, Valentigney
+cent neuf le Frambourg, vingt-cinq, trois cents à La Cluse-et-Mijoux
+Rue des Brillets, vingt-cinq mille trois cent vingt Montferrand-le-Château
+Rue de la Nouelle, vingt-cinq, quatre cent dix Dannemarie-sur-Crète
+Rue de Saint-Fort, Morre
+Rue du Clair Soleil à Seloncourt
+deux rue Jean-Pierre Bangue
+Rue du Maquis de Lucelans au numéro trois cent soixante
+trente rue des Troênes, vingt-cinq mille cent cinquante Pont-de-Roide
+vingt-deux lotissement Miroir Sud, vingt-cinq, trois cent soixante-dix, Les Hôpitaux-Neufs
+six mille cent soixante-seize rue du Clos Rondot, vingt-cinq, cent trente à Villers-le-Lac
+Rue Nicolas Bruand, vingt-cinq mille Besançon
+Rue du Clos aux Roux, vingt-cinq, six cent cinquante La Longeville
+Rue de Fesches-le-Chatel, Dampierre-les-Bois
+Lotissement la Combe au Prêtre à Chemaudin
+sept rue de la Caffode
+Chemin des Places au numéro quatre
+sept route de Baume, vingt-cinq mille cent dix Vergranne
+vingt-neuf BIS avenue de Montjoux, vingt-cinq, zéro zéro zéro, Besançon
+vingt-six lotissement les Grands Prés, vingt-cinq, sept cent vingt à Pugey
+Rue de la Guillemaille, vingt-cinq mille quatre cent quatre-vingt-dix Dampierre-les-Bois
+Rue Paul Elie Dubois, vingt-cinq, deux cent cinquante L'Isle-sur-le-Doubs
+Rue Balthazar Gérard, Vuillafans
+Rue Saint-Antide à Pontarlier
+trois rue Sous Le Clos
+Rue des Criantes au numéro deux
+un place des Jardins du Roide, vingt-cinq mille cent cinquante Pont-de-Roide
+un rue Rouge, vingt-cinq, six cent quarante, Rignosot
+cinq chemin de Prabey, vingt-cinq, zéro zéro zéro à Besançon
+Rue Roger Courtois, vingt-cinq mille deux cents Montbéliard
+L'Orée du Bois, vingt-cinq, cinq cents Les Combes
+Rue Louis Dormoy, Fesches-le-Châtel
+Rue des Vignoles à Vieux-Charmont
+quinze BIS rue Charmontet
+Rue du Champ Sirebon au numéro vingt-huit
+douze rue Étienne Oehmichen, vingt-cinq mille sept cents Valentigney
+vingt rue du Tantillon, vingt-cinq, cinq cents, Les Fins
+cinq rue du Crépon, vingt-cinq, quatre cent soixante-dix à Trévillers
+Rue de l'Herbe d'Avril, vingt-cinq mille Besançon
+Chemin du Menuey, vingt-cinq, trois cent vingt Chemaudin
+Rue sous la Côte, Mandeure
+Rue de Vandoncourt à Audincourt

--- a/server/data/fr/addresses-26.csv
+++ b/server/data/fr/addresses-26.csv
@@ -1,0 +1,70 @@
+vingt-six rue Chevalier Bayard, vingt-six mille deux cent soixante Saint-Donat-sur-l'Herbasse
+cinquante-six avenue du Vercors et de la Résistance, vingt-six, six cents, Tain-l'Hermitage
+un allée Edouard Manet, vingt-six, deux cents à Montélimar
+Avenue de la Forêt de Lente, vingt-six mille cent quatre-vingt-dix Saint-Jean-en-Royans
+Place de l'Ancienne Horloge, vingt-six, sept cents Pierrelatte
+Route de Donzère, Châteauneuf-du-Rhône
+Boulevard Maurice Clerc à Valence
+quarante-cinq route d'Anneyron
+Impasse de Ruinel au numéro cent quatre-vingts
+quatre-vingt-dix-sept rue Chateauvert, vingt-six mille Valence
+quatorze avenue du Docteur Georges Fontaine, vingt-six, cent trente, Saint-Paul-Trois-Châteaux
+deux mille deux cent dix route d'Albon, vingt-six, cent quarante à Anneyron
+Chemin de Chaillard, vingt-six mille cent quatre-vingt-dix Bouvante
+Impasse des Godins, vingt-six, deux cent soixante Bren
+Rue Faventines, Valence
+Chemin des Terrets à Rochefort-Samson
+cent quatre-vingt-cinq route du Four
+Lotissement Le Clos d'Auriac au numéro sept
+vingt-cinq route du Pilon, vingt-six mille deux cent quarante Claveyson
+quatre cent vingt-cinq route de Montalivet, vingt-six, deux cent quarante, Claveyson
+soixante-dix rue Sainte-Euphémie, vingt-six, cent soixante à Manas
+Grand'Rue Jean Jaurès, vingt-six mille trois cents Bourg-de-Péage
+Rue des Quatre Alliances, vingt-six, deux cents Montélimar
+Rue Louis Ollier, Valence
+Rue Charabot à Crest
+cent vingt-cinq chemin de la Côte Rousse
+Allée des Frégates au numéro cinq
+trente-cinq rue des Antignans, vingt-six mille cent dix Nyons
+mille trois cents route de Ponet, vingt-six, cent cinquante, Die
+seize rue des Fauries, vingt-six, deux cent cinquante à Livron-sur-Drôme
+Avenue Léon Laurent, vingt-six mille cent quatre-vingt-dix Saint-Nazaire-en-Royans
+Avenue Désiré Valette, vingt-six, deux cent quarante Saint-Vallier
+Chemin des Roufiats, Montélier
+Avenue Maurice René Simonet à Valence
+soixante-treize rue de la Chamberlière
+Rue Amédée Brenier au numéro vingt-cinq
+deux cent six impasse de Malgras, vingt-six mille cent soixante-dix Buis-les-Baronnies
+quatorze rue Colonel Barrillon, vingt-six, cent dix, Nyons
+dix-sept lotissement Les Residences des Sources, vingt-six, cent trente à Saint-Paul-Trois-Châteaux
+Rue Pierre Julien, vingt-six mille deux cents Montélimar
+Chemin de Ventabren, vingt-six, cent soixante Bonlieu-sur-Roubion
+Rue Jardin Paulin, Bourg-lès-Valence
+Quai Auguste Clément à Bourg-de-Péage
+quarante lotissement l'Allée de la Mucelière
+Avenue du Docteur Charles Jaume au numéro quatre BIS
+quatre cent quatre-vingts allée du Vivarais, vingt-six mille trois cents Bourg-de-Péage
+cinq BIS rue Chéradame, vingt-six, trois cents, Bourg-de-Péage
+sept impasse Charles-Antoine Gailhard, vingt-six, deux cents à Montélimar
+Route de Larnage, vingt-six mille six cents Tain-l'Hermitage
+Chemin de la Delile, vingt-six, sept cent quatre-vingt-dix Suze-la-Rousse
+Rue Chanoine Jouve, Buis-les-Baronnies
+Place Jérôme Cavalli à Lapeyrouse-Mornay
+six cent soixante rue Louis d'Arbalestier
+Impasse du Capitaine au numéro cent quarante-cinq
+vingt impasse des Oches, vingt-six mille deux cent soixante Bren
+quinze chemin Goutte Soleil, vingt-six, deux cent soixante-dix, Mirmande
+dix-huit rue Jean-Antoine Watteau, vingt-six, cent à Romans-sur-Isère
+Chemin du Menon, vingt-six mille cent soixante-dix Buis-les-Baronnies
+Route du Vercors, vingt-six, six cents Beaumont-Monteux
+Lotissement Résidence de la Soie, Saint-Laurent-en-Royans
+Route de l'Oron à Manthes
+treize rue du Docteur Jeune
+Côte Bellevue au numéro soixante-dix
+cent trente route de Claveyson, vingt-six mille six cents Chantemerle-les-Blés
+vingt et un rue Mathieu de la Drôme, vingt-six, zéro zéro zéro, Valence
+quatre avenue de Quebec, vingt-six, deux cent quarante à Saint-Vallier
+Route des Balmes, vingt-six mille cent Romans-sur-Isère
+Rue Véronique, vingt-six, cent vingt Malissard
+Chemin des Pépinières, Geyssans
+Allée Eugène Labiche à Valence

--- a/server/data/fr/addresses-27.csv
+++ b/server/data/fr/addresses-27.csv
@@ -1,0 +1,70 @@
+seize route d'Evreux, vingt-sept mille quatre cent quatre-vingt-dix Autheuil-Authouillet
+dix clos Saint-Gilles, vingt-sept, cent, Val-de-Reuil
+trente-neuf route du Clos de Tilly, vingt-sept, cinq cent vingt à Berville-en-Roumois
+Rue de l'Ouverdière, vingt-sept mille neuf cent quarante Villers-sur-le-Roule
+Rue de Wendehausen, vingt-sept, cinq cent soixante-dix Tillières-sur-Avre
+Impasse du Prasquer, Amfreville-sur-Iton
+Cours de la Croix d'Epine à Vernon
+cent vingt-sept chemin du Mont Perrot
+Rue Vieille d'Ivry au numéro treize
+treize rue du Clos des Ormes, vingt-sept mille cent Le Vaudreuil
+cent huit cité des Baquets, vingt-sept, cinq cents, Manneville-sur-Risle
+deux route de la Chapelle Saint-Léonard, vingt-sept, six cent quatre-vingts à Saint-Aubin-sur-Quillebeuf
+Chemin du Chêne de Sainte-Barbe, vingt-sept mille cent quatre-vingt-dix Glisolles
+Route de Pacy, vingt-sept, quatre cents Louviers
+Rue Gabriel Perelle, Vernon
+Rue du Jonctier au Vieil-Évreux
+cinq rue de la Queronnière
+Allée Frédéric Malbranche au numéro neuf
+un A rue du Gord, vingt-sept mille deux cent quarante Sylvains-les-Moulins
+vingt-trois résidence le Clos du Courtillet, vingt-sept, neuf cent quarante, Aubevoye
+vingt-deux voie Les Cottages, vingt-sept, cent à Val-de-Reuil
+Impasse des Besaches, vingt-sept mille trois cent quatre-vingts Amfreville-sous-les-Monts
+Voie Bichelin, vingt-sept, deux cents Vernon
+Rue de l'Alizé, Saint-Pierre-des-Fleurs
+Route de la Judée à Conteville
+quatre cent trente-trois route de Boissey
+Boulevard de la Verte Bonne au numéro neuf
+onze rue Felix Lepouze, vingt-sept mille cent vingt Pacy-sur-Eure
+quatre cent cinquante-cinq rue du Manoir Fauvel, vingt-sept, six cent quatre-vingts, Trouville-la-Haule
+deux route de Londemare, vingt-sept, trois cent soixante-dix à Fouqueville
+Résidence le Vert Coteau, vingt-sept mille trois cents Bernay
+Rue de la Mare Blanche, vingt-sept, cent soixante Francheville
+Route de la Morelle, Fiquefleur-Équainville
+Route de Fourges à Gasny
+vingt-huit rue des Grands Merisiers
+Rue Charles Michels au numéro cinquante et un
+neuf ancien Chemin de Rouen, vingt-sept mille trois cent cinquante Cauverville-en-Roumois
+soixante-deux A allée de l'Île de Grâce, vingt-sept, six cent quarante, Merey
+vingt-quatre rue du Val Morin, vingt-sept, cent vingt à Pacy-sur-Eure
+Rue Delamarre, vingt-sept mille trois cent soixante-dix Le Thuit-Anger
+Rue des Trois Maillets, vingt-sept, cent trente Verneuil-sur-Avre
+Rue de la Grande Breche, Vraiville
+Rue du Perrey à Bosc-Bénard-Commin
+dix-neuf rue Louis Mallard
+Route du Docteur Thierry de Martel au numéro trois
+cent quatre-vingts route d'Aizier, vingt-sept mille cinq cents Bourneville
+cent trente rue du Bout des Hayes, vingt-sept, six cent quatre-vingts, Trouville-la-Haule
+dix-huit rue du Lotus Bleu, vingt-sept, quatre cents à Louviers
+Chemin du Maraval, vingt-sept mille six cent soixante-dix Le Bosc-Roger-en-Roumois
+Rue de Damville, vingt-sept, cent quatre-vingt-dix Nogent-le-Sec
+Route de Louversey, Sainte-Marthe
+Rue de la Mare Pilette à Hennezis
+soixante-seize rue Coutey
+Lotissement R Guilloux au numéro six
+cent trente-six chemin du Vieux Verneuil, vingt-sept mille cent trente Verneuil-sur-Avre
+six chemin des Malis, vingt-sept, cent vingt, Le Plessis-Hébert
+soixante-dix rue de l'Hélianthe, vingt-sept, cent à Val-de-Reuil
+Rue de West, vingt-sept mille cinq cent dix Tourny
+Rue de la Ville Aux Bonnets, vingt-sept, cent soixante Francheville
+Rue du Vert Buisson, Broglie
+Rue de la Blanche Voie à Saint-Pierre-d'Autils
+un route de Sébécourt
+Route du Castillon au numéro quatre BIS
+six place du Phare, vingt-sept mille six cent quatre-vingts Quillebeuf-sur-Seine
+seize route du Neubourg, vingt-sept, trois cent soixante-dix, Le Thuit-Anger
+vingt rue du Bois de la Fosse, vingt-sept, six cents à Saint-Aubin-sur-Gaillon
+Chemin du Gue Turbure, vingt-sept mille cent vingt Hardencourt-Cocherel
+Rue André Bourvil, vingt-sept, neuf cent trente Guichainville
+Allée Jean Tinguely, Évreux
+Route du Pont de l'Arche à Ecquetot

--- a/server/data/fr/addresses-28.csv
+++ b/server/data/fr/addresses-28.csv
@@ -1,0 +1,70 @@
+dix rue d'Auneau, vingt-huit mille trois cent soixante Prunay-le-Gillon
+un rue de la Carbonniere, vingt-huit, trois cent soixante, La Bourdinière-Saint-Loup
+cinq rue Romain Foure, vingt-huit, trois cents à Coltainville
+Rue de Chailloy, vingt-huit mille cinq cents Garnay
+Rue des Etangs, vingt-huit, huit cents Saumeray
+Rue du Hotbrou, Barjouville
+Boulevard Toutain à Châteaudun
+quarante-deux route de Voves
+Rue de Jallans au numéro quarante et un
+quarante-six rue Lucien Dupuis, vingt-huit mille cinq cents Vernouillet
+trois rue René Hue, vingt-huit, deux cents, Ozoir-le-Breuil
+dix-huit rue des Lucasses, vingt-huit, trois cents à Lèves
+Rue du Maréchal Maunoury, vingt-huit mille cent trente Maintenon
+Rue Giroust, vingt-huit, quatre cents Nogent-le-Rotrou
+Rue Texier Gallas, Auneau
+Rue Gustave Duchesne à Dreux
+dix-sept rue de Chartres
+Rue des Vignes d'Allians au numéro neuf
+trente rue de Brou, vingt-huit mille huit cents Flacey
+deux rue Henri Lemouettre, vingt-huit, deux cent dix, Nogent-le-Roi
+vingt-quatre rue des Sentinelles, vingt-huit, trois cent dix à Toury
+Rue des Vieux Rapporteurs, vingt-huit mille Chartres
+Route d'Oulins, vingt-huit, deux cent soixante Anet
+Place du Dix Huit Octobre, Châteaudun
+Rue Lucien Descaves à Senonches
+quatre-vingt-douze BIS rue François Foreau
+Rue du Haut Murger au numéro vingt-quatre
+deux rue Roland Buthier, vingt-huit mille trois cents Mainvilliers
+deux cent seize A rue de Champfroid, vingt-huit, huit cents, Sancheville
+onze impasse des Joncquets, vingt-huit, cent quatre-vingt-dix à Saint-Georges-sur-Eure
+Rue Maurice Dumais, vingt-huit mille cent quatre-vingt-dix Saint-Georges-sur-Eure
+Chemin de Prouais, vingt-huit, cinq cents La Chapelle-Forainvilliers
+Ruelle de la Charrière, Voves
+Rue du Docteur Bouclet à Sours
+sept rue Saint-Valérien
+Boulevard Delescluze au numéro quarante-cinq BIS
+quinze rue Les Rues Neuves, vingt-huit mille huit cents Montboissier
+vingt-six les Jardins de Villoiseau, vingt-huit, cent soixante, Brou
+vingt-sept rue du Bas des Clos, vingt-huit, cent soixante-dix à Saint-Ange-et-Torçay
+Rue Joseph Fourier, vingt-huit mille Chartres
+Rue du Bout d'Anguy, vingt-huit, trois cents Jouy
+Rue Jules Courtois, Chartres
+Rue du Puits Drouet à Chartres
+trois sentier des Clos Vert
+Rue Gabriel Hayes au numéro onze
+deux hameau de Saintonge, vingt-huit mille cent dix Lucé
+trois rue de Laïr, vingt-huit, trois cent dix, Janville
+quatre-vingt-douze BIS rue Philarète Chasles, vingt-huit, trois cents à Mainvilliers
+Rue du Clos Barreau, vingt-huit mille cinq cents Vert-en-Drouais
+Rue d'Illiers, vingt-huit, cent vingt Montigny-le-Chartif
+Rue de Patay, La Ferté-Villeneuil
+Avenue de Babyloine à Bonneval
+quatorze allée du Hameau Gabriel Péri
+Avenue du Général Marceau au numéro sept
+quatre rue Maury, vingt-huit mille deux cents Châteaudun
+quatorze rue du Clos d'Amilly, vingt-huit, trois cents, Amilly
+quarante-deux rue Villette Gâté, vingt-huit, quatre cents à Nogent-le-Rotrou
+Rue Philippe Lemaître, vingt-huit mille cent Dreux
+Rue de la Mâlerie, vingt-huit, quatre cents Nogent-le-Rotrou
+Rue du Bout de la Vigne, Baudreville
+Rue Adrien Mahaut à Montigny-sur-Avre
+six avenue Saint-Germain Bigeonnette
+Résidence les Hauts du Château au numéro seize
+un place Colombier Vaubrun, vingt-huit mille deux cent dix Chaudon
+un rue du Bois Bert, vingt-huit, deux cent vingt, Douy
+trois impasse MontPensier, vingt-huit, zéro zéro zéro à Chartres
+Route du Trocadéro, vingt-huit mille deux cent quarante Saint-Maurice-Saint-Germain
+Rue de Varize, vingt-huit, deux cents Châteaudun
+Route de Gouillons, Léthuin
+Rue des Champs Brizards à Champhol

--- a/server/data/fr/addresses-29.csv
+++ b/server/data/fr/addresses-29.csv
@@ -1,0 +1,70 @@
+seize rue Lagad Yar, vingt-neuf mille sept cent trente Guilvinec
+six route de Keralias, vingt-neuf, huit cent soixante, Kersaint-Plabennec
+trente-neuf le Clos de Lannec'huen, vingt-neuf, cinq cent dix à Briec
+Hameau de Pentérc'h, vingt-neuf mille cent soixante-dix Saint-Évarzec
+Route de Lezaouvreguen, vingt-neuf, cent Poullan-sur-Mer
+Rue de Parc C'hoadic, Concarneau
+Impasse Serge Gainsbourg à Tréméven
+six allée du Docteur Royer
+Rue de Keralvé au numéro quatre
+un rue du Park, vingt-neuf mille cinq cent vingt Châteauneuf-du-Faou
+deux A avenue du Dorlett, vingt-neuf, neuf cents, Concarneau
+vingt-neuf BIS rue de La Libération, vingt-neuf, quatre cent dix au Cloître-Saint-Thégonnec
+Rue des Dentelières, vingt-neuf mille deux cent soixante Le Folgoët
+Rue du Comte Even, vingt-neuf, huit cent cinquante Gouesnou
+Route de Châteaulin, Plomodiern
+Venelle du Pain Cuit à Quimper
+cinquante-trois rue Lost al Lann
+Route du Guilvinec au numéro quarante
+vingt et un kroaz Hent, vingt-neuf mille cent soixante-dix Fouesnant
+soixante-deux rue Ange de Guernisac, vingt-neuf, six cents, Morlaix
+dix-neuf rue de Tevennec, vingt-neuf, cent à Douarnenez
+Route de Bénodet, vingt-neuf mille Quimper
+Rue de Guimiliau, vingt-neuf, quatre cents Lampaul-Guimiliau
+Rue des Plomarc'h, Douarnenez
+Hent Kersentic à Fouesnant
+vingt-deux rue de Querrien
+Route de Quimper au numéro douze
+vingt chemin Karreg ar Roz, vingt-neuf mille quatre cent soixante-dix Plougastel-Daoulas
+deux route du Circuit du Trégor, vingt-neuf, six cent trente, Plougasnou
+quarante impasse de Kerivarc'h, vingt-neuf, deux cent cinquante à Saint-Pol-de-Léon
+Route de Saint-Hernin, vingt-neuf mille deux cent soixante-dix Cléden-Poher
+Route du Venneg, vingt-neuf, deux cent soixante Saint-Méen
+Rue de Penzance, Camaret-sur-Mer
+Résidence du Petit Bois au Drennec
+quarante-quatre rue du Cléguer
+Le Prajou au numéro vingt-trois A
+sept rue Louis Proust, vingt-neuf mille quatre cents Landivisiau
+trente rue de Batz, vingt-neuf, deux cent cinquante, Saint-Pol-de-Léon
+vingt-quatre allée des Moulins, vingt-neuf, deux cent quatre-vingt-dix à Guipronvel
+Rue Charles Berthelot, vingt-neuf mille deux cents Brest
+Rue du Pontic, vingt-neuf, quatre cents Landivisiau
+Rue de la Croix-Donnart, Plouhinec
+Hent Du à Fouesnant
+cinq BIS chemin de Kerc'hoat
+Avenue de Kerhuel au numéro quatre
+cent soixante-dix-neuf route du Bas de la Rivière, vingt-neuf mille six cents Morlaix
+deux place Terre au Duc, vingt-neuf, zéro zéro zéro, Quimper
+vingt-huit rue de l'Île d'Houat, vingt-neuf, zéro zéro zéro à Quimper
+Rue de Ty-Forn, vingt-neuf mille six cent soixante-dix Taulé
+Rue Alexis l'Hourre, vingt-neuf, huit cent soixante-dix Lannilis
+Impasse An Avel Viz Nordet, Douarnenez
+Rue du Petit Robinson à Morlaix
+quatre rue Amiral Vallon
+Rue de Kergadec au numéro quarante et un
+deux cent cinquante chemin Beg an Dre, vingt-neuf mille quatre cent soixante-dix Plougastel-Daoulas
+trente-deux rue de Lesconil, vingt-neuf, sept cent quarante, Plobannalec-Lesconil
+un rue Eugène Hénaff, vingt-neuf, cinq cent quarante à Spézet
+Hent Bec Kroissen, vingt-neuf mille neuf cent cinquante Bénodet
+Lotissement Park Penduick, vingt-neuf, trois cent soixante Clohars-Carnoët
+Rue des Abbés-Tanguy, Pont-Aven
+Rue Herri Léon à Brest
+vingt-huit chemin de Kerdalaes
+Rue de Bizernig au numéro trois
+soixante-neuf rue du Fret, vingt-neuf mille cent soixante Lanvéoc
+vingt-six avenue Charles de Foucauld, vingt-neuf, deux cents, Brest
+soixante-cinq chemin de Reunouet, vingt-neuf, quatre cent soixante-dix à Loperhet
+Route de Créach Al Louarn, vingt-neuf mille huit cent trente Ploudalmézeau
+Rue de Rénanguip, vingt-neuf, cent quarante Rosporden
+Lotissement de Kerfeunteun, Névez
+Rue de Coat Losquet à Locmaria-Plouzané

--- a/server/data/fr/addresses-2A.csv
+++ b/server/data/fr/addresses-2A.csv
@@ -1,0 +1,70 @@
+huit cours Grandval, vingt mille Ajaccio
+onze rue Forcioli-Conti, vingt, zéro zéro zéro, Ajaccio
+vingt-six lotissement Communal de Pascia Vecchia, vingt, cent vingt-quatre à Zonza
+Parc Berthault, vingt mille Ajaccio
+Lotissement Les Parcs de Porto Vécchio, vingt, cent trente-sept Porto-Vecchio
+Route du Vittulo, Ajaccio
+Boulevard du Roi Jérôme à Ajaccio
+six avenue Napoleon trois
+Rue du Roi de Rome au numéro six
+six chemin de Buggiale, vingt mille cent treize Olmeto
+vingt-huit cours Napoléon, vingt, cent trente-sept, Porto-Vecchio
+treize rue des Pachas, vingt, cent soixante-neuf à Bonifacio
+Rue de la Porta, vingt mille Ajaccio
+Chemin de la Pietrina, vingt, zéro zéro zéro Ajaccio
+Boulevard Sylvestre Marcaggi, Ajaccio
+Rue Sureddi Galloni d'Istria à Olmeto
+deux cent soixante-six P rue des Trois Maries
+Rue du Maréchal Ornano au numéro trois
+trente et un rue Docteur Dell Pellegrino, vingt mille Ajaccio
+treize rue Jean Donat Leandri, vingt, cent dix, Propriano
+onze rue Col Colonna d'Ornano, vingt, zéro zéro zéro à Ajaccio
+Lotissement Domaine de Pinarello, vingt mille cent vingt-quatre Zonza
+Rue du Général Fiorella, vingt, zéro zéro zéro Ajaccio
+Rue A Liscia, Ajaccio
+Lotissement Moretti à Afa
+deux avenue Beverini Vico
+Lotissement Hameaux de Petra Pinzuta au numéro trois
+vingt et un cours Lucien Bonaparte, vingt mille Ajaccio
+huit montée de la Paratella, vingt, cent dix, Propriano
+quarante-huit rue U Golu, vingt, zéro zéro zéro à Ajaccio
+Boulevard Pugliesi Conti, vingt mille Ajaccio
+Rue Miss Campbell, vingt, zéro zéro zéro Ajaccio
+Boulevard Fred Scamaroni, Ajaccio
+Lotissement Arasu Sottanu à Zonza
+six lotissement Les Hauts de Solenzara
+Impasse Quatrina au numéro neuf
+un rue Sainte-Lucie, vingt mille Ajaccio
+quatre-vingt-un rue U Taravu, vingt, zéro zéro zéro, Ajaccio
+treize rue A Gravona, vingt, zéro zéro zéro à Ajaccio
+Rue Cardinal Fesch, vingt mille Ajaccio
+Lotissement Susini, vingt, cent quarante-six Sotta
+Rue du Conventionnel Chiappe, Ajaccio
+Rue du Commandant Benielli à Ajaccio
+quatre BIS terrasse de la Villette
+Rue Major Lambruschini au numéro vingt-six
+quatre lotissement Pasci Pecora, vingt mille Ajaccio
+cinq chemin des Plages, vingt, cent dix, Propriano
+quatre rue Colomba, vingt, zéro zéro zéro à Ajaccio
+Lotissement Valle Longa, vingt mille cent vingt-quatre Zonza
+Rue du Docteur Stéphanopoli, vingt, zéro zéro zéro Ajaccio
+Rue du Comte Marbeuf, Ajaccio
+Boulevard Madame Mère à Ajaccio
+dix-neuf boulevard Jérome et Barthélémy Maglioli
+Place de la Foata au numéro neuf
+sept avenue Antoine Serafini, vingt mille Ajaccio
+quatre lotissement La Pinède, vingt, cent vingt-huit, Albitreccia
+trois lotissement U Furellu, vingt, cent soixante-sept à Afa
+Rue des Glaçis, vingt mille Ajaccio
+Rue De La Citadelle, vingt, cent trente-sept Porto-Vecchio
+Cours du Général Leclerc, Ajaccio
+Rue des Pecheurs à Propriano
+deux lotissement Punta Rossa
+Lotissement Le Clos des Melias au numéro huit
+sept rue Archivolto, vingt mille cent soixante-neuf Bonifacio
+huit rue Camille Pietri, vingt, cent dix, Propriano
+quatre avenue du Premier Consul, vingt, zéro zéro zéro à Ajaccio
+Lotissement Punta Di Vesco, vingt mille cent vingt-huit Grosseto-Prugna
+Lotissement l'Oliveraie, vingt, cent soixante-sept Alata
+Lotissement Domaine Punta d'Araso, Zonza
+Rue Capitaine Paul Bosc à Ajaccio

--- a/server/data/fr/addresses-2B.csv
+++ b/server/data/fr/addresses-2B.csv
@@ -1,0 +1,70 @@
+deux mille vingt-cinq route de Bastia, vingt mille deux cent quarante Ghisonaccia
+mille quatre cent quarante-sept avenue Sampiero Corso, vingt, deux cents, Bastia
+cent quatre chemin du Grecu, vingt, six cents à Furiani
+Lotissement e Strette, vingt mille deux cent quarante Ghisonaccia
+Chemin de Caraghja, vingt, six cents Furiani
+Avenue de Valrose, Borgo
+Chemin du Campu Tondu à San-Martino-di-Lota
+sept chemin Olivetto
+Chemin de Calviani au numéro cent soixante-dix BIS
+onze rue Monseigneur Rigo, vingt mille deux cents Bastia
+cinq cent soixante route de Borgo Village, vingt, deux cent quatre-vingt-dix, Borgo
+cinq cent cinquante-six route de San Gavino, vingt, six cents à Furiani
+Rue Monseigneur Casanova, vingt mille deux cent cinquante Corte
+Route d'Urbino, vingt, deux cent quarante Ghisonaccia
+Route du village, Furiani
+Route Nationale deux cents à Aléria
+trois rue Jules Mondoloni
+Chemin de Rustinchetto au numéro un
+cinquante-trois allée Fuschia, vingt mille deux cent quatre-vingt-dix Borgo
+treize chemin de San Gavinu, vingt, six cents, Furiani
+neuf boulevard Général Giraud, vingt, deux cents à Bastia
+Voie Communale Ancienne Voie Ferrée, vingt mille deux cent quarante Ghisonaccia
+Allée Jaune, vingt, deux cent quatre-vingt-dix Borgo
+Quartier Piento, Furiani
+Cours Charles Jean Sarocchi à Aléria
+cent vingt-neuf ldt Serra Di Pigno
+Route de Ghisoni au numéro trois mille six cents
+soixante-dix route du Monte Pigno, vingt mille deux cent quatre-vingt-dix Borgo
+deux mille huit cent quarante-cinq route du Roi Théodore, vingt, deux cent soixante-dix, Aléria
+deux cent soixante-douze route d'Aregno, vingt, deux cent vingt à Aregno
+Route de Centu Chiave, vingt mille deux cent quatre-vingt-dix Borgo
+Route de Teppe Rosse, vingt, deux cent soixante-dix Aléria
+Lotissement Tozza Alta, Ventiseri
+Allée de Creno à Furiani
+six chemin Masckeri
+Rue Chanoine Letteron au numéro trente-quatre
+sept route du Monte d'Oro, vingt mille deux cent quatre-vingt-dix Borgo
+quatorze rue Strada Romana, vingt, deux cent quarante, Ghisonaccia
+cinquante-trois allée le Paglia Orba, vingt, six cents à Furiani
+Quartier A Riba, vingt mille six cents Furiani
+Boulevard Hyacinthe de Montera, vingt, deux cents Bastia
+Impasse de la Maraninca, Borgo
+Rue des Mulets à Bastia
+soixante-quatorze route de San-Martino
+Allées des Pins au numéro cinq
+mille deux cent soixante-cinq avenue de Borgo, vingt mille deux cent quatre-vingt-dix Borgo
+soixante-cinq route de Paglia Orba, vingt, deux cent quatre-vingt-dix, Borgo
+quatre-vingt-dix place du Mont Olmeli, vingt, deux cent quatre-vingt-dix à Borgo
+Route de la Lagune, vingt mille six cents Furiani
+Quartier Domijo, vingt, six cents Furiani
+Route de Sainte-Helene, Ghisonaccia
+Chemin de Monte-Carlo à Furiani
+quatre-vingt-dix rue du Lustincone
+Allée de l'Oriente au numéro trente-deux
+deux cent trente-quatre rue des Cardelines, vingt mille deux cent quarante Ghisonaccia
+vingt route du Cap, vingt, deux cents, San-Martino-di-Lota
+six boulevard Auguste Gaudin, vingt, deux cents à Bastia
+Rue de Pughjalellu, vingt mille deux cent quatre-vingt-dix Borgo
+Allée Monte Stello, vingt, six cents Furiani
+Allée A Sabina, Borgo
+Place des Amandiers à Borgo
+quinze place de la Tramontane un
+Montée des Aloès au numéro six
+douze allée des Pavots, vingt mille six cents Furiani
+vingt-quatre place Saint-François trois, vingt, deux cent quatre-vingt-dix, Borgo
+quatre chemin de la Porraja, vingt, deux cents à San-Martino-di-Lota
+Allée des Yuccas, vingt mille six cents Furiani
+Route du Fort de Toga, vingt, deux cents Ville-di-Pietrabugno
+Allée l'Amandier, Furiani
+Qur de l'Annonciade à Bastia

--- a/server/data/fr/addresses-30.csv
+++ b/server/data/fr/addresses-30.csv
@@ -1,0 +1,70 @@
+trois cent trente et un chemin de la Blanchonne, trente mille cinq cents Saint-Victor-de-Malcap
+trente chemin de l'Aire de Salle, trente, trois cent quarante, Rousson
+six lotissement le Clos des Camps, trente, trois cent soixante à Saint-Maurice-de-Cazevieille
+Avenue Paul Ravoux, trente mille quatre cents Villeneuve-lès-Avignon
+Chemin de la Combe des Oiseaux, trente, zéro zéro zéro Nîmes
+Chemin du Vallon de Cournet, Castillon-du-Gard
+Impasse Pascaline à Saint-Laurent-des-Arbres
+cent soixante-quinze route du Lavandin
+Montee de la Margue au numéro trente-sept BIS
+quatre-vingt-dix chemin de Reboulène, trente mille trois cent cinquante Lézan
+quarante-trois rue des Costières, trente, zéro zéro zéro, Nîmes
+un rue de la Grande Bourgade, trente, sept cents à Uzès
+Rue des Trois Pigeons, trente mille cent vingt Le Vigan
+Impasse Cavalerie, trente, cent Alès
+Chemin du Sanglier, Nîmes
+Rue Solimany à Saint-Gilles
+quatre-vingt-huit rue du Piquefate
+Rue Jozan au numéro cent quatre
+un rue Lou Sarraie, trente mille Nîmes
+deux impasse des Cigalons, trente, deux cent cinquante, Sommières
+vingt-huit chemin d'Aigues-Vives, trente, sept cent quarante au Cailar
+Rue d'Esparron, trente mille deux cent vingt Aigues-Mortes
+Avenue Jacques Duclos, trente, cinq cent vingt Saint-Martin-de-Valgalgues
+Chemin du Pont des Iles, Nîmes
+Lotissement l'Argile à Saint-Maurice-de-Cazevieille
+onze route de Lédignan
+Rue de Marcel Pagnol au numéro vingt-deux
+huit rue de la Gazelle, trente mille Nîmes
+cent quarante chemin de Saint-Etienne à Larnac, trente, cent, Alès
+soixante-neuf rue Claux Augier, trente, cent quatre-vingt-dix à Saint-Chaptes
+Impasse de la Rousseline, trente mille Nîmes
+Impasse du Bonheur, trente, six cent dix Sauve
+Rue Ruffi, Nîmes
+Rue d'Arbaud à Marguerittes
+deux allée des Anglores
+Rue Paul Aréne au numéro quatre
+cent soixante-huit rue Dieudonné Coste, trente mille Nîmes
+seize TER route des Marines, trente, deux cent quarante, Le Grau-du-Roi
+quarante et un rue des Manilles, trente, deux cent quarante au Grau-du-Roi
+Impasse de l'Armoise, trente mille Nîmes
+Rue du Camp de Bataille, trente, quatre cents Villeneuve-lès-Avignon
+Route de Générac, Aubord
+Impasse de la Montée de Silhol à Alès
+cent quatre-vingts chemin de Coste Ravelle
+Lotissement Le Clos de Castel au numéro quatre
+trente chemin des Pétunias, trente mille trois cent quarante Saint-Privat-des-Vieux
+quarante et un boulevard du Haut des Angles, trente, cent trente-trois, Les Angles
+neuf rue Colonel Denfert, trente, trois cent quatre-vingt-dix à Aramon
+Chemin du Mas de Borne, trente mille sept cent vingt Ribaute-les-Tavernes
+Rue de la Montée de la Place, trente, deux cent cinquante Lecques
+Avenue de Canale, Rodilhan
+Rue de Lamargue à Bagnols-sur-Cèze
+six rue du Général Sabatier
+Rue Cabanes au numéro cent trente-huit
+vingt-neuf rue d'Avéjan, trente mille cent Alès
+soixante-six rue Pierre-Babinot, trente, deux cent vingt, Saint-Laurent-d'Aigouze
+cinq rue Aramon, trente, deux cent vingt à Aigues-Mortes
+Rue du Phlomis, trente mille trois cents Beaucaire
+Rue de la Souleïado, trente, cent trente-deux Caissargues
+Impasse Pitot, Nîmes
+Rue Calendal au Grau-du-Roi
+quatre cent trente-quatre rue Etienne Lenoir
+Rue Roussy au numéro soixante-sept
+cinq lotissement Le Clos de Mardilhon, trente mille cinq cent soixante Saint-Hilaire-de-Brethmas
+cent soixante et onze chemin de Massariès, trente, cent quarante, Tornac
+six mille cent vingt-sept route de Villefort, trente, cinq cent vingt à Saint-Martin-de-Valgalgues
+Hameau du Mas de Clary, trente mille sept cents Baron
+Avenue Robert de Joly, trente, six cent vingt Uchaud
+Chemin de Massanes, Cassagnoles
+Rue André Gaches à Saint-Hippolyte-du-Fort

--- a/server/data/fr/addresses-31.csv
+++ b/server/data/fr/addresses-31.csv
@@ -1,0 +1,70 @@
+trois cent quarante-neuf chemin de Riouas, trente et un mille huit cent soixante Labarthe-sur-Lèze
+deux allée du Salas-Montjoie, trente et un, cinq cent vingt, Ramonville-Saint-Agne
+huit chemin de l'Oustalou, trente et un, cinq cent soixante-dix à Préserville
+Route du Born, trente et un mille trois cent quarante Villemur-sur-Tarn
+Rue Gilbert Cesbron, trente et un, cent Toulouse
+Rue Jean Gayral, Toulouse
+Route d'Eaunes à Muret
+six place de Lautat
+CHEMIN DE LA TOUR au numéro treize
+douze B aVENUE DE REVEL, trente et un mille six cent cinquante Saint-Orens-de-Gameville
+quatorze T sQUARE DES TILLEULS, trente et un, huit cent vingt, Pibrac
+six cent trois cHEMIN DE PEYRELONG, trente et un, huit cent quarante à Aussonne
+Chemin des Feuillets, trente et un mille quatre cent cinquante Montlaur
+RUE JASMIN, trente et un, cent trente Balma
+CHEMIN DE GAGNAC, Saint-Jory
+Rue du Colonel Toussaint à Toulouse
+trente et un chemin del Prat
+RUE DES CEVENNES au numéro vingt-six
+trois impasse Station Radio, trente et un mille quatre cent soixante-dix Fontenilles
+cinq rue Alexis Sevène, trente et un, six cents, Muret
+neuf rUE DE LA FENAISON, trente et un, sept cent quatre-vingts à Castelginest
+Rue de Chaussas, trente et un mille deux cents Toulouse
+Route de Saint-Clar, trente et un, six cents Lherm
+LOTISSEMENT L OREE DU BOIS, Aigrefeuille
+RUE FRANCOISE à Aucamville
+cinquante-deux rUE DES VIGNES
+IMPASSE DES TOURNESOLS au numéro cinquante-trois
+deux chemin du Carrey, trente et un mille cinq cent quatre-vingts Cazaril-Tambourès
+vingt et un rue Ringaud, trente et un, cinq cents, Toulouse
+trente-cinq route de Fronton, trente et un, six cent vingt à Villaudric
+IMPASSE CHATIVE, trente et un mille cent trente Flourens
+Rue Michaëlis, trente et un, cent vingt Roques
+Chemin des Aynats, Bouloc
+Avenue Saint-Germier à Muret
+trois chemin du Payrouillé
+ALLEE DES NYMPHEAS au numéro deux
+un rUE DU LAVOIR, trente et un mille sept cents Beauzelle
+dix-huit rOUTE DE CASTELMAUROU, trente et un, huit cent cinquante, Beaupuy
+dix rue San Pietro, trente et un, cent quatre-vingt-dix à Caujac
+CHEMIN DE BELDOU, trente et un mille cent cinquante Lespinasse
+Chemin de Cazaux, trente et un, deux cent dix Ponlat-Taillebourg
+Rue de la Tour de Nesle, Escalquens
+RUE AMBROISE PARE à Saint-Jean
+quarante et un rue Henri Ebelot
+Chemin de Bragnères Basses au numéro mille quatre cent quatre-vingt-cinq
+un rUE DU VALLON, trente et un mille huit cent cinquante Montrabé
+vingt-cinq rUE DES MONTS DES BOIS NOIRS, trente et un, deux cent quarante, L'Union
+vingt-six avenue de Rudelle, trente et un, six cents à Muret
+Chemin des Bourdettes, trente et un mille cent quatre-vingts Lapeyrouse-Fossat
+Rue d'Oradour sur Glane, trente et un, deux cents Toulouse
+Rue de Porte d'Engraille, Baziège
+RUE DU MARECHAL BERTHIER à Balma
+deux place Lange
+DEPARTEMENTALE huit cent vingt au numéro soixante-quinze
+quatre rUE ARNAUD GOULARD, trente et un mille cent quarante Launaguet
+trente rue Théodore Ozenne, trente et un, zéro zéro zéro, Toulouse
+treize iMPASSE LAMARTINE, trente et un, cent quarante à Aucamville
+Chemin des Agnets, trente et un mille quatre cent dix Noé
+RUE DE MANDELIEU, trente et un, deux cent quarante L'Union
+Rue Matabiau, Toulouse
+Rue du Docteur Étienne Gay à Toulouse
+deux iMPASSE DES CHENES
+Impasse du Professeur Henri Graillot au numéro cinq
+quatre rUE DE L EPERVIER, trente et un mille deux cent quarante L'Union
+neuf iMPASSE PAUL BAYLE, trente et un, deux cent quarante, Saint-Jean
+vingt-trois rue Pierre Contrasty, trente et un, six cent vingt à Fronton
+IMPASSE DORTIS, trente et un mille cent quarante Launaguet
+Rue Guillemin Tarayre, trente et un, zéro zéro zéro Toulouse
+RUE DES BOULBENES, Villeneuve-Tolosane
+Avenue Marcel Doret à Labarthe-sur-Lèze

--- a/server/data/fr/addresses-32.csv
+++ b/server/data/fr/addresses-32.csv
@@ -1,0 +1,70 @@
+six lotissement du Moutet, trente-deux mille cent trente Samatan
+dix-sept rue des Cotingas, trente-deux, zéro zéro zéro, Auch
+dix rue Aymeric de Panat, trente-deux, six cents à L'Isle-Jourdain
+Avenue Anselme Batbie, trente-deux mille deux cent soixante Seissan
+Rue Gavarret, trente-deux, cent Condom
+Impasse de Sauboires, Eauze
+Avenue de Daniate à Nogaro
+cinquante et un rue Adolphe Cadéot
+Avenue du Commandant Parisot au numéro huit
+treize rue Jeanne d'Albret, trente-deux mille Auch
+vingt-quatre résidence Alain Fournier, trente-deux, trois cents, Mirande
+quatre rue de Roques, trente-deux, cent à Condom
+Route de Bouau, trente-deux mille quatre cent quarante Castelnau-d'Auzan
+Résidence de Lézian, trente-deux, trois cents Mirande
+Quartier Le Bielle, Barcelonne-du-Gers
+Rue des Ardouens à Gondrin
+vingt-sept lotissement du Padevant deux
+Route de Marambat au numéro six
+quatorze avenue Pierre de Montesquiou, trente-deux mille Auch
+trois rue André Arnau, trente-deux, cinq cents, Fleurance
+huit rue des Wascons, trente-deux, cent quatre-vingt-dix à Vic-Fezensac
+Chemin de Tuco, trente-deux mille Auch
+Rue Désirat, trente-deux, zéro zéro zéro Auch
+Impasse Léche, Eauze
+Boulevard Lascours à Mirande
+cinquante et un chemin de Bigaoudère
+Rue Camille Catalan au numéro deux
+dix route de Sainte-Agathe, trente-deux mille quatre cent trente Saint-Cricq
+treize A rue Daudirac, trente-deux, quatre cents, Riscle
+dix-sept route de Ségoufielle, trente-deux, six cents à L'Isle-Jourdain
+Rue des Colombages, trente-deux mille cinq cent cinquante Pessan
+Allées Aristide Briand, trente-deux, cinq cents Fleurance
+Rue de Korntal, Mirande
+Lotissement La Talabère à Montaut-les-Créneaux
+trois mille deux cent cinquante-cinq chemin de Jeanchin
+Avenue Corral de Calatrava au numéro deux
+douze rue Odon de Terride, trente-deux mille quatre cent trente Cologne
+mille vingt-huit chemin de la Bordeneuve, trente-deux, six cents, Ségoufielle
+sept chemin de Mirateau, trente-deux, cent à Condom
+Rue Dessoles, trente-deux mille Auch
+Place de la Cathédrale, trente-deux, deux cent vingt Lombez
+Rue des Mousquetaires, Auch
+Place du Cubo Bousset à Jegun
+trois rue Brochain
+Rue Vieille Pousterle au numéro six
+mille huit cent quarante route de Vic, trente-deux mille Auch
+sept place Zaccharie Baqué, trente-deux, cent quatre-vingt-dix, Vic-Fezensac
+trente-trois avenue Edmond Bergès, trente-deux, cent quatre-vingt-dix à Vic-Fezensac
+Route de Nogaro, trente-deux mille sept cent vingt Vergoignan
+Rue du Sang, trente-deux, cinq cent cinquante Pavie
+Rue Roger Trémoulet, Fleurance
+Rue du quatre-vingt-huitème à Auch
+huit rue Lahire
+Rue Jean de Merat au numéro quinze
+sept rue Grichet, trente-deux mille cent Condom
+deux faubourg Bourbon, trente-deux, quatre cent trente, Cologne
+cent quatre-vingt-quinze chemin de l'Aoueilleron, trente-deux, six cents à Pujaudran
+Chemin de la Coustère, trente-deux mille six cents L'Isle-Jourdain
+Rue d'Estalens, trente-deux, cent dix Nogaro
+Chemin du Houga, Barcelonne-du-Gers
+Impasse de Teste à Condom
+trente-six BIS rue du Bataillon de l'Armagnac
+Place Mahomme au numéro trois BIS
+cinq rue de Riguepeu, trente-deux mille cent Condom
+un rue du Haget, trente-deux, zéro zéro zéro, Auch
+dix-sept boulevard Armand Praviel, trente-deux, six cents à L'Isle-Jourdain
+Chemin des Cabirots, trente-deux mille six cents L'Isle-Jourdain
+Rue Albin Bibal, trente-deux, cent quarante Masseube
+Chemin de Jeanton, Ségos
+Place Boué de Lapeyrere à Lectoure

--- a/server/data/fr/addresses-33.csv
+++ b/server/data/fr/addresses-33.csv
@@ -1,0 +1,70 @@
+quarante et un rue Colonel Grandier-Vazeille, trente-trois mille Bordeaux
+seize rue du Docteur Fauché, trente-trois, six cent soixante-dix, Créon
+quatre-vingt-dix avenue du Cap Ferret, trente-trois, cent vingt-sept à Saint-Jean-d'Illac
+Allée de Chappaz, trente-trois mille quatre cent soixante Arsac
+Lotissement Bouleaux de la Possession, trente-trois, trois cent quatre-vingts Marcheprime
+Rue Francis Planté, Pessac
+Rue Berruer à Bordeaux
+quarante-quatre rue Auguste Brutails
+Rue Chantecrit au numéro soixante-dix-huit
+seize avenue du Chemin de la Vie, trente-trois mille quatre cent quarante Ambarès-et-Lagrave
+dix rue de la Réousse, trente-trois, sept cent quarante, Arès
+sept rue de l'Amiral Besson, trente-trois, sept cent dix à Bourg
+Chemin Barreyres, trente-trois mille trois cent quatre-vingts Biganos
+Rue de l'Amiral Pierre Mouly, trente-trois, cent vingt Arcachon
+Rue Saint-Jean d'Etampes, Ayguemorte-les-Graves
+Allée du Petit Mestey à Gujan-Mestras
+vingt-trois quai Port de la Hume
+Route d'Arcachon au numéro quarante-quatre
+quinze rue de Ruat, trente-trois mille Bordeaux
+quarante cours de l'Yser, trente-trois, zéro zéro zéro, Bordeaux
+trente-trois rue Pierre Massieux, trente-trois, quatre cents à Talence
+Route de Gouas, trente-trois mille trois cent quatre-vingt-dix Cartelègue
+Rue Dubarry, trente-trois, cinq cent trente Bassens
+Chemin de Guérin, Salles
+Rue Bahus à Talence
+vingt-trois rue Paul Commarieu
+Allée de Grabasse au numéro douze
+trente-cinq rue de la Dune Pontac, trente-trois mille cent vingt Arcachon
+cent trente-six rue de Graney, trente-trois, quatre cent cinquante, Izon
+quarante-huit cours Georges Mandel, trente-trois, cinq cent quatre-vingt-dix à Saint-Vivien-de-Médoc
+Allée des Bruyères Cazaux, trente-trois mille cent quinze La Teste-de-Buch
+Cours Xavier Moreau, trente-trois, sept cent vingt Podensac
+Chemin du Biala, Cestas
+Rue Chante Cigale à Gujan-Mestras
+douze lotissement Les Moulins
+Rue Medecin Jean Vialar Goudou au numéro quatre-vingt-six
+cinq allée d'Anjou, trente-trois mille cinq cent dix Andernos-les-Bains
+neuf rue Dubrana, trente-trois, trois cent vingt, Eysines
+soixante et un rue Armand Sully Prudhomme, trente-trois, neuf cent quatre-vingts à Audenge
+Rue de Piget, trente-trois mille deux cent quatre-vingt-dix Ludon-Médoc
+Rue Fontaine du Bayle, trente-trois, cinq cent cinquante Le Tourne
+Allée de Moulerens, Gradignan
+Avenue des Galipes à La Teste-de-Buch
+un avenue de la Croix d'Hors
+Allée du Rivage au numéro douze
+huit cité de Caulet, trente-trois mille Bordeaux
+vingt-deux route de Roaillan, trente-trois, deux cent dix, Langon
+vingt-huit rue Formigé, trente-trois, cent dix au Bouscat
+Route de Langoiran, trente-trois mille cinq cent cinquante Capian
+Impasse du Moulin de Pelissey, trente-trois, cent soixante-dix Gradignan
+Avenue de Maubuisson, Carcans
+Rue André Pujol à Pessac
+douze rue Lageyre
+Rue de Malbos au numéro trente-trois
+vingt-cinq rue Félix-le-Carvennec, trente-trois mille sept cent quatre-vingts Soulac-sur-Mer
+six rue Lagueyte, trente-trois, six cent quatre-vingts, Lacanau
+onze rue Charles Nungesser, trente-trois, cent quinze à La Teste-de-Buch
+Impasse du Cuvier, trente-trois mille trois cent vingt Le Taillan-Médoc
+Route de Grimard, trente-trois, six cent soixante-dix Créon
+Rue Desplats, Talence
+Chemin Darnauran à Castelnau-de-Médoc
+six allée Antonio Canova
+Allée Tournesol au numéro quatre
+cinq rue Jean Soula, trente-trois mille Bordeaux
+onze rue Jean Pares, trente-trois, cent vingt-trois, Le Verdon-sur-Mer
+cent soixante et un lotissement Village des Pins, trente-trois, quatre cent soixante-dix à Gujan-Mestras
+Route du Port de Goulée, trente-trois mille trois cent quarante Valeyrac
+Chemin de Courtade, trente-trois, cent quatre-vingt-cinq Le Haillan
+Chemin de Vignac, Carignan-de-Bordeaux
+Rue Daniel Danet à Eysines

--- a/server/data/fr/addresses-34.csv
+++ b/server/data/fr/addresses-34.csv
@@ -1,0 +1,70 @@
+cinq route de l'Apparition, trente-quatre mille deux cent trente Saint-Bauzille-de-la-Sylve
+vingt-six rue des Troupes de Marines, trente-quatre, six cent soixante-dix, Baillargues
+dix-huit chemin de Pierrefiche, trente-quatre, quatre cent quatre-vingts à Laurens
+Rue du Docteur Pons, trente-quatre mille quatre cents Saint-Just
+Plan de l'Ormeau, trente-quatre, cent quatre-vingt-dix Ganges
+Rue du Flanc des Côteaux, Maraussan
+Allée des Sophoras à Pézenas
+dix rue Albert Magnelli
+Rue Guillaume Pellicier au numéro huit
+quatre-vingt-onze rue Maurice Le Boucher, trente-quatre mille Montpellier
+sept rue René Boyer, trente-quatre, cinq cents, Béziers
+deux rue de la Gorgue, trente-quatre, deux cent trente au Pouget
+Rue de la Cantarelle, trente-quatre mille sept cent trente Prades-le-Lez
+Allée Raymond Bussières, trente-quatre, zéro zéro zéro Montpellier
+Impasse des Montilles de Gaillardy, Agde
+Route de Fabrègues à Cournonterral
+deux rue du Four de la Nation
+Cami des Oeillades au numéro un
+neuf rue de la Citernette, trente-quatre mille trois cent quatre-vingts Viols-le-Fort
+dix-neuf avenue de Campagnan, trente-quatre, deux cent trente, Paulhan
+trois impasse de l'Aube, trente-quatre, trois cents à Agde
+Route de Capestang Rd onze, trente-quatre mille cinq cents Béziers
+Route de Mende, trente-quatre, zéro zéro zéro Montpellier
+Chemin de Parignoles, La Livinière
+Rue Toussaint Roussy à Sète
+deux cent dix-sept avenue Étienne-Frédéric Bouisson
+Impasse de Perregaux au numéro sept
+dix-sept avenue Pierre Azéma, trente-quatre mille cinq cent trente Montagnac
+huit cent vingt avenue du Père Soulas, trente-quatre, zéro zéro zéro, Montpellier
+quatorze chemin du Bragalou, trente-quatre, quatre cent quatre-vingt-dix à Murviel-lès-Béziers
+Avenue Roger Nathan Murat, trente-quatre mille trois cent dix Montady
+Avenue de Poussan, trente-quatre, sept cent soixante-dix Gigean
+Chemin du Vic, Magalas
+Rue de la Fouillade à Teyran
+dix-neuf impasse du Souvenir Français
+Lotissement Mas de la Pinede au numéro un
+cinq place des Marroniers, trente-quatre mille quatre cent soixante Cessenon-sur-Orb
+cent soixante-trois avenue Montpellier, trente-quatre, cinq cent vingt, Le Caylar
+quarante et un rue Antoine Di-Luca, trente-quatre, trois cents à Agde
+Rue Saint-Baudile, trente-quatre mille six cent quatre-vingt-dix Fabrègues
+Rue Claude Berthollet, trente-quatre, zéro zéro zéro Montpellier
+Rue Garenne, Sète
+Rue Pierre Lacans à Nissan-lez-Enserune
+quatre rue du Cirque
+Allée Maréchal de Lattre de Tassigny au numéro cent onze
+vingt et un rue du Labech, trente-quatre mille trois cents Agde
+quarante-trois rue Sire de Joinville, trente-quatre, deux cent cinquante, Palavas-les-Flots
+trois cent dix rue de Salaison, trente-quatre, zéro zéro zéro à Montpellier
+Cami du Mas d'Arnaud, trente-quatre mille cinq cent soixante Montbazin
+Rue Font Martin, trente-quatre, quatre cent soixante-dix Pérols
+Rue Porte Olivier, Béziers
+Rue Louis Figuier à Montpellier
+cinquante-cinq chemin des Amouries
+Rue Maguelone au numéro soixante-quatorze
+sept cent vingt-huit route du Mas Desport, trente-quatre mille quatre cents Lunel
+sept rampe des Moulins, trente-quatre, cinq cents, Béziers
+trois cent un chemin des Pibouls, trente-quatre, quatre cent cinquante à Vias
+Impasse Sainte-Brigitte, trente-quatre mille sept cent vingt-cinq Saint-André-de-Sangonis
+Avenue des Jockeys, trente-quatre, deux cent cinquante Palavas-les-Flots
+Rue Frascati, Montagnac
+Rue Eugène Cabrol à Valras-Plage
+un impasse des Hesperides
+Rue Charles Lindberg au numéro cent quatre-vingts
+douze route de Salelles, trente-quatre mille sept cents Le Bosc
+vingt-cinq lotissement Lou Roc, trente-quatre, cent vingt, Lézignan-la-Cèbe
+vingt-neuf rue Lunaret, trente-quatre, zéro zéro zéro à Montpellier
+Avenue de Badones, trente-quatre mille cinq cents Béziers
+Allée des Lavognes, trente-quatre, cent soixante-dix Castelnau-le-Lez
+Rue des Nénuphars, Pérols
+Rue du Docteur Mas à Maraussan

--- a/server/data/fr/addresses-35.csv
+++ b/server/data/fr/addresses-35.csv
@@ -1,0 +1,70 @@
+neuf rue du Pilote Hédouin, trente-cinq mille quatre cents Saint-Malo
+un allée de Kéréon, trente-cinq, cent trente-deux, Vezin-le-Coquet
+quarante-sept avenue Etienne et Marie Pinault, trente-cinq, sept cent quarante à Pacé
+Rue du Champ Guigneux, trente-cinq mille huit cents Saint-Briac-sur-Mer
+Boulevard de Laval, trente-cinq, cinq cents Vitré
+rue Honoré de Balzac, L'Hermitage
+Rue Marguerite Claudel à Saint-Malo
+quatre la Croix Auray
+Rue du Champ Gaudois au numéro onze
+vingt-deux rue Docteur Dordain et ses Fils, trente-cinq mille Rennes
+dix rue du Hameau de l'Abbaye, trente-cinq, sept cent soixante-dix, Vern-sur-Seiche
+quatre rue de La Croix Poulin, trente-cinq, cinq cent vingt à Melesse
+Square Lucien Rose, trente-cinq mille Rennes
+Boulevard de Rochebonne, trente-cinq, quatre cents Saint-Malo
+Rue de Bel-Orient, Vitré
+Allée du Ménez à Vitré
+dix-sept rue du Docteur Dordain
+Rue François Guihard au numéro vingt-quatre
+dix rue de la Jamette, trente-cinq mille six cent quatre-vingt-dix Acigné
+deux rue de la Dorangerie, trente-cinq, trois cents, Fougères
+onze rue du Vau Chalet, trente-cinq, huit cent trente à Betton
+Allée des Monts d'Arrée, trente-cinq mille cinq cents Vitré
+Rue Renault de la Marzelière, trente-cinq, quatre cent soixante-dix Bain-de-Bretagne
+Rue du Champ de la Roche, Monterfil
+Rue de Vern à Rennes
+seize launay Hyon
+rue Frédéric Benoist au numéro cent cinq
+quatorze rue des Vaux Parés, trente-cinq mille cinq cent dix Cesson-Sévigné
+huit rue Albert Gérard, trente-cinq, zéro zéro zéro, Rennes
+un le Tertre, trente-cinq, cent trente-deux à Vezin-le-Coquet
+Rue de la Ville-ès-Meniers, trente-cinq mille huit cents Dinard
+Rue de Barbine, trente-cinq, huit cents Dinard
+Rue Monseigneur Gry, Louvigné-du-Désert
+Rue de la Haute Guais à Dinard
+six BIS rue Jean Théard
+Rue de la Pommerais au numéro quarante-neuf
+treize résidence des Côteaux, trente-cinq mille cent trente-trois Laignelet
+vingt-deux rue de Lozier, trente-cinq, quatre cents, Saint-Malo
+onze rue Abbé Talvas, trente-cinq, quatre cent quatre-vingt-dix à Chauvigné
+Lotissement La Noë, trente-cinq mille quatre cent vingt La Bazouge-du-Désert
+Rue du Docteur Even, trente-cinq, cinq cent quatre-vingts Guichen
+Rue Nantaise, Janzé
+Rue des Dorelles à Bruz
+treize allée Doyen Alexandre Lamache
+Promenade du Gué Maheu au numéro trente-huit
+vingt-deux boulevard de la Motelle, trente-cinq mille cent trente-trois Lécousse
+seize rue Hellerie, trente-cinq, cinq cents, Vitré
+vingt-six rue de la Moutaudière, trente-cinq, trois cent soixante-dix à Étrelles
+Ruelle du Colombier, trente-cinq mille quatre cent vingt Saint-Georges-de-Reintembault
+Ménéhil, trente-cinq, huit cent cinquante Romillé
+Rue du Bosphore, Rennes
+Rue de Bout de Lande à Laillé
+trois rue Arthur Fontaine
+Rue du Pré aux Biches au numéro sept
+vingt-deux aLL DES FOUGERES, trente-cinq mille quatre cent quatre-vingts Guipry
+six rue des Lirons, trente-cinq, sept cent quarante, Pacé
+onze rue d'Échange, trente-cinq, zéro zéro zéro à Rennes
+Rue Martin Feuillée, trente-cinq mille Rennes
+Avenue de Moka, trente-cinq, quatre cents Saint-Malo
+Avenue Pierre Le Treut, Châteaugiron
+Rue Pierre Gillouard à La Bouëxière
+quatorze rue de la Gastinaye
+Rue Porte Saint-Léonard au numéro deux
+quatre allée Adolphe Orain, trente-cinq mille Rennes
+dix-neuf allée de Coïmbra, trente-cinq, zéro zéro zéro, Rennes
+seize allée de la Teurtais, trente-cinq, trois cents à Fougères
+Rue du Port-Hue, trente-cinq mille huit cents Saint-Briac-sur-Mer
+Rue Robert D'Arbrissel, trente-cinq, deux cent quarante Retiers
+Square de la Mettrie, Rennes
+Résidence Domaine des Chenes à Saint-Domineuc

--- a/server/data/fr/addresses-36.csv
+++ b/server/data/fr/addresses-36.csv
@@ -1,0 +1,70 @@
+cent trente-trois rue Ernest Pinard, trente-six mille deux cent dix Chabris
+vingt rue Gachet, trente-six, huit cents, Migné
+deux BIS chemin de la Baignade, trente-six, zéro zéro zéro à Châteauroux
+Route de Vaudouan, trente-six mille quatre cents Le Magny
+Rue de la Mare au Diable, trente-six, quatre cents La Châtre
+Espace Mendes France, Châteauroux
+Rue Roger Moisan à Chabris
+vingt-trois rue Henri de Rochefort
+Route de Chandelle au numéro cinq
+un route de Mouhers, trente-six mille trois cent quarante Cluis
+trois cent quatre-vingts avenue de La Châtre, trente-six, zéro zéro zéro, Châteauroux
+vingt-trois allée des Druides, trente-six, trois cent trente au Poinçonnet
+Route de Lothiers Gare, trente-six mille trois cent cinquante Luant
+Route de Courtioux, trente-six, deux cent trente Mers-sur-Indre
+Rue du Docteur Bauchet, Thevet-Saint-Julien
+Allée de la Mogador au Poinçonnet
+huit allée Paul Rué
+Rue Jérome Legrand au numéro deux
+vingt route de Claise, trente-six mille cinq cents Méobecq
+vingt-sept route du Guerriau, trente-six, cent, Issoudun
+quinze rue de Paumule, trente-six, deux cents au Pêchereau
+Chemin des Conges, trente-six mille deux cent soixante Reuilly
+Boulevard Croix-Normand, trente-six, zéro zéro zéro Châteauroux
+Rue de l'Orme Saint-Paterne, Issoudun
+Rue des Véveilles à Cluis
+deux les Touchettès
+Impasse de Maroux au numéro quatre
+vingt et un boulevard George Sand, trente-six mille Châteauroux
+quatre route de Buzançais, trente-six, huit cents, Saint-Gaultier
+vingt et un rue de Château Fort, trente-six, deux cent cinquante à Niherne
+Le Brunetin, trente-six mille trois cent trente Arthon
+Rue Théophile Nepveu, trente-six, huit cents Saint-Gaultier
+Rue Passageon, Châteauroux
+Place Agnès Sorel à Villiers
+quarante-six boulevard de la Vrille
+Chemin du Patureau au numéro sept
+quatre-vingt-treize rue Auclert-Descôttes, trente-six mille deux cents Argenton-sur-Creuse
+trente-sept rue Henri Prieuré, trente-six, quatre cents, Lacs
+quinze chemin de la Caillaudière, trente-six, six cents à Vicq-sur-Nahon
+Rue Alphonse Fleury, trente-six mille quatre cents La Châtre
+Rue Lézerat, trente-six, zéro zéro zéro Châteauroux
+Rue d'Acadie, Châteauroux
+Avenue Rollinat à Argenton-sur-Creuse
+huit route de Valençay
+Place du dix Juin mille neuf cent quarante-quatre au numéro douze
+trois chemin du Gourdon, trente-six mille deux cent trente Tranzault
+neuf route de Levroux, trente-six, cinq cents, Sougé
+quatre beauvais, trente-six, deux cents à Ceaulmont
+Rue de l'Abreuvoir de Maroux, trente-six mille deux cents Argenton-sur-Creuse
+Allée des Maisons Rouges, trente-six, trois cent trente Le Poinçonnet
+Rue de Bord-le-Creux, Saint-Denis-de-Jouhet
+Rue Lucien Coupet à Issoudun
+vingt-six avenue Thabaud Boislareine
+Rue Auguste Matheron au numéro dix-sept
+douze route de Marlanges, trente-six mille deux cent quatre-vingt-dix Saulnay
+onze impasse Sagot, trente-six, zéro zéro zéro, Châteauroux
+quatre BIS chemin du Guignier, trente-six, trois cent trente à Velles
+Allée des Cailloux, trente-six mille cent vingt Ardentes
+Rue Monte à Peine, trente-six, cent cinquante Vatan
+Rue du Préfet Dalphonse, Châteauroux
+Rue Bonnac à Clion
+huit chemin de Pellebuzan
+Rue de Marban au numéro vingt-trois
+dix-sept rue Roger Cazala, trente-six mille Châteauroux
+quatre chemin de Barmont, trente-six, cent, Issoudun
+quatorze avenue Maurice Rollinat, trente-six, deux cents à Ceaulmont
+Les Chocats, trente-six mille deux cents Badecon-le-Pin
+Rue de Caserne, trente-six, cent soixante Sainte-Sévère-sur-Indre
+Champs de Brande, La Pérouille
+Route de la Croix de Faslay à Luant

--- a/server/data/fr/addresses-37.csv
+++ b/server/data/fr/addresses-37.csv
@@ -1,0 +1,70 @@
+quarante-cinq chemin de Vitrie, trente-sept mille deux cent soixante-dix Véretz
+quarante rue de Feunet, trente-sept, deux cent vingt, Avon-les-Roches
+trois allée de Moncontour, trente-sept, zéro zéro zéro à Tours
+Rue de Moranne, trente-sept mille trois cent trente Channay-sur-Lathan
+Rue du Carroi Vau, trente-sept, deux cent trente Fondettes
+Rue de la Vienne, Parçay-sur-Vienne
+Impasse de la Bourdinerie à Vernou-sur-Brenne
+quarante route de Pernay
+Rue Cinq-Pères au numéro un
+cinq rue des Bulonnières, trente-sept mille deux cent trente Saint-Étienne-de-Chigny
+vingt et un rue de la Blandinière, trente-sept, cinq cents, La Roche-Clermault
+dix-sept rue des Belles Maisons, trente-sept, deux cent soixante-dix à Larçay
+Route de la Noiraie, trente-sept mille cinq cent trente Limeray
+Route de la Fuie, trente-sept, cent cinquante Épeigné-les-Bois
+Rue de Langeais, Saint-Cyr-sur-Loire
+Rue du Liget à Tours
+trente-neuf BIS rue Bellanger
+Le Baillin au numéro deux
+dix-sept chemin du Jard, trente-sept mille cinq cent cinquante Saint-Avertin
+vingt-huit rue Juan Miro, trente-sept, zéro zéro zéro, Tours
+treize rue Bretonneau, trente-sept, cinq cent quarante à Saint-Cyr-sur-Loire
+Rue du Maréchal Reille, trente-sept mille trois cent quatre-vingt-dix Cerelles
+Rue du Gué Romain, trente-sept, trois cent dix Reignac-sur-Indre
+Rue des Anciens AFN, Saint-Branchs
+Place Jean de Bueil à Bueil-en-Touraine
+quarante-trois allée de la Fouasserie
+Allée des Mariniers au numéro trente-cinq
+quarante-quatre boulevard Marchant Duplessis, trente-sept mille Tours
+treize rue d'Amboise, trente-sept, cent dix, Auzouer-en-Touraine
+quarante-six rue de Nazelles, trente-sept, quatre cents à Amboise
+Rue des Écoins, trente-sept mille cinq cents Chinon
+Rue de Grandlay, trente-sept, cent cinquante Bléré
+Rue de Barbeneuve, Loches
+Rue de la Logerie à Parçay-Meslay
+dix-huit rue Jean de la Barre
+Rue Tonnellé au numéro neuf
+trente-quatre rue des Basses Rivières, trente-sept mille deux cent dix Rochecorbon
+dix-sept quai Paul Bert, trente-sept, zéro zéro zéro, Tours
+douze rue Maurice Beaufils, trente-sept, sept cents à Saint-Pierre-des-Corps
+Rue du Morier, trente-sept mille cinq cent trente Limeray
+Rue du Puits Berthet, trente-sept, deux cent quatre-vingt-dix Preuilly-sur-Claise
+Rue des Fosses Rouges, Reignac-sur-Indre
+Rue François Delepine à Nazelles-Négron
+dix-sept rue de l'Adjudant Velin
+Place du Jardin d'Alençay au numéro trois
+vingt-huit rue Jehan Fouquet, trente-sept mille deux cent trente Fondettes
+treize rue Chanoine Noël Carlotti, trente-sept, trois cent vingt, Esvres
+vingt chemin de l'Harmerie, trente-sept, deux cent soixante-dix à Véretz
+Boulevard de Chinon, trente-sept mille trois cents Joué-lès-Tours
+Rue d'Athée sur Cher, trente-sept, cent cinquante Bléré
+Rue de la Bonleuvre, Auzouer-en-Touraine
+Chemin de la Pierre Bise à Montreuil-en-Touraine
+six rue du Tertre de l'Horloge
+Route de la Lussardière au numéro trois
+vingt les Noraies, trente-sept mille huit cents Marcilly-sur-Vienne
+vingt rue de la Levée de la Loire, trente-sept, cinq cent vingt, La Riche
+deux rue de la Quillonnière, trente-sept, deux cent dix à Parçay-Meslay
+Allée du Grand Clos, trente-sept mille trois cent soixante Saint-Antoine-du-Rocher
+Impasse de la Pièce des Viviers, trente-sept, deux cent cinquante Sorigny
+Rue de la Buhardière, Mettray
+Le Crucifix Vert à Courçay
+neuf rue de la Pointe Luneau
+Rue du Véron au numéro cent un
+vingt et un rue du Docteur Giraudet, trente-sept mille Tours
+trente-deux rue de la Comtesse de Ségur, trente-sept, sept cents, La Ville-aux-Dames
+six rue du Sénateur Belle, trente-sept, trois cent soixante à Rouziers-de-Touraine
+Rue Michel Petrucciani, trente-sept mille deux cent soixante-dix Montlouis-sur-Loire
+Route de la Mesliere, trente-sept, cinq cents Seuilly
+Avenue Louis le Bescam, Montbazon
+Rue François Richer à Tours

--- a/server/data/fr/addresses-38.csv
+++ b/server/data/fr/addresses-38.csv
@@ -1,0 +1,70 @@
+vingt-deux chemin du Lotissement la Plaine, trente-huit mille quatre cent soixante-dix Vinay
+deux cent trente-huit rue des Gaberts, trente-huit, sept cent soixante, Varces-Allières-et-Risset
+douze allée des Balcons, trente-huit, cent à Grenoble
+Route des Feytaux, trente-huit mille deux cent soixante-dix Lentiol
+Chemin de la Sonnière, trente-huit, huit cent cinquante Paladru
+Allée de Pré Mayen, Montbonnot-Saint-Martin
+Route de Salaise à Roussillon
+quatre impasse de Raffet
+Impasse des Terrasses de Muzias au numéro soixante-huit
+cinq cent soixante route de Valfroide, trente-huit mille six cent quatre-vingt-dix Colombe
+cinquante-cinq rue de Vezonne, trente-huit, sept cent quatre-vingts, Estrablin
+vingt et un montée de Champe, trente-huit, six cent vingt à Massieu
+Grande Rue de Torjonas, trente-huit mille cent dix-huit Saint-Baudille-de-la-Tour
+Rue des cinq Crêts, trente-huit, huit cent trente Saint-Pierre-d'Allevard
+Avenue Rochambeau, Grenoble
+Boulevard Docteur Valois à Renage
+trois cent soixante-douze route des Hôpitaux
+Route de la Croisette au numéro douze
+cent cinquante-huit impasse Auguste Ravier, trente-huit mille trois cent quarante Voreppe
+vingt et un rue Paul Janet, trente-huit, cent, Grenoble
+trois cent trente-quatre rue de la Pierre du Perron, trente-huit, cinq cent soixante à Jarrie
+Allée de Bethleem, trente-huit mille six cent dix Gières
+Route du Clodit, trente-huit, sept cent soixante-dix La Motte-d'Aveillans
+Chemin de Varvotier, Faverges-de-la-Tour
+Route du Meynat à La Chapelle-de-la-Tour
+deux cent deux rue du Docteur Robert
+Place de la Fûterie au numéro onze
+quatre allée des Deux Brions, trente-huit mille quatre cent cinquante Vif
+cent trente et un avenue du Granier, trente-huit, cinq cent trente, Pontcharra
+trente allée du Clos Maleissa, trente-huit, quatre cent quarante à Royas
+Chemin des Rayettes, trente-huit mille trois cent quarante Voreppe
+Chemin d'Eynoud, trente-huit, sept cent trente Chélieu
+Rue de l'Alpette, Le Pont-de-Beauvoisin
+Allée du Pré Vert à Pontcharra
+cent deux impasse du Haut Boyet
+Rue Jean Pellerin au numéro six cent soixante-dix-huit
+cent deux rue de Bouvardière, trente-huit mille trois cent quarante Voreppe
+quinze montée de Bullières, trente-huit, cinq cent soixante, Jarrie
+soixante et onze chemin de Champ Jaillet, trente-huit, cent quatre-vingt-dix à Bernin
+Rue Paviot, trente-huit mille cent vingt Saint-Égrève
+Chemin des Semaises, trente-huit, trois cent trente Saint-Ismier
+Chemin des Papagères, Les Éparres
+Route de Saint-Georges-de-Commiers à Champ-sur-Drac
+trois montée de l'Enclos
+Allée des Deux Mondes au numéro cinquante-quatre
+cinq cent soixante-quatre rue Château Dauphin, trente-huit mille cinq cent trente La Buissière
+sept cent quatre-vingt-deux chemin des Grandes Bruyères, trente-huit, cent vingt et un, Chonas-l'Amballan
+trente-quatre quai Xavier Jouvin, trente-huit, zéro zéro zéro à Grenoble
+Chemin du Suzon, trente-huit mille deux cent soixante Pommier-de-Beaurepaire
+Rue de Chamechaude, trente-huit, trois cent vingt Poisat
+Route de Cassejoie, Faverges-de-la-Tour
+Impasse du Furon à Sassenage
+cent quatre-vingt-dix-sept chemin du Bois Rival
+Rue des Georges au numéro treize
+quarante-deux BIS quai de France, trente-huit mille Grenoble
+trois cent soixante-dix rue de Chataignieres, trente-huit, huit cent quatre-vingt-dix, Vignieu
+quatre cent huit chemin de Bourchanin, trente-huit, trois cent quatre-vingt-dix à Bouvesse-Quirieu
+Chemin de Boulun, trente-huit mille deux cent dix Tullins
+Chemin des Grangettes, trente-huit, six cent soixante Lumbin
+Avenue de Chartreuse, Meylan
+Route de Faverges de la T à Saint-Clair-de-la-Tour
+quatre cent trente chemin Jullien
+Chemin de Malsouche au numéro cent
+vingt-huit rue du Foullet, trente-huit mille six cent quatre-vingt-dix Bévenais
+dix chemin du Funiculaire, trente-huit, six cent soixante, Saint-Hilaire
+onze chemin de Fond Ratel, trente-huit, six cent quarante à Claix
+Montée de Patan, trente-huit mille sept cent trente Chélieu
+Avenue des Jeux Olympiques, trente-huit, cent Grenoble
+Route du Saquet, Saint-Julien-de-Raz
+Rue Xavier Jouvin à Voreppe

--- a/server/data/fr/addresses-39.csv
+++ b/server/data/fr/addresses-39.csv
@@ -1,0 +1,70 @@
+un rue des Perchées, trente-neuf mille huit cents Poligny
+vingt-quatre rue d'Olivet, trente-neuf, cent dix, Salins-les-Bains
+deux rue du Champ Belland, trente-neuf, deux cents à Avignon-lès-Saint-Claude
+Rue Général Baratier, trente-neuf mille cent Dole
+Chemin de la Chaux Berthod, trente-neuf, trois cent dix Lamoura
+Chemin de Rosset, Choux
+Rue Jean Breuil à Arinthod
+cent vingt-sept rue de Charrière
+Rue des Grandes Carrières au numéro trente-neuf
+trente-huit B rue François Monin, trente-neuf mille cinq cent soixante-dix Montmorot
+sept route du Val d'Amour, trente-neuf, six cents, Écleux
+cent vingt-trois route de Lons-le-Saunier, trente-neuf, trois cents à Ney
+Rue du Vanneret, trente-neuf mille quatre cent soixante Foncine-le-Haut
+Route de Dole, trente-neuf, trois cent quatre-vingts Mont-sous-Vaudrey
+Rue de Guenebout, Jouhe
+Rue des Boisdels à Cuisia
+deux cent vingt-six rue des Tappes
+Charrière Baron au numéro cinq
+deux cent quatre-vingt-treize rue de la Lathe, trente-neuf mille cinq cent soixante-dix Perrigny
+treize rue du Louvot, trente-neuf, cent quarante, Nance
+six rue Jean Weber, trente-neuf, huit cents à Poligny
+Rue des Moutelles, trente-neuf mille cent Crissey
+Rue du Mattier, trente-neuf, cent trente Doucier
+Route de Chaussin, Saint-Baraing
+Rue Louis Grandchavin à Morez
+trente rue de Samerey
+Rue de Fleurier au numéro dix
+cent trente route de Juhans, trente-neuf mille cent quarante Arlay
+cinq rue du Processionnal, trente-neuf, deux cent cinquante, Mignovillard
+quatre B route du Deschaux, trente-neuf, trois cent quatre-vingts à Mont-sous-Vaudrey
+Rue Roger Merlin, trente-neuf mille huit cents Colonne
+Rue du Viseney, trente-neuf, cinq cent soixante-dix Mirebel
+Ruelle des Pitoux, Rahon
+Place sur la Chapelle à Lect
+neuf rue Jean Joseph Pallu
+Montée de l'Ermitage au numéro six BIS
+deux chemin de Bonlieu, trente-neuf mille deux cent trente Saint-Lothain
+onze rue des Poisets, trente-neuf, trois cents, Crotenay
+neuf rue des Turots, trente-neuf, trois cent quatre-vingts à La Vieille-Loye
+Rue de Peintre, trente-neuf mille deux cent quatre-vingt-dix Chevigny
+Impasse du Pertuis, trente-neuf, cent Baverans
+Chemin de Montenay, Lons-le-Saunier
+Rue Coquaine à Vosbles
+quatorze A avenue de Northwich
+Rue de Friquet au numéro onze
+onze rue du Déroube, trente-neuf mille cinq cent soixante-dix Vernantois
+sept rue Jean de Chalon, trente-neuf, deux cent quarante, Arinthod
+cinq rue des Chanerons, trente-neuf, cent quarante à Desnes
+Route de Maisod, trente-neuf mille deux cent soixante Charchilla
+Rue d'Azans, trente-neuf, cent Dole
+Route de Marignat, Chassal
+Rue des Caboulots à Tavaux
+six rue Parandier
+Route de l'Abergement au numéro vingt-huit
+seize chemin des Toupes, trente-neuf mille cinq cent soixante-dix Trenal
+un rue Lillette, trente-neuf, deux cent cinquante, Nozeroy
+trois champ du Rafourg, trente-neuf, cent dix à Pont-d'Héry
+La Petite Biolée, trente-neuf mille cent quatre-vingt-dix Cuisia
+Rue des Grand Vignes, trente-neuf, deux cent quatre-vingt-dix Rainans
+Rue de Grand Contour, Belmont
+Rue Alano Di Piave à Moirans-en-Montagne
+deux impasse Combernoz
+Rue du Petit-Montagna au numéro treize
+onze les Pessettes, trente-neuf mille cent cinquante Prénovel
+soixante-huit rue du Saulçois, trente-neuf, cent vingt, Petit-Noir
+quatre rue Lecourbe, trente-neuf, cent vingt à Chaussin
+Rue du Mont-Joly, trente-neuf mille cent Sampans
+Rue du Quart d'Avaux, trente-neuf, deux cent trente Passenans
+Rue d'Hauterive, Gevry
+Rue de la Bretenière à Authume

--- a/server/data/fr/addresses-40.csv
+++ b/server/data/fr/addresses-40.csv
@@ -1,0 +1,70 @@
+neuf cent six route de Tosse, quarante mille deux cent trente Saint-Vincent-de-Tyrosse
+vingt-quatre route de Boulins, quarante, deux cent trente, Josse
+sept cent trente-sept route de Gracian, quarante, cinq cent soixante à Vielle-Saint-Girons
+Route de Pomarez, quarante mille trois cent soixante Tilh
+Rue de Bascarry, quarante, deux cent soixante Castets
+Square Dous Casous, Messanges
+Route des Bordes de Haut à Hastingues
+mille cent quatre-vingt-dix-neuf route de Pignada-Pelay
+Rue Paul Ducournau au numéro seize
+onze rue Charles Bernadet, quarante mille cent Dax
+mille quarante-trois route de Commensacq, quarante, deux cent dix, Labouheyre
+quatre rue Francis James, quarante, cent trente à Capbreton
+Route de Monte Cristo, quarante mille deux cent trente Saubrigues
+Rue Paul Clément, quarante, deux cent trente Saint-Vincent-de-Tyrosse
+Rue Christophe Parabère, Grenade-sur-l'Adour
+Rue du Barrat à Saint-Lon-les-Mines
+six cent soixante et onze avenue d'Albret
+Rue de l'Arriou au numéro soixante
+cent soixante-quinze route de Ginx, quarante mille cent vingt Cachen
+mille quatre cent soixante et onze chemin de Garrelon, quarante, zéro zéro zéro, Mont-de-Marsan
+quarante chemin de Pinsoulet, quarante, six cents à Biscarrosse
+Chemin de Lausseignac, quarante mille trois cent quatre-vingts Gamarde-les-Bains
+Route du Hameau des cinq Cantons, quarante, trois cent quatre-vingt-dix Saint-André-de-Seignanx
+Avenue des Grands Lacs, Sanguinet
+Rue du Placot à Saint-Justin
+cent quarante-quatre avenue du Midou
+Route du Lacay au numéro neuf cents
+cent vingt-huit avenue de Pau, quarante mille cent cinquante Soorts-Hossegor
+deux cent quatre-vingt-huit chemin du Fidel, quarante, deux cent cinquante, Mugron
+deux mille cinq cent trois route de Dax, quarante, trois cent soixante à Pomarez
+Route de Perquie, quarante mille cent quatre-vingt-dix Arthez-d'Armagnac
+Avenue Auguste Duhau, quarante, cent quatre-vingts Bénesse-lès-Dax
+Avenue du Port d'Albret, Soustons
+Route de Peyrehorade à Saint-Pandelon
+vingt rue Alfred Longuefosse
+Route de Bouneau au numéro huit cent quatre-vingt-quatorze
+quatre allée René Barjavel, quarante mille Mont-de-Marsan
+deux impasse Lacay, quarante, quatre cents, Tartas
+trois cent quarante chemin des Esclaousoles, quarante, cinq cents à Montgaillard
+Route de Saint-Perdon, quarante mille deux cent quatre-vingts Benquet
+Allée des Mouliots, quarante, trois cents Peyrehorade
+Route de Crabeyron, Aureilhan
+Chemin du Gert à Pomarez
+quatre cent trente-neuf route de Lestrilles
+Chemin de Castera au numéro soixante-quinze
+cent douze avenue des Bergeronnettes, quarante mille cent cinquante Soorts-Hossegor
+neuf cent soixante-dix-huit route de Saint-Cricq, quarante, trois cents, Sorde-l'Abbaye
+cinq cent trente-deux avenue du Brassenx, quarante, cent dix à Ygos-Saint-Saturnin
+Route d'Orthez, quarante mille deux cent quatre-vingt-dix Estibeaux
+Chemin du Pont du Bos, quarante, trois cent soixante Pomarez
+Route des Bois de Larchets, Mimizan
+Route de Boudicq à Goos
+six cent vingt-huit route du Marensin
+Avenue de la Grande Dune au numéro sept cent soixante-deux
+cent dix-neuf route de Menauton, quarante mille trois cent quatre-vingts Onard
+mille soixante-six route de Pouy, quarante, cinq cents, Montaut
+cent quatre-vingts rue de Paile, quarante, cinq cent soixante à Vielle-Saint-Girons
+Avenue des Pibales, quarante mille cent cinquante Soorts-Hossegor
+Rue Charles Duvicq, quarante, deux cent trente Tosse
+Avenue du Marensin, Magescq
+Route de Yon à Garrosse
+vingt-six A rue du Général Lamarque
+Allée de la Chalosse au numéro onze
+cent quatre-vingt-deux allée de Brouhailles, quarante mille six cents Biscarrosse
+neuf cent vingt-sept route de Pouillon, quarante, trois cent cinquante, Gaas
+un rue Pierre Lisse, quarante, zéro zéro zéro à Mont-de-Marsan
+Route de Menroux, quarante mille quatre cent dix Pissos
+Route du Caloy, quarante, zéro quatre-vingt-dix Lucbardez-et-Bargues
+Route du Nel, Saint-Julien-en-Born
+Rue Lacabaille à Bretagne-de-Marsan

--- a/server/data/fr/addresses-41.csv
+++ b/server/data/fr/addresses-41.csv
@@ -1,0 +1,70 @@
+vingt-deux rue des Mangottes, quarante et un mille trois cent cinquante Saint-Claude-de-Diray
+deux rue d'Avigne, quarante et un, cent quarante, Thésée
+un rue David Douillet, quarante et un, huit cents à Montoire-sur-le-Loir
+Rue Georges Bontront, quarante et un mille trois cents Salbris
+Route de Cormeray, quarante et un, cent vingt Chitenay
+Rue Cassandre Salviati, Mer
+Chemin des Linereaux à Contres
+un place du huit Mai quarante-cinq
+Rue des Rancheries au numéro dix-sept
+six deux e Impasse du Glacis, quarante et un mille Blois
+soixante-seize rue des Hautes Granges, quarante et un, zéro zéro zéro, Blois
+cinq rue Marie Jousselin, quarante et un, cent vingt à Sambin
+Rue Réal des Prés, quarante et un mille deux cents Romorantin-Lanthenay
+Rue de Lamotte Beuvron, quarante et un, six cents Chaumont-sur-Tharonne
+Rue Avrain de Meung, La Ferté-Beauharnais
+Faubourg Chartrain à Vendôme
+trente-sept avenue Louis Chaumel
+Rue René Crozet au numéro deux cent quatre-vingts
+six BIS rue des Origères, quarante et un mille cent vingt Cormeray
+trois rue de la Tricanderie, quarante et un, deux cents, Romorantin-Lanthenay
+neuf rue Porte aux Dames, quarante et un, deux cents à Romorantin-Lanthenay
+Impasse des Boulayes, quarante et un mille Villebarou
+Allée de la Bigotterie, quarante et un, quatre cents Faverolles-sur-Cher
+Place des Carriers, La Chaussée-Saint-Victor
+Avenue de Salbris à Romorantin-Lanthenay
+deux rue du Bourg Saint-Jean
+Chemin des Grands Auvernats au numéro dix
+trois rue des Gilbardières, quarante et un mille cent dix Pouillé
+vingt-trois rue d'Audun, quarante et un, trois cent trente, Fossé
+deux BIS rue de Bas Foux, quarante et un, trois cent cinquante à Vineuil
+Route des Maugères, quarante et un mille quatre cents Faverolles-sur-Cher
+Quai Ulysse Besnard, quarante et un, zéro zéro zéro Blois
+Rue de la Gaudrie, Châtillon-sur-Cher
+Rue de Villerbon à La Chaussée-Saint-Victor
+cinquante-cinq rue Julien Nadau
+Place Roland Beaufrère au numéro soixante-neuf
+vingt-deux rue de la Blatière, quarante et un mille trois cent vingt Mennetou-sur-Cher
+cinq rue de l'Aulnière, quarante et un, trois cents, Souesmes
+trois rue Paulin Durand, quarante et un, trois cents à Salbris
+Rue de la Vallée Saint-Lubin, quarante et un mille trois cent trente Averdon
+Route de la Foltiere, quarante et un, quatre cents Angé
+Rue de Chémery, Mur-de-Sologne
+Rue des Sistrées à Soings-en-Sologne
+vingt-neuf rue de la Fosse d'Oille
+Chemin des Beaudries au numéro deux BIS
+huit rue du Clos Berger, quarante et un mille cent soixante Lignières
+un rue des Roies, quarante et un, cent trente, Selles-sur-Cher
+vingt-cinq rue de La Pierrette, quarante et un, cent à Naveil
+Rue des Mardelles, quarante et un mille deux cent cinquante Mont-près-Chambord
+Rue Ducoux, quarante et un, zéro zéro zéro Blois
+Rue de la Chambonnelle, Romorantin-Lanthenay
+Rue des Murlets à Selles-Saint-Denis
+dix rue Paul Renouard
+Boulevard Paul Boncour au numéro quinze D
+quatre rue des Fossés Jean Tirés, quarante et un mille cent cinquante Onzain
+trente-quatre rue Zélie Fauquet, quarante et un, trois cent vingt, Châtres-sur-Cher
+quatorze rue Maurice Hallé, quarante et un, deux cent quatre-vingt-dix à Oucques
+Rue Clos Saint-Barthélémy, quarante et un mille cent Saint-Ouen
+Route de Mosnes, quarante et un, quatre cents Vallières-les-Grandes
+Route du Bonveau, La Ferté-Saint-Cyr
+Rue de la Goualière à Blois
+seize chemin des Cotterelles
+Route de Contres au numéro cent soixante-dix-neuf
+quatre retour du Remenier, quarante et un mille Blois
+soixante-cinq rue de la Vilatte, quarante et un, cent trente, Billy
+quatorze rue des Javelles, quarante et un, deux cents à Romorantin-Lanthenay
+Rue Gilbert Michel, quarante et un mille quatre cents Saint-Georges-sur-Cher
+Rue des Guillonnières, quarante et un, trois cent cinquante Saint-Claude-de-Diray
+Rue des Fillettes, Chouzy-sur-Cisse
+Rue de Cabochon à Blois

--- a/server/data/fr/addresses-42.csv
+++ b/server/data/fr/addresses-42.csv
@@ -1,0 +1,70 @@
+cent vingt-neuf route de la Chabure, quarante-deux mille quatre cents Saint-Chamond
+trois cent soixante-quatorze rue Victor Dupré, quarante-deux, cent vingt, Commelle-Vernay
+cent trente-neuf vallon de Cotatay, quarante-deux, cinq cents au Chambon-Feugerolles
+Rue Peillon, quarante-deux mille cent cinquante-trois Riorges
+Impasse du Chant d'Oiseau, quarante-deux, six cent quatre-vingts Saint-Marcellin-en-Forez
+Impasse de la Vivaraize, Saint-Étienne
+Rue de la Tour de Varan à Firminy
+quatorze avenue du Grand Marais
+Rue du Gabion au numéro quatorze
+vingt et un rue Nicolas Perrin, quarante-deux mille sept cents Firminy
+cinquante-trois rue Saint-Alban, quarante-deux, trois cents, Roanne
+quatre-vingt-sept chemin du Pinay, quarante-deux, huit cents à Saint-Romain-en-Jarez
+Passage des Docteurs Charcot, quarante-deux mille deux cent quarante Unieux
+Allée des Hauts de la Mirandole, quarante-deux, trois cents Villerest
+Allée de l'Échauguette, Saint-Étienne
+Rue du Chagnon à Sail-sous-Couzan
+neuf place Antonin Vincent
+Rue Prof. Antoine Guerpillon au numéro seize
+neuf lotissement le Village des Bruyères, quarante-deux mille huit cents Rive-de-Gier
+dix-huit chemin de Toux, quarante-deux, huit cents, Genilac
+deux cent soixante-quatorze chemin des Olcas, quarante-deux, cent cinquante-cinq à Ouches
+Place Jacques Fougerat, quarante-deux mille six cent trente Régny
+Rue des Rives de Loire, quarante-deux, trois cents Villerest
+Rue de Trebande, Saint-Romain-la-Motte
+Jardin Pailler à Pouilly-les-Nonains
+douze rue Emile Noirot
+Route de Corbet au numéro cinq cent soixante et un
+quinze passage Rivier, quarante-deux mille cent vingt Le Coteau
+trente-huit route de L'Etrat, quarante-deux, deux cent soixante-dix, Saint-Priest-en-Jarez
+trente-sept route de Chavanne, quarante-deux, quatre cents à Saint-Chamond
+Rue Fernand Contandin, quarante-deux mille huit cents Tartaras
+Route de Couroulle, quarante-deux, cinq cent vingt Roisey
+Avenue du Charles de Gaulle, Sorbiers
+Chemin des Pellins à Pouilly-les-Nonains
+sept cent sept rue Pierre Dubreuil
+Place Jovin Bouchard au numéro huit
+trente-cinq chemin de l'Heurt, quarante-deux mille six cent dix Saint-Romain-le-Puy
+quatre rue Jean Servanton, quarante-deux, zéro zéro zéro, Saint-Étienne
+treize passage du Pré des Soeurs, quarante-deux, zéro zéro zéro à Saint-Étienne
+Allée Claude Laval, quarante-deux mille six cent cinquante Saint-Jean-Bonnefonds
+Rue de la Modure, quarante-deux, deux cent vingt Saint-Julien-Molin-Molette
+Rue des Jarretières, Andrézieux-Bouthéon
+Rue de Cadore à Roanne
+deux cent seize chemin du Gd Fossé Métral
+Rue Julien Vachet au numéro un
+six cent trente-cinq route de Grandchamp, quarante-deux mille six cents Pralong
+cinq rue Preynat, quarante-deux, zéro zéro zéro, Saint-Étienne
+vingt-deux route de Melay, quarante-deux, sept cent vingt à Briennon
+Rue Michel Devillaine, quarante-deux mille trois cents Roanne
+Rue de Sainte-Claire, quarante-deux, six cents Montbrison
+Boulevard Bergson, Roche-la-Molière
+Rue Sibert à Saint-Chamond
+dix route de Rivas
+Route du Chatar au numéro six cent cinquante et un
+quatre allée des Chataîgniers, quarante-deux mille trois cent quatre-vingt-dix Villars
+trente-deux clos Bel Air, quarante-deux, cent vingt, Commelle-Vernay
+cent quarante-neuf allée Bel Horizon, quarante-deux, cent cinquante-cinq à Saint-Léger-sur-Roanne
+Boulevard Henri Sénéclauze, quarante-deux mille deux cent vingt Bourg-Argental
+Rue Beaunier, quarante-deux, zéro zéro zéro Saint-Étienne
+Route des Ports de Saint-Just, Saint-Genest-Lerpt
+Rue Cécile Sauvage à Saint-Étienne
+cinq cent cinquante-huit route de la Durèze
+Rue René Mahinc au numéro trente-six
+un allée du Moulin de Saint-Paul, quarante-deux mille quatre cent quatre-vingts La Fouillouse
+vingt-trois chemin de Beautin, quarante-deux, cinq cent vingt, Roisey
+quatorze la Petite Gorge, quarante-deux, quatre cent dix à Chavanay
+Rue du Cygne Sauvage, quarante-deux mille deux cent quatre-vingt-dix Sorbiers
+Rue des Trois Meules, quarante-deux, zéro zéro zéro Saint-Étienne
+Rue Puerto Lumbreras, Mably
+Rue de la Roche du Mas à Saint-Christo-en-Jarez

--- a/server/data/fr/addresses-43.csv
+++ b/server/data/fr/addresses-43.csv
@@ -1,0 +1,70 @@
+quatre faubourg des Carmes, quarante-trois mille Le Puy-en-Velay
+douze rue Charles Rocher, quarante-trois, zéro zéro zéro, Le Puy-en-Velay
+dix chemin Plom, quarante-trois, trois cent quatre-vingt-dix à Vézézoux
+Rue de la Roche Arnaud, quarante-trois mille Le Puy-en-Velay
+Avenue de Vals, quarante-trois, sept cent cinquante Vals-près-le-Puy
+Rue de Luzy, Tence
+Chemin de Peyrelas à Sainte-Sigolène
+dix-sept rue Guillaume de la Roue
+Rue Via Strada au numéro cinquante-deux
+quatre avenue de Roderie, quarante-trois mille Aiguilhe
+quatre route de Jumeaux, quarante-trois, trois cent quatre-vingt-dix, Vézézoux
+quatre route de la Roche des Taillas, quarante-trois, six cents à Sainte-Sigolène
+Rue Chaussade, quarante-trois mille cent vingt Monistrol-sur-Loire
+Rue Via Bolen, quarante-trois, trois cent cinquante Borne
+Rue du Coteau des Bories, Brives-Charensac
+Avenue d'Ours Mons au Puy-en-Velay
+quatorze rue des Vios
+Route de Cornassac au numéro vingt-cinq
+trente-six boulevard Vercingétorix, quarante-trois mille cent Brioude
+un rue Bayon, quarante-trois, deux cent quarante, Saint-Just-Malmont
+dix-huit rue de Genebret, quarante-trois, sept cents à Brives-Charensac
+Rue de la Pelote, quarante-trois mille sept cents Saint-Germain-Laprade
+Chemin de la Girette, quarante-trois, sept cent cinquante Vals-près-le-Puy
+Grand Place Grand Place, Saint-Didier-en-Velay
+Lotissement La Côte à Dunières
+quatre rue d'Annonay
+Place du Planet de la Croix au numéro six
+dix-sept rue du Bas-Vernay, quarante-trois mille deux cent quarante Saint-Just-Malmont
+onze lotissement Tilleuls, quarante-trois, cent vingt, Monistrol-sur-Loire
+quatorze chemin des Bruyérettes, quarante-trois, six cents à Sainte-Sigolène
+Rue Vibert, quarante-trois mille Le Puy-en-Velay
+Rue des Genebrades, quarante-trois, sept cents Blavozy
+Rue d'Arfeuil, Yssingeaux
+Chemin de la Chalm à Arsac-en-Velay
+trente-quatre route de la Vernelle
+Avenue de la Cathédrale au numéro sept
+cinquante-deux B route de Saugues, quarante-trois mille Espaly-Saint-Marcel
+vingt-neuf rue Langlade, quarante-trois, cent cinquante, Le Monastier-sur-Gazeille
+dix impasse de Courbières, quarante-trois, sept cents à Saint-Germain-Laprade
+Lotissement Cote Vieille, quarante-trois mille deux cent quarante Saint-Just-Malmont
+Rue de la Saulnerie Vieille, quarante-trois, zéro zéro zéro Le Puy-en-Velay
+Rue de la Bassevialle, Saint-Maurice-de-Lignon
+Rue des Dourlioux à Vézézoux
+trente-neuf avenue de la Broussillonne
+Route de Nurlet au numéro dix-huit
+trois BIS place Maréchal Noël de Jourda Devaux, quarante-trois mille cent vingt Monistrol-sur-Loire
+trente-deux avenue du Val Vert, quarante-trois, zéro zéro zéro, Le Puy-en-Velay
+trois route de Reveyrolles, quarante-trois, six cents à Sainte-Sigolène
+Rue Coursière de Bellevue, quarante-trois mille trois cents Langeac
+Quartier de Saignecroze, quarante-trois, deux cents Yssingeaux
+Route de Lubières, Vergongheon
+Chemin des Bachats à Bas-en-Basset
+vingt chemin de la Ribeyre
+Route des Gorges de la Loire au numéro dix
+dix-neuf lotissement La Croix des Rameaux, quarante-trois mille six cents Sainte-Sigolène
+sept rue Porte Aiguière, quarante-trois, zéro zéro zéro, Le Puy-en-Velay
+vingt-quatre rue de Corsac, quarante-trois, sept cents à Brives-Charensac
+Lotissement La Chabanne, quarante-trois mille sept cents Saint-Germain-Laprade
+Boulevard Président Bertrand, quarante-trois, zéro zéro zéro Le Puy-en-Velay
+Rue Pierre Moulin, Saint-Just-Malmont
+Chemin des Pâtres à Sainte-Florine
+trente-deux rue Notre-Dame de l'Oratoire
+Rue de l'Arkose au numéro vingt-neuf
+trois chemin de Lourette, quarante-trois mille deux cent dix Bas-en-Basset
+dix-huit avenue Veron de la Combe, quarante-trois, cent quarante, Saint-Didier-en-Velay
+quinze rue des Maissard, quarante-trois, sept cents à Blavozy
+Route du Ramel, quarante-trois mille deux cents Saint-Maurice-de-Lignon
+Impasse des Olliers, quarante-trois, trois cents Langeac
+Chemin de Bayle, Aurec-sur-Loire
+Boulevard Saint-Roch à Aurec-sur-Loire

--- a/server/data/fr/addresses-44.csv
+++ b/server/data/fr/addresses-44.csv
@@ -1,0 +1,70 @@
+six rue Jean-Louis Lagrange, quarante-quatre mille sept cents Orvault
+cinq place Notre-Dame du Chatellier, quarante-quatre, trois cent dix, Saint-Lumine-de-Coutais
+quatre-vingt-huit rue de Trignac, quarante-quatre, six cents à Saint-Nazaire
+Rue du Moulin de Toulon, quarante-quatre mille cent soixante-dix Nozay
+Avenue de Suroit, quarante-quatre, zéro zéro zéro Nantes
+Chemin de Siriff, Saint-Nazaire
+Rue du Capitaine Robert Martin à Frossay
+vingt-neuf rue Général Botha
+Impasse du Seigle au numéro trois
+trois rue de Subrette, quarante-quatre mille deux cent quatre-vingt-dix Guémené-Penfao
+cinq cent quatre-vingt-dix-huit route de Clisson, quarante-quatre, cent vingt, Vertou
+dix-neuf boulevard Gustave Roch, quarante-quatre, zéro zéro zéro à Nantes
+Rue de l'Étier, quarante-quatre mille six cent vingt La Montagne
+Languin - Le Doussais, quarante-quatre, trois cent quatre-vingt-dix Nort-sur-Erdre
+Rue Gulliver, La Chapelle-sur-Erdre
+Route de la Colinerie à Pornic
+trois impasse de la Boisselée
+Rue Théodore Patry au numéro quatorze
+six rue de la Florie, quarante-quatre mille deux cent soixante Prinquiau
+six mille cent soixante-quinze route de la Noë Nozou, quarante-quatre, huit cent soixante, Saint-Aignan-Grandlieu
+sept impasse des Baladins, quarante-quatre, sept cent soixante à La Bernerie-en-Retz
+Rue de Saint-Molf, quarante-quatre mille quatre cent vingt Mesquer
+Avenue du Chêne Gala, quarante-quatre, quatre cents Rezé
+Route des Terres Quartières, Bouaye
+Chemin du Pré Rival à Herbignac
+soixante-neuf route de Prézégat
+Avenue Moreau au numéro trente
+quatorze boulevard Pierre de Maupertuis, quarante-quatre mille six cents Saint-Nazaire
+quarante-six rue du Pontereau, quarante-quatre, zéro zéro zéro, Nantes
+cinq rue d'Aurelle de Paladines, quarante-quatre, zéro zéro zéro à Nantes
+Avenue des Redellières, quarante-quatre mille quatre cents Rezé
+Allée des Consuls, quarante-quatre, trois cent cinquante Guérande
+Route du Fan, La Turballe
+Cour des Automates à Nantes
+seize allée des Petits Brivins
+Cour des Paludiers au numéro deux
+cinquante-cinq allée Louis Daquin, quarante-quatre mille six cents Saint-Nazaire
+dix-huit rue Cheviré, quarante-quatre, zéro zéro zéro, Nantes
+seize rue Kervégan, quarante-quatre, zéro zéro zéro à Nantes
+Rue de la Croix Joselle, quarante-quatre mille deux cent dix Pornic
+Rue Jean de Brunhoff, quarante-quatre, sept cents Orvault
+Rue de Paimboeuf, Saint-Père-en-Retz
+Rue Lucien Aubert à Nantes
+cent soixante-douze rue du Roi Albert un er
+Rue Pierre Fleury au numéro soixante et un
+soixante-quatre avenue de la Prinais, quarante-quatre mille deux cent cinquante Saint-Brevin-les-Pins
+trente-huit rue de Briord, quarante-quatre, sept cent dix, Port-Saint-Père
+trente et un rue des Ceps de Vignes, quarante-quatre, huit cent cinquante au Cellier
+Rue de l'Abbé Fourage, quarante-quatre mille cent quatre-vingt-dix Gorges
+Rue du Savetier, quarante-quatre, sept cents Orvault
+Rue Robert Mankel, Vertou
+Route de Bréhadour à Guérande
+cinq rue de la Gare de Chantenay
+Rue de la Tortière au numéro quatorze
+deux route de Vertou, quarante-quatre mille Nantes
+neuf place d'Herbauges, quarante-quatre, cent dix-huit, La Chevrolière
+deux cent quarante-sept rue des Maîtres, quarante-quatre, cent cinquante à Saint-Géréon
+Rue des Terres-Neuvas, quarante-quatre mille trois cent quarante Bouguenais
+Rue du Faubourg de Béré, quarante-quatre, cent dix Châteaubriant
+Impasse de la Tanzanite, Aigrefeuille-sur-Maine
+Impasse Pierre Le Bloch à Saint-Brevin-les-Pins
+onze avenue Cottineau
+La Bricaudière au numéro quarante-six
+dix impasse de la Goulonnière, quarante-quatre mille deux cent trente Saint-Sébastien-sur-Loire
+onze rue Fernand Pineau-Chaillou, quarante-quatre, zéro zéro zéro, Nantes
+vingt et un allée des Vosges, quarante-quatre, deux cent cinquante à Saint-Brevin-les-Pins
+Rue Élie Delaunay, quarante-quatre mille Nantes
+Rue du Pont de Men, quarante-quatre, quatre cent dix Herbignac
+Rue de la Sinière, Couëron
+Rue Lanoue Bras de Fer à La Chapelle-sur-Erdre

--- a/server/data/fr/addresses-45.csv
+++ b/server/data/fr/addresses-45.csv
@@ -1,0 +1,70 @@
+vingt-six rue de Lisledon, quarante-cinq mille sept cents Villemandeur
+huit rue Neuve Tudelle, quarante-cinq, zéro zéro zéro, Orléans
+cinquante-deux chemin de Chaingy, quarante-cinq, cent quarante à Saint-Jean-de-la-Ruelle
+Sentier des Grès, quarante-cinq mille cent trente Huisseau-sur-Mauves
+Rue de Caciacus, quarante-cinq, quatre cent trente Chécy
+Rue Marcel Belot, Olivet
+Rue de Bou à Mardié
+trois rue du Decau
+Rue du Razoir au numéro quarante-huit
+quatre-vingt-trois rue de la Malécotière, quarante-cinq mille quatre cent trente Chécy
+cinquante-quatre rue Geneviève Perrier, quarante-cinq, cent soixante, Olivet
+neuf rue du Baillou, quarante-cinq, trois cent dix à Villamblain
+Rue de la Pierre Aux Fées, quarante-cinq mille cent vingt Cepoy
+Rue Abbé Pasty, quarante-cinq, cent trente Baule
+Rue des Mobiles de la Charente, Chambon-la-Forêt
+Rue du Clos des Alouettes à Boynes
+huit chemin de Mellerettes
+Rue de Montaran au numéro mille cinq cent deux
+deux rue de Béraire, quarante-cinq mille trois cent quatre-vingts La Chapelle-Saint-Mesmin
+mille huit cent quatre-vingt-dix route de Jargeau, quarante-cinq, six cent quarante, Sandillon
+seize BIS rue aux Ligneaux, quarante-cinq, zéro zéro zéro à Orléans
+Avenue de la Pierre du Carreau, quarante-cinq mille deux cent vingt Saint-Germain-des-Prés
+Rue d'Égypte, quarante-cinq, deux cent cinquante Ouzouer-sur-Trézée
+Rue du Petit Pailly, La Chapelle-Saint-Mesmin
+Rue de Chivache à Ingré
+deux cent vingt rue de la Fassière
+Rue de Crowborough au numéro cinquante
+vingt rue Grant Montvilliers, quarante-cinq mille trois cents Escrennes
+quatre rue des Haudières, quarante-cinq, six cents, Villemurlin
+neuf rue des Cherrières, quarante-cinq, cent trente au Bardon
+Rue Clément Baudeau, quarante-cinq mille sept cents Villemandeur
+Rue de Chantaloup, quarante-cinq, trois cents Dadonville
+Avenue Dauphine, Orléans
+Rue d'Artenay à Sougy
+six hameau du Moulois
+Hameau de Nestin au numéro cent dix-sept
+cent soixante et un allée de la Tournière, quarante-cinq mille sept cent soixante-dix Saran
+douze route de Molaine, quarante-cinq, cinq cent dix, Tigy
+huit rue du Pré Cormier, quarante-cinq, deux cent soixante à Vieilles-Maisons-sur-Joudry
+Route de Courcy, quarante-cinq mille cent soixante-dix Chilleurs-aux-Bois
+Rue de Montargis, quarante-cinq, cent quatre-vingt-dix Cravant
+Rue de Gaucourt, Orléans
+Rue des Hautes Guignères à Tavers
+dix impasse de la Croix Saint-Fiacre
+Route de Férolles au numéro quarante-deux
+quatre chemin de Bardilly, quarante-cinq mille trois cent quatre-vingt-dix Desmonts
+cinquante-neuf rue des Hauts-Champs, quarante-cinq, zéro zéro zéro, Orléans
+trente rue de Sougy, quarante-cinq, cinq cent vingt à Chevilly
+Chemin de la Bruère, quarante-cinq mille cent trente Meung-sur-Loire
+Rue des Tacreniers, quarante-cinq, sept cent cinquante Saint-Pryvé-Saint-Mesmin
+Rue du Sicantin, Saint-Denis-en-Val
+Route d'Ouvrouer Les Champs à Tigy
+trente-deux route Rd deux mille sept
+Route de St Martin au numéro dix-sept
+vingt-huit chemin Vert du Blénois, quarante-cinq mille cent trente Meung-sur-Loire
+cent quatre-vingt-dix rue Paulin Labarre, quarante-cinq, cent soixante, Olivet
+deux route de Montargis, quarante-cinq, sept cents à Chevillon-sur-Huillard
+Rue des Murlins, quarante-cinq mille Orléans
+Rue Jean Wiener, quarante-cinq, quatre cents Fleury-les-Aubrais
+Rue des Boudeaux, Nesploy
+Rue de Montabuzard à Ingré
+huit cent un rue Léon Plancheron
+Rue du Chemin Bessier au numéro huit
+un rue de la Bretauche, quarante-cinq mille quatre cent cinquante Fay-aux-Loges
+vingt route de Pithiviers, quarante-cinq, trois cents, Sermaises
+quinze rue des Chaffauts, quarante-cinq, trois cent quatre-vingts à La Chapelle-Saint-Mesmin
+Rue de la Marine de Loire, quarante-cinq mille Orléans
+Route d'Olivet, quarante-cinq, cent soixante Ardon
+Rue de Poily, Outarville
+Rue Serin Moulin à Jargeau

--- a/server/data/fr/addresses-46.csv
+++ b/server/data/fr/addresses-46.csv
@@ -1,0 +1,70 @@
+vingt rue Ernest Marcouly, quarante-six mille sept cents Puy-l'Évêque
+trente-quatre rue de Bournazel, quarante-six, cinq cents, Gramat
+onze rue Gaston Lavigne, quarante-six, cent à Figeac
+Impasse la Carriera, quarante-six mille Cahors
+Place de la Balmelle, quarante-six, cinq cents Gramat
+Rue René Lafargue, Prayssac
+Rue du quarante-cinq e Parallèle à Gignac
+trente-cinq rue Feydel
+Boulevard des Érables au numéro seize
+un rue Henri Alleg, quarante-six mille cent trente Biars-sur-Cère
+trois rue Jacques Chapou, quarante-six, cent trente, Biars-sur-Cère
+cent quatre-vingt-quatre rue du Plein Sud, quarante-six, zéro quatre-vingt-dix à Lamagdelaine
+Allées du Fajal, quarante-six mille deux cent trente Lalbenque
+Avenue Gaston Monnerville, quarante-six, quatre cents Saint-Céré
+Rue Cyprien Tillet, Figeac
+Rue des Scafignous à Puy-l'Évêque
+deux cent deux avenue Jean Lurçat
+Avenue Fernand Pezet au numéro dix-sept
+cinq rue des Canabals, quarante-six mille quatre-vingt-dix Espère
+soixante-neuf rue les Terrrases Vaxis, quarante-six, zéro zéro zéro, Cahors
+six cent quarante-six route de Saint-Cirice, quarante-six, zéro zéro zéro à Cahors
+Avenue Président Georges Pompidou, quarante-six mille cent Figeac
+Avenue du Maréchal Bessières, quarante-six, deux cent vingt Prayssac
+Chemin de Peyrerufe, Lalbenque
+Côte de Nouret à Cahors
+un rue du Grial
+Rue de Colomb au numéro seize
+cinquante-deux rue du Général Ambert, quarante-six mille quatre cents Saint-Céré
+vingt BIS rue du Commandant Poirier, quarante-six, sept cents, Puy-l'Évêque
+quarante-trois rue Fouillac, quarante-six, zéro zéro zéro à Cahors
+Impasse de la Sourdoire, quarante-six mille cent dix Vayrac
+Rue Saint-Géry, quarante-six, zéro zéro zéro Cahors
+Boulevard de Tour-de-Ville, Cajarc
+Route de Hautesserre à Flaujac-Poujols
+dix rue de Denny
+Chemin de Fréjavise au numéro trois cent vingt-huit
+douze rue de Panafé, quarante-six mille cent Figeac
+six rue Pierre Bugat, quarante-six, cent, Figeac
+quatre-vingt-douze rue du Pech Barriat, quarante-six, deux cent trente à Lalbenque
+Rue Lacam, quarante-six mille trois cents Gourdon
+Avenue Anatole-de-Monzie, quarante-six, quatre cents Saint-Céré
+Rue de Lugagnac, Limogne-en-Quercy
+Avenue de Montviguier à Figeac
+neuf cent soixante et onze route du Puy de Mont
+Rue des Deux Pigeonniers au numéro onze
+cinquante-neuf impasse le Gary, quarante-six mille quatre cents Saint-Laurent-les-Tours
+deux passage de Pleysse, quarante-six, huit cents, Montcuq
+cent huit rue Jean Baptiste Delpech, quarante-six, zéro zéro zéro à Cahors
+Avenue Jean Admirat, quarante-six mille trois cents Gourdon
+Rue du Grimpadou, quarante-six, huit cents Montcuq
+Rue de Vidaillac, Limogne-en-Quercy
+Rue Saint-Barthelémy à Cahors
+deux cent trente-deux route de l'Acqueduc
+Route de la Tour de Vayrols au numéro neuf cent trente-cinq
+quinze passage Lacapelle, quarante-six mille Cahors
+quatorze côte de la Roussille, quarante-six, zéro quatre-vingt-dix, Pradines
+quarante chemin Rhode, quarante-six, zéro quatre-vingt-dix à Flaujac-Poujols
+Rue du Cuzoul, quarante-six mille cent soixante Cajarc
+Impasse Bergougnoux, quarante-six, cent quarante Sauzet
+Avenue du Tumulus, Gramat
+Boulevard Mainiol à Gourdon
+sept BIS boulevard du Colonel Teulié
+Avenue Anatole de Monzie au numéro six cent vingt-sept
+quatre-vingt-dix-huit chemin du Commandant Lavaysse, quarante-six mille quatre cents Saint-Céré
+six mille quatre cent quatre-vingt-onze route de Monteil, quarante-six, quatre cents, Saint-Céré
+deux cent neuf rue Alfred Filliol, quarante-six, trois cents à Gourdon
+Route de Montdoumerc, quarante-six mille deux cent trente Lalbenque
+Rue Garrezac, quarante-six, quatre cents Saint-Céré
+Rue de Montmartre, Montcuq
+Rue Figeacaise à Bagnac-sur-Célé

--- a/server/data/fr/addresses-47.csv
+++ b/server/data/fr/addresses-47.csv
@@ -1,0 +1,70 @@
+deux cent quatre rue Raymond Peydecastaing, quarante-sept mille cent quatre-vingts Meilhan-sur-Garonne
+sept rue des Rondes Saint-Louis, quarante-sept, zéro zéro zéro, Agen
+treize rue Charles Pujos, quarante-sept, quatre cents à Tonneins
+Rue Roger Bissière, quarante-sept mille deux cent dix Villeréal
+Rue Cardonet, quarante-sept, trois cent quatre-vingts Monclar
+Boulevard des Ormeaux, Clairac
+Place Lachapelle à Lamontjoie
+vingt-neuf BIS avenue Jean Claude Cayrel
+Rue de Daubas au numéro soixante
+trente-quatre avenue des Martyrs Resistanc, quarante-sept mille deux cents Marmande
+onze BIS chemin du Rechou, quarante-sept, trois cent dix, Aubiac
+cent cinquante-huit avenue Georges Delpech, quarante-sept, zéro zéro zéro à Agen
+Chemin Mole Daspe, quarante-sept mille deux cents Beaupuy
+Rue de Tombeloly, quarante-sept, deux cents Marmande
+Rue Lagauzère, Marmande
+Rue Comte de Martignac à Saint-Pardoux-Isaac
+vingt-huit rue Edmond Haraucourt
+Avenue J F Kennedy au numéro seize
+cent quatre-vingt-deux rue Fumadelles, quarante-sept mille Agen
+cinq rue du Couloumé, quarante-sept, trois cent vingt, Clairac
+huit rue de la Cité des Fleurs, quarante-sept, sept cents à Casteljaloux
+Chemin de Lhoste, quarante-sept mille trois cent dix Estillac
+Rue de Saint-Michel Castelnau, quarante-sept, sept cents Casteljaloux
+Place de la Lémance, Monsempron-Libos
+Chemin de Commarque à Brax
+six rue Daniel Roux
+Chemin Saint-Lannes au numéro quatre
+dix-huit impasse de Montherlant, quarante-sept mille cinq cent vingt Le Passage
+neuf rue Joseph Fontanié, quarante-sept, deux cent quarante, Bon-Encontre
+cinq impasse Félix Laville, quarante-sept, cinq cents à Fumel
+Rue du Docteur Couyba, quarante-sept mille cent dix Sainte-Livrade-sur-Lot
+Lotissement d'Albret, quarante-sept, deux cent trente Lavardac
+Rue Maurice Rontin, Mézin
+Rue Sénéchal Balzac d'Entrague à Castelculier
+seize avenue Jean Coulon
+Avenue Pierre Buffin au numéro vingt-cinq
+un rue de la Tranquillité, quarante-sept mille cent dix Sainte-Livrade-sur-Lot
+treize rue du Padouen, quarante-sept, cent soixante, Buzet-sur-Baïse
+douze avenue de Marmande, quarante-sept, sept cents à Casteljaloux
+Rue Roques, quarante-sept mille Agen
+Route de Carrère de Garonne, quarante-sept, quatre cent cinquante Colayrac-Saint-Cirq
+Rue de Coquard, Villeneuve-sur-Lot
+Rue Marcel Rogué à Agen
+deux BIS rue André Pal
+Rue Villalonga au numéro seize
+cinq cent quatre avenue de Comarque, quarante-sept mille deux cent soixante Castelmoron-sur-Lot
+quatre allée de Saint-Marty, quarante-sept, cinq cent dix, Foulayronnes
+quarante-neuf rue Emile Sentini, quarante-sept, zéro zéro zéro à Agen
+Rue Jegun de Marans, quarante-sept mille Agen
+Rue d'Escanteloup, quarante-sept, deux cents Marmande
+Avenue Max Grosselle, Mézin
+Rue Marguerite Brouillet à Villeneuve-sur-Lot
+treize rue des Cités Unies
+Place Armand-Fallières au numéro vingt-quatre
+vingt et un rue des Adouberies, quarante-sept mille deux cents Marmande
+dix-neuf cité Marfaut, quarante-sept, deux cent trente, Barbaste
+six mille sept cent cinquante-trois rue de la Flouride, quarante-sept, sept cents à Casteljaloux
+Rue des Isserts, quarante-sept mille deux cents Marmande
+Place Monseigneur Jean Pouzet, quarante-sept, zéro zéro zéro Agen
+Avenue du Commandant Christian Baylac, Marmande
+Rue Léon Bonnet à Villeneuve-sur-Lot
+quarante-trois avenue des Lions
+Rue du Ruisseau de la Paix au numéro dix
+huit BIS rue Lamaison, quarante-sept mille quatre cents Tonneins
+cinq rue de Barris, quarante-sept, trois cents, Villeneuve-sur-Lot
+six rue Alexis Pain, quarante-sept, zéro zéro zéro à Agen
+Avenue de Bagnaria Arsa, quarante-sept mille cent dix Sainte-Livrade-sur-Lot
+Chemin de le Croix du Guide, quarante-sept, cent dix Sainte-Livrade-sur-Lot
+Rue Michel Blum, Marmande
+Rue Jean Duthil à Casteljaloux

--- a/server/data/fr/addresses-48.csv
+++ b/server/data/fr/addresses-48.csv
@@ -1,0 +1,70 @@
+deux rue Villette, quarante-huit mille cent Marvejols
+deux rue Gilbert Portalier, quarante-huit, quatre cents, Florac
+sept rue Jean Chastel, quarante-huit, deux cents à Saint-Chély-d'Apcher
+Chemin d'Yssenges, quarante-huit mille quatre cents Florac
+Impasse de la Faïsse, quarante-huit, zéro zéro zéro Mende
+Route de l'Empéry, Marvejols
+Boulevard Lucien Arnault à Mende
+quinze chemin de l'Abbé de Born
+Rue de Rémuret au numéro un
+quarante-huit chemin de Séjalan, quarante-huit mille Mende
+sept rue des Carces, quarante-huit, zéro zéro zéro, Mende
+cinq rue Adrien Troupel, quarante-huit, trois cents à Langogne
+Avenue de Ramilles, quarante-huit mille Mende
+Route de Saint-Léger-du-Malzieu, quarante-huit, cent quarante Le Malzieu-Ville
+Avenue de la Méridienne, Marvejols
+Avenue du Docteur Conturie à Langogne
+dix-neuf avenue Théophile Roussel
+Route d'Aubrac au numéro dix
+deux A route de Rieucros, quarante-huit mille Mende
+treize chemin du Géant, quarante-huit, cent, Marvejols
+vingt et un rue du Chazalet, quarante-huit, huit cents à Villefort
+Lotissement des Grèzes, quarante-huit mille quatre cents Florac
+Avenue Jean Monestier, quarante-huit, quatre cents Florac
+Avenue François Olive (mille huit cent quatre-vingt-dix-mille neuf cent cinquante-huit), Marvejols
+Rue Théodore Jean à Marvejols
+seize rue Pierre Grasset
+Rue du Docteur Yves Dalle au numéro quatre TER
+seize route du Mas Neuf, quarante-huit mille trois cents Langogne
+trois place Urbain cinq, quarante-huit, zéro zéro zéro, Mende
+trois BIS chemin du Lignon, quarante-huit, cent à Marvejols
+Rue Picaucel, quarante-huit mille Mende
+Impasse des Hauts du Langouyrou, quarante-huit, trois cents Langogne
+Route du Causse d'Auge, Mende
+Rue du Faubourg Saint-Gervais à Mende
+vingt chemin de la Maison Forte
+Rue Piencourt au numéro treize
+un route du Viala, quarante-huit mille deux cent vingt Fraissinet-de-Lozère
+cinq chemin de Fraissinet, quarante-huit, trois cent vingt, Ispagnac
+vingt-quatre rue Alexandre Bécamel, quarante-huit, zéro zéro zéro à Mende
+Quartier Plaisance, quarante-huit mille deux cent vingt Fraissinet-de-Lozère
+Allée Paul Doumer, quarante-huit, zéro zéro zéro Mende
+Rue de la Cabalade, Les Vignes
+Rue du Cros Del Rieu à Aumont-Aubrac
+trente-deux chemin de Marijoulet
+Avenue Jean-Antoine Chaptal au numéro dix
+dix rue du Petit Tour de Ville, quarante-huit mille trois cents Langogne
+un BIS impasse du Four Moulon, quarante-huit, zéro zéro zéro, Mende
+trois rue Grand Charriera, quarante-huit, zéro zéro zéro à Badaroux
+Route du Languedoc, quarante-huit mille cent trente Aumont-Aubrac
+Rue de l'Estouranche, quarante-huit, cent Chirac
+Cité du Rance, Mende
+Chemin de Chaldecoste à Mende
+quinze route de Sarroul
+Rue René Gibelin au numéro douze
+deux A avenue Paulin Daudé, quarante-huit mille Mende
+treize avenue du Docteur de Framond, quarante-huit, cent, Marvejols
+quatorze avenue de Pineton, quarante-huit, cent à Marvejols
+Place du Clos de Rieucros, quarante-huit mille Mende
+Route de la Margeride, quarante-huit, cent trente Aumont-Aubrac
+Rue d'Aigues Passes, Mende
+Rue l'Estival au Monastier-Pin-Moriès
+neuf avenue du Malzieu
+Place de Chirac au numéro cinq
+quatre impasse du Coteau des Ecureuils, quarante-huit mille Mende
+deux chemin de Costevieille Basse, quarante-huit, cent, Marvejols
+trente-sept avenue Pierre Pignide, quarante-huit, deux cents à Saint-Chély-d'Apcher
+Route de la Brèze, quarante-huit mille cent cinquante Meyrueis
+Avenue de Peyre, quarante-huit, cent trente Aumont-Aubrac
+Rue de Sabel, Barjac
+Esplanade Marceau Farelle à Florac

--- a/server/data/fr/addresses-49.csv
+++ b/server/data/fr/addresses-49.csv
@@ -1,0 +1,70 @@
+six rue du Thiberge, quarante-neuf mille deux cent vingt Brain-sur-Longuenée
+deux rue du Chaussy, quarante-neuf, sept cent trente, Varennes-sur-Loire
+sept place Jules Raimbault, quarante-neuf, deux cent soixante au Puy-Notre-Dame
+Chemin du Ratonneau, quarante-neuf mille trois cent soixante Somloire
+RUE DU PIED MOISI, quarante-neuf, zéro zéro zéro Angers
+Chemin du Boulevard, Blou
+Square de Monza à Cholet
+huit rue Sébastien Cady
+Avenue des Deux Sœurs au numéro un
+trente-trois rue Geoffroy de la Tour Landry, quarante-neuf mille cent vingt La Tourlandry
+quatre rue de Coulaines, quarante-neuf, cent soixante-dix, La Possonnière
+un route de la Corniche Angevine, quarante-neuf, cent quatre-vingt-dix à Saint-Aubin-de-Luigné
+AVENUE DU GENERAL PATTON, quarante-neuf mille Angers
+Rue Sabotière, quarante-neuf, trois cent quatre-vingts Notre-Dame-d'Allençon
+Rue de la Petite Jarrie, Saint-Germain-sur-Moine
+Rue Dubois de La Ferté à La Pommeraye
+sept rue Cesbron Lavau
+Rue du Général Faugeron au numéro huit
+un C voie Communale Bréges, quarante-neuf mille cinq cents Nyoiseau
+vingt-deux avenue des Plantagenêts, quarante-neuf, deux cent cinquante, Beaufort-en-Vallée
+treize rue Bodinier, quarante-neuf, zéro zéro zéro à Angers
+Clos des Marronniers, quarante-neuf mille six cent quatre-vingts Neuillé
+Allée de Palerme, quarante-neuf, quatre cent soixante Montreuil-Juigné
+Rue du Gai Logis, La Romagne
+Rue de la Sermonière à Saint-Paul-du-Bois
+cent vingt-deux rUE SAINT-JACQUES
+Square Maurice Dureau au numéro deux B
+vingt-trois rue de la Croix des Mares, quarante-neuf mille deux cent soixante-dix Le Fuilet
+cinq iMPASSE DU PREGENTIL, quarante-neuf, zéro zéro zéro, Angers
+un rue René Mabileau, quarante-neuf, quatre cents à Saumur
+Rue du Pont Poiroux, quarante-neuf mille cent soixante Longué-Jumelles
+Rue du Puits de l'Aire, quarante-neuf, trois cents Cholet
+Rue du Capitaine Blaise, Avrillé
+RUE LOUIS LEROY à Angers
+cinq chemin des Palnaies
+Rue des Ardoises au numéro vingt et un
+onze rue des Hauts de l'Êvre, quarante-neuf mille six cents Beaupréau
+soixante-neuf rue Jean de Béjarry, quarante-neuf, six cents, Gesté
+deux placé des Acacias, quarante-neuf, six cent quatre-vingts à Vivy
+Chemin de Chasles, quarante-neuf mille six cent dix Juigné-sur-Loire
+Chemin de la Grand-Maison, quarante-neuf, cent cinquante Baugé-en-Anjou
+Rue Constant Gérard, Noyant-la-Gravoyère
+Rue de la Croix Combeau à Brain-sur-l'Authion
+sept place Henri et Albert Lair
+Rue Belébat au numéro soixante-huit
+quatre rue Henry Arnault, quarante-neuf mille six cent quarante Morannes
+dix pASSAGE DE CHANTILLY, quarante-neuf, zéro zéro zéro, Angers
+dix rue Georges Gautier, quarante-neuf, cent trente aux Ponts-de-Cé
+PASSAGE DES MEILLERAIES, quarante-neuf mille Angers
+RUE RENE OGER, quarante-neuf, zéro zéro zéro Angers
+Rue Tuboeuf, Saint-Georges-sur-Loire
+Avenue Jean Boutton aux Ponts-de-Cé
+cent deux B rue Alphonse Darmaillacq
+Rue Florent Papin au numéro treize
+sept rUE RONSARD, quarante-neuf mille Angers
+quinze TER aVENUE DE LA BLANCHERAIE, quarante-neuf, zéro zéro zéro, Angers
+quatorze rue de Seiches, quarante-neuf, cent quarante à Montreuil-sur-Loir
+La Buxiere, quarante-neuf mille quatre cent cinquante Saint-Macaire-en-Mauges
+Rue des Airaults, quarante-neuf, deux cent cinquante Beaufort-en-Vallée
+SQUARE DE LA CHOUANIERE, Angers
+Levée Ligerienne à Saint-Jean-de-la-Croix
+six rue Joseph Suteau
+Rue de la Gaubretière au numéro trois
+dix-sept hameau des Bigottières, quarante-neuf mille quatre cent soixante Feneu
+sept rue du Boeuf Couronne, quarante-neuf, cent soixante-dix, Saint-Georges-sur-Loire
+dix rUE DES ANGLES, quarante-neuf, zéro zéro zéro à Angers
+Route du Clos Huchet, quarante-neuf mille six cent trente Mazé
+Rue du Docteur Assier, quarante-neuf, cent soixante Longué-Jumelles
+Avenue Jean Vaugoyau, Avrillé
+SQUARE DU GRAND CORNILLE à Angers

--- a/server/data/fr/addresses-50.csv
+++ b/server/data/fr/addresses-50.csv
@@ -1,0 +1,70 @@
+vingt B chemin de l'Aillerie, cinquante mille cinq cents Carentan
+six saint Luc, cinquante, six cent quatre-vingt-dix, Couville
+deux cent quatre-vingt-huit rue Cornu, cinquante, trois cent soixante à Picauville
+Rue du Docteur Philippe Hérouard, cinquante mille cinq cent soixante-dix Marigny
+Rue du Tertre Burel, cinquante, cent soixante-dix Pontorson
+Route du Hameau Corbin, Brillevast
+Rue Pierre Guéroult à Querqueville
+quarante-quatre A rue du Val l'Abbé
+Rue de la Saint-Côme au numéro treize
+vingt et un cité de la Calière, cinquante mille sept cent soixante-dix Pirou
+trois chemin Marie Madeleine Postel, cinquante, sept cents, Tamerville
+cinq avenue de Scissy, cinquante, six cent dix à Jullouville
+Avenue du Passous, cinquante mille deux cent trente Agon-Coutainville
+Promenade du Petit Port, cinquante, deux cent soixante-dix Barneville-Carteret
+La Roque, Héauville
+Route de la Malenfandière à Saint-Aubin-des-Préaux
+sept la Fieffe Verbot de Haut
+Rue de la Pierre du Tertre au numéro trente-six
+vingt-six cité du Jardin de Garot, cinquante mille deux cent dix Cerisy-la-Salle
+un rue de la Sienne, cinquante, deux cents, Heugueville-sur-Sienne
+douze BIS hameau de Bellanville, cinquante, trois cent trente à Cosqueville
+Rue Béchevel, cinquante mille Saint-Lô
+Rue de Valognes, cinquante, quatre cent quarante Sainte-Croix-Hague
+Route de Cuves, Saint-Pois
+Route de Giéville à Condé-sur-Vire
+cinq rue de la Croûte
+Route de Diélette au numéro trente-trois
+cent quatorze rue de la Polle, cinquante mille cent Cherbourg-Octeville
+deux route de Saint-Marcouf, cinquante, trois cent quarante, Pierreville
+quatre rue du Clos Bihel, cinquante, cent vingt à Équeurdreville-Hainneville
+Rue de Fernand Fleuret, cinquante mille trois cent quatre-vingts Saint-Pair-sur-Mer
+Rue Lefevre et Toulorge, cinquante, quatre cent soixante-dix La Glacerie
+Rue des Cohues, Villedieu-les-Poêles
+Rue René Leseigneur à La Glacerie
+deux rue Forfert
+Rue Georges Sorel au numéro un
+douze allée Benoît Frachon, cinquante mille cent vingt Équeurdreville-Hainneville
+neuf rue Ernest Duprey, cinquante, deux cent trente, Agon-Coutainville
+trois cent cinquante-cinq route de Catteville, cinquante, trois cent quatre-vingts à Saint-Pair-sur-Mer
+Rue de la Gallouette, cinquante mille cinq cent cinquante Saint-Vaast-la-Hougue
+Rue du Varrot, cinquante, cent quatre-vingts Agneaux
+Rue de l'Entre Deux Rochers, Donville-les-Bains
+Rue de Haut à Saint-Germain-des-Vaux
+vingt résidence des Tamaris
+Route de la Mer Ronthon au numéro trente-huit
+sept route du Pont de la Roque, cinquante mille deux cents Monthuchon
+cinq place Bagot, cinquante, deux cent quarante, Saint-James
+dix-sept BIS rue Marechal Montgomery, cinquante, deux cent vingt à Pontaubault
+Rue de l'Abbaye des Reines, cinquante mille cinq cents Saint-Pellerin
+Rue de la Cocardière, cinquante, quatre cents Granville
+Rue du Hameau Maçon, Créances
+Rue Feburon à Saint-Hilaire-du-Harcouët
+treize rue du Pois de Senteur
+Rue Bernard Mannessiez au numéro huit BIS
+un rue de Sercq, cinquante mille deux cent soixante-dix Barneville-Carteret
+trente-deux rue du Cap, cinquante, sept cent soixante, Montfarville
+cent soixante-douze A route de Coutances, cinquante, trois cent cinquante à Donville-les-Bains
+Chemin du Maunet, cinquante mille sept cent quarante Carolles
+Route de Houessey, cinquante, six cent quarante Le Teilleul
+Route de la Fossé, Saint-Quentin-sur-le-Homme
+Rue de la Losquette à La Chapelle-en-Juger
+vingt-trois route de la Chasse Hannot
+Rue Philippe d'Aigneaux au numéro vingt et un
+sept rue Pétricot, cinquante mille sept cent soixante Anneville-en-Saire
+deux rue de la Voie Royale, cinquante, six cent soixante, Orval
+deux rue de la Quenaudière, cinquante, quatre cent trente à Bretteville-sur-Ay
+Rue es Gosse, cinquante mille cinq cent trente Champeaux
+Le Poteau, cinquante, cent soixante Guilberville
+Impasse du Long Pré, La Glacerie
+Rue Fernand Thomine à Cherbourg-Octeville

--- a/server/data/fr/addresses-51.csv
+++ b/server/data/fr/addresses-51.csv
@@ -1,0 +1,70 @@
+vingt et un rue des Beaux Anges, cinquante et un mille trois cents Vitry-le-François
+vingt BIS rue Henry Martin, cinquante et un, deux cent vingt, Loivre
+sept rue Alfred Neymarck, cinquante et un, zéro zéro zéro à Châlons-en-Champagne
+Chemin des Wardes, cinquante et un mille deux cent vingt Saint-Thierry
+Avenue Paul Chandon, cinquante et un, deux cents Épernay
+Rue de Crépy, Witry-lès-Reims
+Rue Gustave de Bohan à Fresne-lès-Reims
+vingt-cinq rue de la Crayere
+Route de Witry au numéro deux cent treize
+quarante-six rue de l'Atteignant, cinquante et un mille cent Reims
+treize rue Petit Hutin, cinquante et un, cent, Reims
+quatorze BIS rue Heurpé, cinquante et un, cent cinquante à Tours-sur-Marne
+Rue du cent dix-neuf Eme Ri, cinquante et un mille deux cent vingt Cauroy-lès-Hermonville
+Avenue Cook, cinquante et un, cent Reims
+Rue Ulysse Ginat, Fagnières
+Rue Joseph Misiack à Fismes
+cinq avenue du Haut des Termes
+Rue Louis Guibert au numéro cinq
+douze rue Caque, cinquante et un mille Châlons-en-Champagne
+un rue Thérèse et Robert Chapelle, cinquante et un, deux cent vingt, Hermonville
+vingt allée de Sébastopol, cinquante et un, cent à Reims
+Allée Albert Préjean, cinquante et un mille quatre cent trente Tinqueux
+Avenue Brebant, cinquante et un, cent Reims
+Rue Rene Lemaire, Épernay
+Chemin de la Fosse aux Brebis à Châlons-en-Champagne
+six rue Goulin
+Avenue des Nelmons au numéro soixante-douze
+vingt-neuf rue François Dor, cinquante et un mille cent Reims
+quatre chemin de Vatry, cinquante et un, cinq cent dix, Cheniers
+vingt-huit rue Gérard Chardonnet, cinquante et un, trois cent cinquante à Cormontreuil
+Rue Passe Demoiselles, cinquante et un mille cent Reims
+Allée Santos Dumont, cinquante et un, quatre cent cinquante Bétheny
+Rue la Pérouse, Reims
+Rue du Moulin de l'Archeveque à Saint-Brice-Courcelles
+un route de la Neuvillette
+Rue Docteur Roger Fesneau au numéro quatorze
+sept rue de la Brouetterie, cinquante et un mille trois cents Vitry-le-François
+quatre cent trente-huit rue du Faubourg Saint-Aignan, cinquante et un, deux cent trente, Fère-Champenoise
+quarante et un rue du Grand Der, cinquante et un, trois cents à Frignicourt
+Rue du Docteur Louis, cinquante et un mille cent soixante Ay
+Rue du Général Mazillier, cinquante et un, cent Reims
+Rue du Perthois, Frignicourt
+Rue Bergeron à Blacy
+vingt et un rue du trois cent cinquante-cinq e Régiment d'Infanterie
+Rue du Docteur Lafitte au numéro treize
+vingt-quatre rue Saint-Gengoulf, cinquante et un mille trois cent vingt Haussimont
+cent cinquante-deux rue de l'Hôpital Auban Moët, cinquante et un, deux cents, Épernay
+un rue du Château Senart, cinquante et un, trois cent soixante-dix à Saint-Brice-Courcelles
+Rue Saint-Pierre les Dames, cinquante et un mille cent Reims
+Rue de la Fontaine Saint-Maurice, cinquante et un, cinq cent dix Villers-le-Château
+Résidence du Champ Gaulois, Suippes
+Allée Nadia et Lili Boulanger à Bétheny
+deux rue de Loiselet
+Rue du Paulmier au numéro sept
+quatorze boulevard du Cubry, cinquante et un mille deux cents Épernay
+cent neuf rue Guyot Prieur, cinquante et un, deux cent trente, Fère-Champenoise
+deux rue de Grandpierre, cinquante et un, deux cents à Épernay
+Rue du Groupe Tritant, cinquante et un mille Châlons-en-Champagne
+Chemin des Semonts, cinquante et un, deux cents Épernay
+Rue René Lisambert, Fagnières
+Rue Houzeau Muiron à Reims
+dix-huit rue de Villedommange
+Rue de Flancourt au numéro dix
+six rue Croix Saint-Marc, cinquante et un mille cent Reims
+quinze chemin du CBR, cinquante et un, cent soixante-dix, Fismes
+trente rue de Choiset, cinquante et un, trois cents à Loisy-sur-Marne
+Faubourg de la Neuville, cinquante et un mille deux cent vingt Cormicy
+Allée du Frère Jean Oudart, cinquante et un, cinq cent trente Pierry
+Rue de Branscourt, Jonchery-sur-Vesle
+Rue Nicolas Gogol à Reims

--- a/server/data/fr/addresses-52.csv
+++ b/server/data/fr/addresses-52.csv
@@ -1,0 +1,70 @@
+six cent trois rue de l'Étoile de Langres, cinquante-deux mille deux cents Langres
+cinquante-trois BIS rue du Professeur Bouchard, cinquante-deux, deux cent vingt, Montier-en-Der
+cinq route de Rizaucourt, cinquante-deux, trois cent trente à Colombey-les-Deux-Églises
+Rue du Puits Royau, cinquante-deux mille cent Saint-Dizier
+Rue de la Priolée, cinquante-deux, cent Perthes
+Rue Brulé, Chaumont
+Rue Decomble à Chaumont
+sept rue Brabant
+Village Pershing au numéro quatre cent vingt-huit
+vingt-deux chemin des Morionnes, cinquante-deux mille cent Saint-Dizier
+trois ruelle du Petit Pont, cinquante-deux, cent trente, Montreuil-sur-Blaise
+six quartier des Fours à Coke, cinquante-deux, cent à Saint-Dizier
+Rue du Capitaine Tassard, cinquante-deux mille Chaumont
+Allée Danielle Casanova, cinquante-deux, cent Saint-Dizier
+Rue du Val Barizien, Chaumont
+Rue Jean Carbon à Bourbonne-les-Bains
+dix-neuf avenue Turenne
+Place des Bains au numéro un BIS
+huit route des Caillottes, cinquante-deux mille deux cent quatre-vingt-dix Éclaron-Braucourt-Sainte-Livière
+quatre rue de Viéville, cinquante-deux, zéro zéro zéro, Chaumont
+quatre BIS place Becquey, cinquante-deux, cent à Saint-Dizier
+Rue des Clefmonts, cinquante-deux mille cent Saint-Dizier
+Avenue Irma Masson, cinquante-deux, trois cents Joinville
+Hameau de Flancourt, Ceffonds
+Rue Lefroit Dupain à Bourbonne-les-Bains
+neuf rue Des Princes
+Ruelle de la Piquelle au numéro douze
+vingt-six rue de Langres, cinquante-deux mille six cents Chalindrey
+six rue Émile Jolibois, cinquante-deux, zéro zéro zéro, Chaumont
+treize BIS allée Pierre Arnoult, cinquante-deux, deux cent vingt à Montier-en-Der
+Rue de la Fontaine du Grand Jardin, cinquante-deux mille trois cents Joinville
+Rue des Lachats, cinquante-deux, cent Saint-Dizier
+Rue du Val de Borne, Bourbonne-les-Bains
+Route de la Horre à Puellemontier
+trois rue Jômeray
+Rue de Chamarandes au numéro seize
+trente-trois hameau de la Grève, cinquante-deux mille deux cent vingt Ceffonds
+un ruelle des Prélots, cinquante-deux, zéro zéro zéro, Jonchery
+sept rue du Maquis du Val, cinquante-deux, deux cent quatre-vingt-dix à Humbécourt
+Passage du Renard, cinquante-deux mille trois cents Joinville
+Rue du Val Anne-Marie, cinquante-deux, zéro zéro zéro Chaumont
+Rue du Général Defrance, Wassy
+Avenue de la Loubert à Saint-Dizier
+trente-trois BIS place Jacques Anquetil
+Rue Walferdin au numéro douze
+vingt et un rue du Parc À Cerises, cinquante-deux mille cent Chancenay
+vingt rue Camille Gillet, cinquante-deux, trois cents, Joinville
+onze rue de la Grande Inglée, cinquante-deux, deux cent vingt à Montier-en-Der
+Avenue de la Collinière, cinquante-deux mille deux cents Langres
+Rue du Chanoine Roussel, cinquante-deux, deux cents Langres
+Émile Combes, Chaumont
+Rue de la Coterelle à Jonchery
+quatre-vingt-six rue des Eturbées
+Rue Félix Bablon au numéro vingt-huit
+cinq route Nationale quatre, cinquante-deux mille cent Hallignicourt
+soixante-deux rue de Lamartine, cinquante-deux, zéro zéro zéro, Chamarandes-Choignes
+trois rue de la Chadrelle, cinquante-deux, six cents à Heuilley-Cotton
+Rue Charles Lucot, cinquante-deux mille cent Saint-Dizier
+Rue de Pichot, cinquante-deux, trois cent trente Rizaucourt-Buchey
+Rue de l'Etanche, Saint-Dizier
+Allée de Flandre à Saint-Dizier
+soixante-trois rue Denis Mougeot
+Rue de la Victoire de la Marne au numéro vingt-neuf
+vingt-trois rue de la Scierie du Grand Chantier, cinquante-deux mille cent Saint-Dizier
+quatre rue du Moulin À Vent, cinquante-deux, deux cents, Langres
+douze impasse Marguerite Leyenberger, cinquante-deux, deux cents à Langres
+Rue des Petites Halles, cinquante-deux mille cent Saint-Dizier
+Route d'Hallignicourt, cinquante-deux, cent Villiers-en-Lieu
+Rue d'Ambrieres, Éclaron-Braucourt-Sainte-Livière
+Rue des Frères Garnier à Chaumont

--- a/server/data/fr/addresses-53.csv
+++ b/server/data/fr/addresses-53.csv
@@ -1,0 +1,70 @@
+quarante-neuf rue des Ayrelles, cinquante-trois mille Laval
+dix-huit rue du Cardinal L.M Bille, cinquante-trois, zéro zéro zéro, Laval
+cent dix rue d'Hilard, cinquante-trois, zéro zéro zéro à Laval
+Place Terrepintonne, cinquante-trois mille cent cinquante Montsûrs
+Rue des Abbés Gaugain, cinquante-trois, cent soixante Hambers
+Rue des Quatres Vents, Château-Gontier
+Rue de la Mauhitière à Mayenne
+douze rue de l'Etamoire
+Rue de l'Abbé Angot au numéro vingt-huit
+cinq place Jacques de Montesson, cinquante-trois mille sept cents Saint-Aubin-du-Désert
+dix BIS rue de Frénouse, cinquante-trois, deux cent trente, Cossé-le-Vivien
+dix rue de la Vaige, cinquante-trois, cent soixante-dix à La Cropte
+Rue des Trois Régiments, cinquante-trois mille Laval
+Ruelle de Beausoleil, cinquante-trois, zéro zéro zéro Laval
+Parc de la Sourderie, Villaines-la-Juhel
+Route de Neau à Évron
+six rue Henri Dès
+Rue du Vieux Saint-Louis au numéro trois cent cinquante-cinq
+un rue des Abélias, cinquante-trois mille quatre cent quarante La Bazoge-Montpinçon
+vingt-sept rue de Bouletière, cinquante-trois, deux cent soixante, Entrammes
+trente-trois route de Mirwault, cinquante-trois, deux cents à Château-Gontier
+Rue du Bois de l'Huisserie, cinquante-trois mille Laval
+Rue de la Chartrie, cinquante-trois, huit cent dix Changé
+Allée Constant Feinte, Laval
+Rue de Gesnes à Montsûrs
+cinquante-deux boulevard Félix Grat
+Rue de Louverné au numéro vingt-cinq
+quatorze allée Pierre César Ferret, cinquante-trois mille Laval
+neuf impasse Roger Bambuck, cinquante-trois, neuf cent cinquante, Louverné
+vingt-neuf rue Ulphace Benoit, cinquante-trois, deux cent quarante à Andouillé
+Impasse des Gonettes, cinquante-trois mille deux cent quarante Andouillé
+Rue Pierre Barauderie, cinquante-trois, trois cent cinquante Fontaine-Couverte
+Place Saint-Tugal, Laval
+Rue Ambroise de Loré à Oisseau
+sept rue de la Noue Fleurie
+Rue du Heaume au numéro vingt-trois
+quinze rue Livet de Monfeu, cinquante-trois mille six cents Évron
+un rue Belle-Plante, cinquante-trois, cinq cents, Ernée
+sept rue du Béron, cinquante-trois, deux cents à Coudray
+Route de Château Gontier, cinquante-trois mille quatre cents Craon
+Lotissement du Petit Marcilly, cinquante-trois, cent quatre-vingt-dix Landivy
+Place d'Anjou, Laval
+Lotissement de la Touche à La Chapelle-Craonnaise
+vingt-six rue André de Lohéac
+Rue Angèle Ligère au numéro dix
+un rue Jean-Baptiste Robin, cinquante-trois mille neuf cent quarante Ahuillé
+seize faubourg Sainte-Anne, cinquante-trois, trois cent cinquante, La Roë
+onze rue du Domaine des Mottes, cinquante-trois, deux cent soixante à Forcé
+Rue des Bordagers, cinquante-trois mille huit cent dix Changé
+Route de Loigné, cinquante-trois, deux cents Château-Gontier
+Rue de Bootz, Laval
+Rue de Côuterne à Lassay-les-Châteaux
+huit passage de Quincampoix
+Rue de la Maillarderie au numéro soixante-sept
+sept B rue du Château Trompette, cinquante-trois mille cent Mayenne
+deux place Renault Morlière, cinquante-trois, cinq cents, Ernée
+quatorze rue de l'Embûche, cinquante-trois, quatre cent quarante à Aron
+Rue de Prés, cinquante-trois mille sept cents Courcité
+Allée Prosper Mortou, cinquante-trois, zéro zéro zéro Laval
+Rue de la Philipotière, Laval
+Cité des Noyers à Javron-les-Chapelles
+huit rue du Haut de l'Allée
+Rue du Pont Gate au numéro quatorze
+quatre avenue Raoul Vadepied, cinquante-trois mille six cents Châtres-la-Forêt
+six rue Berthe Marcou, cinquante-trois, deux cent trente, Cossé-le-Vivien
+seize rue de la Claverie, cinquante-trois, deux cents à Azé
+Rue de la Chambrouillère, cinquante-trois mille neuf cent soixante Bonchamp-lès-Laval
+Boulevard Brune, cinquante-trois, zéro zéro zéro Laval
+Place Voisin, Ernée
+Rue de Quifeu à Saint-Germain-le-Fouilloux

--- a/server/data/fr/addresses-54.csv
+++ b/server/data/fr/addresses-54.csv
@@ -1,0 +1,70 @@
+vingt-huit rue du Docteur Grandjean, cinquante-quatre mille cent dix Réméréville
+dix rue de la Kaukenne, cinquante-quatre, cent cinquante, Briey
+treize rue du Carreau de la Mine, cinquante-quatre, sept cent quatre-vingt-dix à Mancieulles
+Allée Marcel Wenck, cinquante-quatre mille deux cent dix Saint-Nicolas-de-Port
+Rue de la Vallée de l'Esch, cinquante-quatre, trois cent quatre-vingts Rogéville
+Lotissement Le Grand Jovier, Batilly
+Rue Eugène Ory à Pont-à-Mousson
+trente-sept BIS rue de Pont A Mousson
+Rue de Pont-Saint-Vincent au numéro quinze
+vingt et un rue des Chichenottes, cinquante-quatre mille trois cent soixante Barbonville
+cinquante et un rue de Tomblaine, cinquante-quatre, quatre cent vingt, Saulxures-lès-Nancy
+cinq rue des Deux Épis, cinquante-quatre, six cent trente à Flavigny-sur-Moselle
+Rue Ascou, cinquante-quatre mille sept cent trente Ville-Houdlémont
+Rue de la Haute-Brin, cinquante-quatre, deux cent quatre-vingts Brin-sur-Seille
+Route de Toul, Blénod-lès-Toul
+Rue du Comte de Frawenberg à Bouxières-aux-Dames
+six rue du Chauxfour
+Rue Jean Feuillette au numéro dix-huit
+deux avenue du Commandant Charcot, cinquante-quatre mille trois cent vingt Maxéville
+six allée de la Butte Sainte-Geneviève, cinquante-quatre, quatre cent vingt-cinq, Pulnoy
+un rue des Marnes Grises, cinquante-quatre, deux cent quatre-vingts à Seichamps
+Rue du Lorguillon, cinquante-quatre mille sept cent cinquante Trieux
+Rue des Ullions, cinquante-quatre, deux cent soixante Longuyon
+Rue du Bois le Prêtre, Fey-en-Haye
+Route de Badménil à Baccarat
+trente et un rue Hubert Sensiquet
+Rue de Jolimont au numéro vingt-huit
+trois rue Marcellin Munier, cinquante-quatre mille trois cent quatre-vingts Landremont
+quinze route de Sanzey, cinquante-quatre, deux cents, Boucq
+trois boulevard Tolstoï, cinquante-quatre, cinq cent dix à Tomblaine
+Rue du Chambré, cinquante-quatre mille sept cent soixante Faulx
+Rue Val des Faulx, cinquante-quatre, six cent soixante-dix Custines
+Rue de Ménil, Lunéville
+Rue Lionnois à Nancy
+douze rue de l'Abbé Devaux
+Rue du vingt et un Juin mille neuf cent quarante au numéro cinq
+vingt-six rue du Chanoine Piéron, cinquante-quatre mille six cents Villers-lès-Nancy
+un chemin du Rouau, cinquante-quatre, cent soixante, Pierreville
+vingt-huit rue du Cloué, cinquante-quatre, cent cinquante à Briey
+Rue du Général Custine, cinquante-quatre mille Nancy
+Rue Houdevaux, cinquante-quatre, cent treize Bulligny
+Rue Alfred Songeur, Maidières
+Rue Raugraff à Nancy
+quatre cour du Couvent
+Rue du Poncé au numéro vingt et un
+quarante-huit rue du Vieil Aître, cinquante-quatre mille Nancy
+trente-deux rue de Saurupt, cinquante-quatre, zéro zéro zéro, Nancy
+vingt-quatre rue Monseigneur Turinaz, cinquante-quatre, zéro zéro zéro à Nancy
+Rue du Blanc Mur, cinquante-quatre mille deux cent dix Saint-Nicolas-de-Port
+Rue de la Bouillante, cinquante-quatre, trois cent quatre-vingts Dieulouard
+Chemin du Poirier d'Anne, Pierre-Percée
+Chemin de la Gare de Rosières à Dombasle-sur-Meurthe
+treize rue de la Petite Embanie
+Rue Henry Brun au numéro six cent quarante-cinq
+trente-six rue Hanzelet, cinquante-quatre mille cent dix Haraucourt
+onze rue Michâtel, cinquante-quatre, deux cents, Toul
+dix-neuf rue de Laneuveville, cinquante-quatre, sept cents à Montauville
+Rue du Radimont, cinquante-quatre mille sept cent trente Gorcy
+Place de la Quatrième République, cinquante-quatre, deux cent trente Chaligny
+Rue des Soeurs Bonnaventure, Villers-en-Haye
+Rue du quatorze Septembre à Dombasle-sur-Meurthe
+trois rue Eugène Sillien
+Rue Baron Buquet au numéro trente et un
+un quai de Bitche, cinquante-quatre mille trois cents Lunéville
+vingt et un rue d'Haussonville, cinquante-quatre, cent dix, Dombasle-sur-Meurthe
+deux rue Chiffetraie, cinquante-quatre, trois cent soixante-dix à Hoéville
+Rue de Maixe, cinquante-quatre mille trois cent soixante-dix Deuxville
+Route de Villey-Saint-Étienne, cinquante-quatre, deux cents Toul
+Placette Ville d'Avray, Heillecourt
+Rue de la Taille Michaud à Velaine-en-Haye

--- a/server/data/fr/addresses-55.csv
+++ b/server/data/fr/addresses-55.csv
@@ -1,0 +1,70 @@
+sept rue de Revigny, cinquante-cinq mille Robert-Espagne
+quatre route de Sampigny, cinquante-cinq, trois cents, Mécrin
+vingt-quatre chemin de Plein Chaumont, cinquante-cinq, zéro zéro zéro à Bar-le-Duc
+Rue Vouillaume, cinquante-cinq mille cent soixante-dix Ancerville
+Rue de la Croix de Fresnes, cinquante-cinq, cent soixante Ville-en-Woëvre
+Rue Laurenceau Bompard, Guerpont
+Rue Voiselle à Longeville-en-Barrois
+sept rue Miss Skinner
+Impasse de Pennsylvanie au numéro quatorze
+cinq chemin de Burledon, cinquante-cinq mille Bar-le-Duc
+vingt-cinq avenue Letellier, cinquante-cinq, huit cent quarante, Thierville-sur-Meuse
+un ruelle de l'Asile, cinquante-cinq, zéro zéro zéro à Chardogne
+Place Dom Jean-Baptiste Maugérard, cinquante-cinq mille cent vingt Clermont-en-Argonne
+Rue Sylvain Bailleux, cinquante-cinq, six cents Montmédy
+Rue des Brouets, Brabant-en-Argonne
+Avenue Jean Errard à Verdun
+quatre rue de l'Église A Vigneulles
+Rue de Meneaufil au numéro dix-sept
+six chemin de la Vieille Côte, cinquante-cinq mille huit cents Andernay
+trente-sept avenue Prud'Homme Havette, cinquante-cinq, quatre cents, Étain
+trois rue du Château à Hattonchâtel, cinquante-cinq, deux cent dix à Vigneulles-lès-Hattonchâtel
+Rue de Bégarenne, cinquante-cinq mille Fains-Véel
+Rue des Chalaidrelles, cinquante-cinq, zéro zéro zéro Bar-le-Duc
+Rue Vancassel, Verdun
+Rue de la Brasserie Meuse à Bar-le-Duc
+cinquante-sept rue d'Égremont
+Rue Aubry au numéro cinq
+quarante-deux rue du Pré Pommeré, cinquante-cinq mille cent Verdun
+vingt-huit avenue du cent cinquante e R.un., cinquante-cinq, huit cent quarante, Thierville-sur-Meuse
+un voie de Bar, cinquante-cinq, zéro zéro zéro à Resson
+Avenue du huit e B.C.P., cinquante-cinq mille quatre cents Étain
+Place Monseigneur Ginisty, cinquante-cinq, cent Verdun
+Rue du Briolet, Verdun
+Ruelle de Nonancourt à Pouilly-sur-Meuse
+trente-sept rue Mongauld
+Rue Bar la Ville au numéro dix-sept
+seize rue Paul Deroulède, cinquante-cinq mille cent Verdun
+huit rue Robert Rouy, cinquante-cinq, huit cents, Mognéville
+vingt et un chemin de Vaux le Comte, cinquante-cinq, zéro zéro zéro à Bar-le-Duc
+Rue de Morvaux, cinquante-cinq mille trois cents Saint-Mihiel
+Avenue Pierre Goubet et Jean Van Heeghe, cinquante-cinq, huit cent quarante Thierville-sur-Meuse
+Rue du Cornuet, Ancerville
+Voie de Hasoy à Resson
+trois rue Gaston Thiebaut
+Côte Saint-Barthélémy au numéro trente et un
+quatre route de Murvaux, cinquante-cinq mille cent cinquante Brandeville
+neuf rue Pierre Santoni, cinquante-cinq, deux cents, Commercy
+cinq place Georges Guérin, cinquante-cinq, cent à Verdun
+Rue de Maestricht, cinquante-cinq mille Bar-le-Duc
+Rue des Senades, cinquante-cinq, cent vingt Les Islettes
+Rue des Reinettes Dorées, Ancerville
+Rue d'Elbingerode à Bouligny
+vingt-quatre rue Mautroté
+Rue de Moranville au numéro dix
+vingt-sept allée des Cramaux, cinquante-cinq mille cent Verdun
+deux chemin des Houys, cinquante-cinq, cent vingt, Les Islettes
+six rue du Château des Quatre Vents, cinquante-cinq, deux cent dix à Vigneulles-lès-Hattonchâtel
+Allée Henri-Alain Fournier, cinquante-cinq mille trois cents Saint-Mihiel
+Rue du Mouty, cinquante-cinq, trois cent vingt Les Monthairons
+Rue du Petit Tour, Heudicourt-sous-les-Côtes
+Boulevard de la Rochelle à Bar-le-Duc
+un chemin du Poirier Judas
+Rue des Comtes de Chiny au numéro onze
+deux côte des Fermes, cinquante-cinq mille Longeville-en-Barrois
+quarante-cinq lotissement du Bas de Braux, cinquante-cinq, cent soixante-dix, Ancerville
+onze rue du Joncroy, cinquante-cinq, quatre cents à Buzy-Darmont
+Impasse et Place des Myosotis, cinquante-cinq mille trois cent dix Tronville-en-Barrois
+Rue des Fosses à Terre, cinquante-cinq, cent Bras-sur-Meuse
+Rue de la Tête d'Or, Saint-Mihiel
+Rue de Sompheu à Sampigny

--- a/server/data/fr/addresses-56.csv
+++ b/server/data/fr/addresses-56.csv
@@ -1,0 +1,70 @@
+cent vingt-deux avenue de Kermario, cinquante-six mille trois cent quarante Carnac
+dix-huit rue Île de Sein, cinquante-six, six cents, Lanester
+quarante-six rue de Quehellio, cinquante-six, cent à Lorient
+Rue de Kerlioret, cinquante-six mille quatre cent soixante-dix Saint-Philibert
+Rue Yves Rocher, cinquante-six, deux cents La Chapelle-Gaceline
+Rue Perrine Samson, Grand-Champ
+Avenue Commune de Paris à Lanester
+vingt-neuf rue de Gestel
+Rue Guyot Jomard au numéro quatorze
+huit rue des Îles Logoden, cinquante-six mille Vannes
+sept rue du Marché aux Femmes, cinquante-six, trois cents, Pontivy
+douze rue de Kerstang, cinquante-six, huit cent soixante à Séné
+Route de Kerfanc, cinquante-six mille huit cent soixante-dix Baden
+Rue du Commandant du Noday, cinquante-six, quatre cent trente Mauron
+Rue de Kervegan, Carnac
+Rue de Coueslan à Saint-Dolay
+quinze chemin du Perello
+Impasse de Lann Kerpenru au numéro quatorze
+cinquante-six route de Port-Louis, cinquante-six mille cinq cent soixante-dix Locmiquélic
+deux BIS impasse du Guernehué, cinquante-six, cent quatre-vingt-dix, La Trinité-Surzur
+vingt rue de Croix Izan, cinquante-six, quatre cent dix à Étel
+Domaine de Kerdual, cinquante-six mille quatre cent soixante-dix La Trinité-sur-Mer
+Rue de Renaron, cinquante-six, cinq cent dix Saint-Pierre-Quiberon
+Rue André Bouler, Vannes
+Rue de Kerbos à Gourin
+dix-huit cité de l'Avenir
+Impasse Kreiz er Gêr au numéro huit
+un rue des Huniers, cinquante-six mille quatre cent dix Étel
+dix-huit boulevard de la Base Nautique, cinquante-six, trois cent quarante, Carnac
+sept mille quatre cent soixante-quatorze rue Izenah, cinquante-six, huit cent soixante-dix à Baden
+Rue Paul Février, cinquante-six mille cent Lorient
+Rue Les Hauts de Bellamer, cinquante-six, cinq cent vingt Guidel
+Rue Eugène Le Thiec, Ploemeur
+Rue Jean-Marie Toulliou à Lorient
+quarante-trois résidence de Kergurset
+Rue de Poulbretion au numéro seize
+quinze avenue de Prat Ar Mor, cinquante-six mille six cents Lanester
+quatorze rue Arthur trois de Richemond, cinquante-six, huit cent quatre-vingt-dix, Plescop
+un rue du Talhouët, cinquante-six, sept cents à Hennebont
+Route de Kerjacob, cinquante-six mille quatre cent quarante Languidic
+Avenue des Naiades, cinquante-six, cent soixante-dix Quiberon
+Rue Jean Laviquel, Saint-Avé
+Rue du Croizic à Pluméliau
+cinq BIS chemin du Village de Penhoat-Quinio
+Rue de l'Amiral Pierre Ronarc'h au numéro quarante-cinq
+un impasse Men Beniguet, cinquante-six mille trois cent soixante-dix Sarzeau
+quatorze résidence du Mané, cinquante-six, sept cents, Kervignac
+six chemin de Ker Henry, cinquante-six, six cent dix à Arradon
+Route de Pont Lorois, cinquante-six mille sept cents Merlevenez
+Rue de Montsarrac, cinquante-six, huit cent soixante Séné
+Rue de Lanvelan, Carnac
+Clos du Ratz à Arradon
+un impasse N° trois
+Rue du Sabot d'Or au numéro quinze
+trois rue de Kerlaboux, cinquante-six mille neuf cent vingt Saint-Gonnery
+dix-neuf rue Jean et Yves Texier Lahoulle, cinquante-six, zéro zéro zéro, Vannes
+trois rue Mathurin Eveno, cinquante-six, deux cent cinquante à Monterblanc
+Impasse Hent er Mor, cinquante-six mille trois cent soixante-dix Sarzeau
+Rue du Raillé, cinquante-six, cent trente Camoël
+Avenue Raymond Marcellin, Theix
+Rue du Mare au Tour-du-Parc
+quatorze rue de Kercaves
+Les Livardieres au numéro cent quatre-vingt-neuf
+vingt-neuf rue Amiral Lacaze, cinquante-six mille cent Lorient
+vingt-trois rue de Ker-Eostin, cinquante-six, trois cents, Pontivy
+soixante-quatorze rue de Kerulve, cinquante-six, cent à Lorient
+Rue Ehen Bras, cinquante-six mille quatre cents Sainte-Anne-d'Auray
+Résidence Clair Vallon, cinquante-six, zéro zéro zéro Vannes
+Rue Georges Le Poder, Auray
+Rue de Kéraudren à Saint-Gildas-de-Rhuys

--- a/server/data/fr/addresses-57.csv
+++ b/server/data/fr/addresses-57.csv
@@ -1,0 +1,70 @@
+neuf rond-Point Marie Curie, cinquante-sept mille cent soixante-dix Château-Salins
+vingt-quatre rue des Bagrasses, cinquante-sept, quatre cent vingt, Verny
+onze rue de Nonnenfels, cinquante-sept, neuf cent vingt à Kédange-sur-Canner
+Lotissement le Champ du Roy, cinquante-sept mille deux cent soixante-dix Uckange
+Rue de Nassau, cinquante-sept, cent cinquante Creutzwald
+Domaine de la Moselle, Illange
+Rue du Crassier à Stiring-Wendel
+soixante-sept rue d'Eschviller
+Square Paille-Maille au numéro huit
+neuf rue Charles Abel, cinquante-sept mille Metz
+six rue de Knutange, cinquante-sept, cent quatre-vingt-dix, Florange
+trente-quatre rue de Civray, cinquante-sept, huit cents à Freyming-Merlebach
+Rue des Engagés Volontaires, cinquante-sept mille Metz
+Rue de Boismortier, cinquante-sept, cent Thionville
+Rue du Ehrenweg, Garrebourg
+Boucle Alsace-Lorraine à Cattenom
+huit rue de Lambervaux
+Rue de Castviller au numéro cinq
+quatre square Alphonse Bourg, cinquante-sept mille trois cent cinquante Stiring-Wendel
+cent sept rue de Queuleu, cinquante-sept, zéro zéro zéro, Metz
+onze A rue de Metzeresche, cinquante-sept, neuf cent vingt à Kédange-sur-Canner
+Rue du Vieux Chene, cinquante-sept mille soixante-dix Saint-Julien-lès-Metz
+Allée des Brochets, cinquante-sept, huit cent dix Rhodes
+Rue Guérin de Waldersbach, Thionville
+Rue Edouard Fortuné de Bade à Rodemack
+quatre rue Coutié
+Rue Schellenthal au numéro trente-huit
+cent vingt-quatre rue de Laudrefang, cinquante-sept mille trois cent quatre-vingt-cinq Teting-sur-Nied
+cinquante-cinq rue de Mouterhouse, cinquante-sept, deux cent trente, Baerenthal
+vingt-cinq place Monseigneur Pelt, cinquante-sept, cinq cent soixante-dix à Rodemack
+Impasse Gilberte Brossolette, cinquante-sept mille deux cent quatre-vingts Maizières-lès-Metz
+Rue des Grandes Portions, cinquante-sept, deux cent quarante-cinq Peltre
+Rue le Moyne, Metz
+Boucle des Prunelliers à Thionville
+soixante-quatorze rue de Rioux Martin
+Rue de la Grande Somgué au numéro vingt-sept
+quatre rue Graham Bell, cinquante-sept mille Metz
+onze route de Viller, cinquante-sept, trois cent quatre-vingts, Guessling-Hémering
+six A rue du Heidaecker, cinquante-sept, cinq cent dix à Puttelange-aux-Lacs
+Rue Jean Burger, cinquante-sept mille soixante-dix Saint-Julien-lès-Metz
+Rue des trois Pierres, cinquante-sept, trois cent dix Guénange
+Rue Florence, Serémange-Erzange
+En Jurue à Marieulles
+quatorze rue Charles Emeringer
+Rue du Beunier au numéro douze
+quarante-cinq rue de Nachy, cinquante-sept mille cent quarante Woippy
+vingt-quatre boucle du Bois, cinquante-sept, cent, Thionville
+quatre la Petite Saison, cinquante-sept, neuf cent trente-cinq à Luttange
+Boucle Sylvie de Selancy, cinquante-sept mille cent Manom
+Rue Claire Oster, cinquante-sept, deux cents Sarreguemines
+Rue de Vaulry, Rurange-lès-Thionville
+Rue du Duché de Lorraine à Condé-Northen
+dix impasse de Nice
+Rue Bonterre au numéro sept
+un rue de Rôde, cinquante-sept mille cent vingt Rombas
+dix-huit rue St Andrews, cinquante-sept, deux cents, Sarreguemines
+quinze rue Antoine Ménard, cinquante-sept, deux cent cinquante-cinq à Sainte-Marie-aux-Chênes
+Impasse des Malgré-Nous, cinquante-sept mille cent Thionville
+Rue Heitzler René, cinquante-sept, trois cent quarante Morhange
+Rue des Macons, Hottviller
+Rue de Baignes Sainte-Radegonde à Gros-Réderching
+un rue de Gravelotte
+Rue de Langgöns au numéro un
+sept passage du Liseron, cinquante-sept mille cinq cent soixante-dix Gavisse
+treize rue du Stade Bockange, cinquante-sept, deux cent vingt, Piblange
+quarante-sept rue de Schoeneck, cinquante-sept, trois cent cinquante à Stiring-Wendel
+Rue du Puits Simon, cinquante-sept mille trois cent cinquante Stiring-Wendel
+Allée des Ducs du Luxembourg, cinquante-sept, cinq cent soixante-dix Rodemack
+Rue de Dampont, Colmen
+Rue des Messieurs à Honskirch

--- a/server/data/fr/addresses-58.csv
+++ b/server/data/fr/addresses-58.csv
@@ -1,0 +1,70 @@
+trois place de Bethléem, cinquante-huit mille cinq cents Clamecy
+trente rue Commandant Paul Pierre Clerc, cinquante-huit, zéro zéro zéro, Nevers
+vingt-neuf C rue des Champs Pacaud, cinquante-huit, zéro zéro zéro à Nevers
+Rue de Grenois, cinquante-huit mille quatre cent vingt Asnan
+Rue de Cornille, cinquante-huit, cent dix Châtillon-en-Bazois
+Rue Instituteur Pittié, Nevers
+Route de Guichy à Vielmanay
+onze rue des Montmenades
+Rue de Trangy au numéro soixante-seize BIS
+six rue de l'Étang Honoré, cinquante-huit mille trois cent soixante Saint-Honoré-les-Bains
+trois rue Louis Vicat, cinquante-huit, zéro zéro zéro, Nevers
+soixante T route des Feuillats, cinquante-huit, trois cents à Decize
+Route de la Machine, cinquante-huit mille trois cents Saint-Léger-des-Vignes
+Rue Des Docks, cinquante-huit, zéro zéro zéro Nevers
+Rue de Pouillyzot, Pouilly-sur-Loire
+Rue Yves Cogoi à Fourchambault
+vingt et un rue Commandant Fabien
+Route du Lac Le Mont au numéro huit
+trois route de Dardault, cinquante-huit mille cent soixante Druy-Parigny
+trois rue du Crot du Lac, cinquante-huit, deux cent dix, Menou
+deux route de Jaugenay, cinquante-huit, cent soixante à Chevenon
+Passage Paillard, cinquante-huit mille cent cinquante Pouilly-sur-Loire
+Rue des Rapies, cinquante-huit, quatre cents Champvoux
+Route des Bertranges, Raveau
+Rue du P'Tit Pont à Ruages
+un rue du Puits Charles
+Allée le Brix au numéro sept
+trente-trois BIS rue du Colonel Rabier, cinquante-huit mille deux cents Cosne-Cours-sur-Loire
+soixante et un avenue Louis Coudant, cinquante-huit, trois cent quarante, Cercy-la-Tour
+onze rue de la Verly, cinquante-huit, cinq cents à Villiers-sur-Yonne
+Rue des Montapins, cinquante-huit mille Nevers
+Rue Paul Barreau, cinquante-huit, cent quarante Lormes
+Chemin du Bois des Hâtes, Saint-Benin-d'Azy
+Rue Thirault à Dornecy
+neuf rue Pierre Corbier
+Rue de Vignelle au numéro quarante
+deux impasse du Buisson des Chaumes, cinquante-huit mille quatre cents Chaulgnes
+un rue Mesves, cinquante-huit, cent cinquante, Pouilly-sur-Loire
+dix-huit rue Fonmorigny, cinquante-huit, zéro zéro zéro à Nevers
+Rue Georges Tardy, cinquante-huit mille Nevers
+Rue Charles Roy, cinquante-huit, zéro zéro zéro Nevers
+Rue Henri Choquet, Varennes-Vauzelles
+Rue Franc Nohain à Nevers
+un rue Quinto Elmetti
+Rue de la Chaume de Mars au numéro sept
+quatre rue Marcel Deschaumes, cinquante-huit mille deux cent soixante La Machine
+dix rue Achille Millien, cinquante-huit, quatre cents, La Charité-sur-Loire
+soixante-quatre avenue Louis Fouchere, cinquante-huit, six cent quarante à Varennes-Vauzelles
+Rue Martin des Amognes, cinquante-huit mille deux cent soixante-dix Saint-Benin-d'Azy
+Route du Tridon, cinquante-huit, cent vingt Château-Chinon (Campagne)
+Avenue Laubespin, Pouilly-sur-Loire
+Route Vallée François à Ciez
+trois faubourg de Crux
+Rue Noël Pointe au numéro quatorze
+trois rue du Mazou, cinquante-huit mille quatre cents Mesves-sur-Loire
+dix-huit rue des Abbes, cinquante-huit, cent trente, Guérigny
+un allée du Crot de l'Orme, cinquante-huit, trois cent cinquante à Arbourse
+Rue de la Tour aux Filles, cinquante-huit mille quatre cent dix Entrains-sur-Nohain
+Rue Lucien Perreimond, cinquante-huit, trois cents Champvert
+Rue du Champ du Pavillon, Decize
+Rue Nicolas Delange à Nevers
+quarante-neuf route Buissonniere
+Chemin de Chauviau au numéro seize
+treize impasse de la Bagatelle, cinquante-huit mille Nevers
+trente et un boulevard du Grand Pré des Bordes, cinquante-huit, zéro zéro zéro, Nevers
+neuf rue Mirangron, cinquante-huit, zéro zéro zéro à Nevers
+Rue de Garchy, cinquante-huit mille cent cinquante Pouilly-sur-Loire
+Allée de l'Orleanais, cinquante-huit, deux cents Cosne-Cours-sur-Loire
+Rue Marguerite Monnot, Decize
+Rue Marcel Turpin à Varennes-Vauzelles

--- a/server/data/fr/addresses-59.csv
+++ b/server/data/fr/addresses-59.csv
@@ -1,0 +1,70 @@
+trois cent cinquante-sept rUE LEON GAMBETTA, cinquante-neuf mille Lille
+neuf rue du Chronique, cinquante-neuf, cent quarante-quatre, Wargnies-le-Grand
+cinq rue Pierre Merlen, cinquante-neuf, cent cinquante-trois à Grand-Fort-Philippe
+Rue Kuhlmann, cinquante-neuf mille Lille
+Rue Jacques Varlet, cinquante-neuf, trois cent dix Beuvry-la-Forêt
+Rue Vasseur, Solesmes
+Rue Ch Theillier de Ponchevill à Valenciennes
+vingt-neuf clos des Tonneliers
+Rue Maurice Rose au numéro douze
+trente-sept rue Fauqueux, cinquante-neuf mille cent soixante-seize Masny
+quinze boulevard Caraman, cinquante-neuf, deux cent vingt, Denain
+quarante-sept rue d'Aire, cinquante-neuf, cent quatre-vingt-neuf à Boëseghem
+Rue Roger Speybrock, cinquante-neuf mille deux cents Tourcoing
+Impasse Toury, cinquante-neuf, cent vingt-trois Bray-Dunes
+Rue Victor Delannoy, Orchies
+Rue Pierre Lembrez à Râches
+trente-sept grand-Place Norbert Segard
+Pav de la Tranquillite au numéro huit
+deux cour Dathis, cinquante-neuf mille Lille
+un chemin d'ERRE, cinquante-neuf, cent vingt-quatre, Escaudain
+quarante-trois A rUE DE LANNOY, cinquante-neuf, zéro zéro zéro à Lille
+Rue Jean Bar, cinquante-neuf mille cent quarante et un Thun-Saint-Martin
+Rue de Wattrelos, cinquante-neuf, cent quinze Leers
+Boulevard de la République - François Mitterrand, Dunkerque
+Bern Straete à Bailleul
+six cent quatre-vingt-dix rue d'Anhiers
+Rue du Lieutenant-Colonel Charles Van Coppenolle au numéro vingt-cinq
+deux cent quatre-vingt-six avenue de Dunkerque, cinquante-neuf mille cent trente Lambersart
+onze rue Louis Bataille, cinquante-neuf, cinq cent soixante, Comines
+vingt et un rue Marie-Louise Meyer, cinquante-neuf, six cent dix à Fourmies
+Avenue Ernest Couteaux, cinquante-neuf mille deux cent trente Saint-Amand-les-Eaux
+Avenue du Clair Village, cinquante-neuf, neuf cent dix Bondues
+Route de Douai, Mouchin
+Avenue Alfred Motte à Roubaix
+neuf rue du Blanc Ballot
+Contour des Petites Haies au numéro trente-six
+soixante-douze rUE CATTEAU, cinquante-neuf mille deux cents Tourcoing
+cinq rue Paul Greffe, cinquante-neuf, deux cent trente, Saint-Amand-les-Eaux
+neuf cent trente-huit domaine de la Vigne, cinquante-neuf, neuf cent dix à Bondues
+RUE DE PUEBLA, cinquante-neuf mille Lille
+Rue de Waziers, cinquante-neuf, quatre cent cinquante Sin-le-Noble
+Rue de Menin, Tourcoing
+Rue Charles Leurette à Gravelines
+vingt-huit rue Lucien-Bouillot
+Rue de la Fosse Bernard au numéro soixante-sept
+soixante-deux rue de la Blanche Porte, cinquante-neuf mille deux cents Tourcoing
+vingt-sept rue Florimond Delemer, cinquante-neuf, trois cent soixante-dix, Mons-en-Barœul
+un rue Jean de Haynin, cinquante-neuf, cinq cent soixante-dix à Bavay
+Chemin de Loisel, cinquante-neuf mille deux cent cinquante Halluin
+Rue du XXème Siècle, cinquante-neuf, zéro zéro zéro Lille
+Résidence La Butte, Rexpoëde
+Rue de Fournes à Genech
+trente-huit rue de Lez-Fontaine
+Rue Victor Delloue au numéro trente-quatre
+soixante-neuf rue Jean-Baptiste Ducrocq, cinquante-neuf mille sept cents Marcq-en-Barœul
+cinq cent soixante-quatre rue Adolphe Strady, cinquante-neuf, six cent quatre-vingt-dix, Vieux-Condé
+cinq cent vingt-sept rue du Sarloton, cinquante-neuf, cent quarante-quatre à Gommegnies
+Chemin de la Grande Tourbière, cinquante-neuf mille huit cent soixante-dix Marchiennes
+Rue du Docteur Pierchon, cinquante-neuf, deux cent cinquante Halluin
+Rue Eugène Lefebvre, Poix-du-Nord
+Avenue de Jussieu à Lambersart
+quatorze rue des Bajeux
+Rue Miternique au numéro quatre
+deux mille sept cent trois route de Steenvoorde, cinquante-neuf mille six cent soixante-dix Cassel
+trente-deux rue Lesage Senault, cinquante-neuf, zéro zéro zéro, Lille
+quatre-vingt-deux rue Belle Rade, cinquante-neuf, deux cent quarante à Dunkerque
+Rue Henri Millez, cinquante-neuf mille huit cent trente Louvil
+Place du Hainaut, cinquante-neuf, trois cents Valenciennes
+Rue Paul Francke, Cappelle-la-Grande
+Quai de Gravelines à Roubaix

--- a/server/data/fr/addresses-60.csv
+++ b/server/data/fr/addresses-60.csv
@@ -1,0 +1,70 @@
+deux cent quarante-neuf rue Fernand Desjardins, soixante mille sept cent trente Novillers
+cent quatre-vingt-un rue de Tillarue, soixante, trois cent vingt, Saint-Sauveur
+quatre rue Yvonne Drouin, soixante, neuf cent quarante à Cinqueux
+Rue Reant Henri, soixante mille cent trente Wavignies
+Rue de Savignies, soixante, zéro zéro zéro Beauvais
+Sentier du Moulin d'Inval, Courcelles-lès-Gisors
+Rue des Tournettes à Montiers
+cent cinquante-cinq rue Belle Assise
+Rue du Marais Colin au numéro douze
+six rue de Froide Cuisse, soixante mille deux cent quarante Bachivillers
+onze route de Dammartin, soixante, trois cent trente, Ève
+cent douze grande Avenue, soixante, deux cent soixante à Lamorlaye
+Rue Nationale Rn trente-deux, soixante mille cent soixante-dix Cambronne-lès-Ribécourt
+Allée Jacques Topin, soixante, cent douze Milly-sur-Thérain
+Rue de Bernes, Morangles
+Avenue des Martyrs de la Liberté à Compiègne
+cinquante-cinq rue de Marqueglise
+Clos des Lauriers au numéro six
+un rue du Champ du Mouton, soixante mille deux cent quatre-vingt-dix Monchy-Saint-Éloi
+trente-neuf BIS rue Louis Hennon, soixante, quatre cent vingt, Tricot
+trois rue de Montreuil sur Thérain, soixante, neuf cent trente à Bailleul-sur-Thérain
+Rue Georges Méliés, soixante mille deux cent trente Chambly
+Rue de Prés Miny, soixante, sept cents Pontpoint
+Rue Charles Lescot, Pont-Sainte-Maxence
+Rue Louis Nicolas Vauquelin à Noyon
+sept rue Duvoir
+Rue Jean Levert au numéro trente-cinq
+vingt-sept rue de Carroix, soixante mille deux cent vingt Romescamps
+quatorze voie Communale Ferme de la Chapelle, soixante, trois cents, Fontaine-Chaalis
+seize rue de la Voierie, soixante, cent vingt à Hardivillers
+Rue du Wart, soixante mille cinq cent dix Bresles
+Rue Cambry, soixante, zéro zéro zéro Beauvais
+Rue du Prince Radziwill, Ermenonville
+Rue Amédée Bouquerel à Compiègne
+un rue du Puits Berthaud
+Chemin du Bois de Soavre au numéro quatre
+trente BIS rue Lucien Hubaut, soixante mille cent quarante et un Boursonne
+un rue Princesse Louise, soixante, neuf cent cinquante, Ermenonville
+six rue du Vivier Corax, soixante, deux cents à Compiègne
+Rue Corbier Thiébaut, soixante mille deux cent soixante-dix Gouvieux
+Rue Montalet, soixante, cent dix Amblainville
+Rue du Chanoine Seret, Cauvigny
+Sente du Coq à Crépy-en-Valois
+trois square Gabriel-Auguste Ancelet
+Route de Mouy au numéro quatre
+onze rue Amédée Levasseur, soixante mille deux cent vingt Boutavent
+trente-neuf huit e Avenue, soixante, deux cent soixante, Lamorlaye
+deux rue Victor Presson, soixante, deux cent trente à Chambly
+Rue Brachedal, soixante mille deux cent quarante Chaumont-en-Vexin
+Rue de Montdidier, soixante, cent trente Erquinvillers
+Rue Alfred Goriot, Chambly
+Rue du Docteur Gey à Andeville
+douze rue des Blassiers
+Rue Despinas au numéro vingt-deux
+six BIS avenue Georges Bataille, soixante mille trois cent trente Le Plessis-Belleville
+cent seize rue Marcel Balasse, soixante, deux cent quatre-vingts, Margny-lès-Compiègne
+trente-neuf rue du Général Taupin, soixante, huit cent dix à Barbery
+Square de la Mare-Gaudry, soixante mille deux cents Compiègne
+Rue l'Écureuil, soixante, quatre cents Noyon
+Rue Charles Deneux, Bresles
+Rue du Champ des Cosaques à Noyon
+sept allée Georges Feydeau
+Square du Président Kennedy au numéro quatre
+sept rue Suleau, soixante mille deux cent dix Sommereux
+six rue du Clos du Jeu d'Arc, soixante, huit cent quatre-vingts, Le Meux
+dix rue du Bois du Fayel, soixante, deux cent quarante à Bachivillers
+Rue d'Arona, soixante mille deux cents Compiègne
+Rue du Bois Saint-Martin, soixante, quatre cent quatre-vingts Abbeville-Saint-Lucien
+Allée de la Prele, Noyon
+Rue Alexandre Merelle à Lormaison

--- a/server/data/fr/addresses-61.csv
+++ b/server/data/fr/addresses-61.csv
@@ -1,0 +1,70 @@
+cent douze rue Cazault, soixante et un mille Alençon
+trois rue de Damigny, soixante et un, deux cent cinquante, Lonrai
+treize lotissement la Perelle, soixante et un, deux cent vingt à Bellou-en-Houlme
+Chemin du Haut Village, soixante et un mille sept cent quatre-vingt-dix Saint-Pierre-du-Regard
+Route de Champsecret, soixante et un, quatre cent cinquante La Ferrière-aux-Étangs
+Impasse de la Vacherie, Saint-Loyer-des-Champs
+Rue François Le Rees à Domfront
+quatre rue Du Cours
+Route de Tourouvre au numéro six
+vingt-deux rue Yves Silvestre, soixante et un mille deux cents Argentan
+trente-huit rue des Marcheries, soixante et un, zéro zéro zéro, Alençon
+huit rue de Montgacel, soixante et un, quatre cents au Pin-la-Garenne
+Ruelle Ferté, soixante et un mille quatre cents Mortagne-au-Perche
+Rue de la Jéhannière, soixante et un, cent Flers
+Rue de la Motte Ango, Flers
+Chemin des Randonnées à Ronfeugerai
+un route d'Échauffour
+Boulevard Albert Christophle au numéro vingt et un
+dix-sept rue du Colonel Guérin, soixante et un mille quatre cents Mortagne-au-Perche
+vingt rue du Docteur Boulay, soixante et un, deux cent quatre-vingt-dix, Longny-au-Perche
+sept impasse Ducercle, soixante et un, cinq cents à Sées
+Rue du Champ Beaumont, soixante et un mille Saint-Germain-du-Corbéis
+Rue Ulysse Houel, soixante et un, cent soixante Bailleul
+Rue Des Guichets, Sées
+Rue Paul Saniez à Flers
+trente-trois rue du Château d'Ô
+Rue Chevalier du Merle au numéro seize
+trois la Cour de la Métairie, soixante et un mille trois cent quarante Courcerault
+quatre rue de la Normandie Maine, soixante et un, trois cent cinquante, Passais
+douze rue Louis Esparre, soixante et un, cent quarante à Juvigny-sous-Andaine
+Rue Gabriel Hubert, soixante et un mille sept cents Domfront
+Rue Raymond Billard, soixante et un, trois cents L'Aigle
+Rue Commandant Moriceau, Domfront
+Hameau de la Pelzinière au Theil
+vingt-sept route d'Ecouves
+Rue de Fordingbridge au numéro dix
+vingt-six rue Mondrel, soixante et un mille cent quatre-vingt-dix Tourouvre
+quarante-cinq rue Schnetz, soixante et un, cent, Flers
+quatre rue du Pré Plat, soixante et un, zéro zéro zéro à Saint-Germain-du-Corbéis
+Rue Auguste Durand, soixante et un mille six cents Magny-le-Désert
+Allée de la Templierie, soixante et un, zéro zéro zéro Saint-Germain-du-Corbéis
+Résidence du Champ de la Ville, Le Pin-la-Garenne
+Rue Demées à Alençon
+deux cent vingt-sept A rue des Ferrons
+Avenue de Stuhlingen au numéro trente-quatre
+dix rue Louis Pellerin, soixante et un mille cent soixante Chambois
+sept rue du Port Mahon, soixante et un, deux cent quatre-vingt-dix, Longny-au-Perche
+cent six BIS rue de Mauvaisville, soixante et un, deux cents à Argentan
+Cours Clemenceau, soixante et un mille Alençon
+Avenue de Courteille, soixante et un, zéro zéro zéro Alençon
+Rue Allain deux, Vimoutiers
+Place de l'Epine à Saint-Michel-Tubœuf
+cent vingt et un rue du Hariel
+Résidence du Hêtre Pourpre au numéro trois
+trente-huit rue Labillardière, soixante et un mille Alençon
+cinq place des Ribauderies, soixante et un, deux cent quarante, Nonant-le-Pin
+vingt-six avenue de Paris Qrt Lescot, soixante et un, deux cents à Argentan
+Rue de Sontra, soixante et un mille cent vingt Vimoutiers
+Rue Montcacune, soixante et un, quatre cents Mortagne-au-Perche
+Rue Louvagny, Sarceaux
+Allée Prieuré à Saint-Georges-des-Groseillers
+huit rue de L'Île de France
+Voie Communale Le Tuilot au numéro dix-sept
+vingt-six route de Vaugelay, soixante et un mille trois cent quatre-vingts Soligny-la-Trappe
+quinze rue de Nully, soixante et un, quatre cents, Saint-Hilaire-le-Châtel
+vingt et un rue Docteur René Leroy, soixante et un, cent à La Carneille
+Boulevard Brochard, soixante et un mille cent quarante Bagnoles-de-l'Orne
+Rue Racinet, soixante et un, cent cinquante Écouché
+Allée Marot, Damigny
+Rue de Vervaine à Condé-sur-Sarthe

--- a/server/data/fr/addresses-62.csv
+++ b/server/data/fr/addresses-62.csv
@@ -1,0 +1,70 @@
+soixante-cinq avenue de Douvres, soixante-deux mille cent cinquante-cinq Merlimont
+neuf rue Betterots, soixante-deux, cent quarante-neuf, Givenchy-lès-la-Bassée
+huit rue de l'Estade, soixante-deux, six cent dix à Nielles-lès-Ardres
+Rue Le Clos Planche Tournoire, soixante-deux mille trois cent quarante Hames-Boucres
+Rue Julien Hermant, soixante-deux, six cent quatre-vingt-dix Aubigny-en-Artois
+Chemin de Chiconet, Sallaumines
+Rue du Mont Rôti à Preures
+soixante-douze rue de Thérouanne
+Rue des Coltineurs au numéro deux
+cinquante-sept quai du Commerce, soixante-deux mille cent Calais
+six cent quarante rue de la Jandrie, soixante-deux, deux cent trente-deux, Hinges
+treize résidence du Clair Marais, soixante-deux, trois cent soixante-dix à Saint-Folquin
+Chemin d'Aire Hameau de Bucamps, soixante-deux mille trois cent dix Azincourt
+Rue André Mancey, soixante-deux, quatre cent soixante-dix Calonne-Ricouart
+Rue d'Ervillers, Mory
+Rue de Waben à Verton
+vingt et un rue de Beaume
+Rue Saint-Winocq au numéro cent dix-neuf
+dix-huit rue d'Aumerval, soixante-deux mille cinq cent cinquante Floringhem
+vingt et un rue de Noeux, soixante-deux, cent treize, Sailly-Labourse
+cinquante-quatre rue Hector Laloux, soixante-deux, trois cents à Lens
+Boulevard Fosse deux, soixante-deux mille trois cent vingt Rouvroy
+Rue du Carloy, soixante-deux, cent soixante et un Duisans
+Rue de Dippendal, Bouquehault
+Chemin du Puits Bérault à Wailly-Beaucamp
+dix chemin du Beauregard
+Chemin de Manneret au numéro dix
+deux cent vingt-trois rue Ignace Humblot, soixante-deux mille cent trente-huit Auchy-les-Mines
+onze rue Charles Demuynck, soixante-deux, trois cent vingt, Rouvroy
+dix-sept rue du Bonnier, soixante-deux, deux cent dix à Avion
+Rue Léon Pinart, soixante-deux mille deux cent cinquante Marquise
+Rue Gabriel Pollet, soixante-deux, neuf cent soixante-dix Courcelles-lès-Lens
+Rue de Bus, Bertincourt
+Rue de Pont à Vendin à Noyelles-sous-Lens
+douze rue des Revers
+Rue de Dourges au numéro quatre cent quatre-vingt-douze
+quatorze rue de Louez, soixante-deux mille cent soixante et un Marœuil
+trente-deux rue Samuel Goulet, soixante-deux, cinq cent quatre-vingt-dix, Oignies
+six rue de Bacqueville, soixante-deux, deux cent vingt et un à Noyelles-sous-Lens
+Rue Dubrulle, soixante-deux mille huit cent soixante-dix Douriez
+Rue Victor Decriem, soixante-deux, trois cent trente Isbergues
+Route de Méricourt, Rouvroy
+Rue Augustin Lefebvre à Labourse
+vingt-deux rue d'Annay
+Rue Rice Oxley au numéro treize
+quinze voie de l'Iseran, soixante-deux mille deux cent dix-sept Beaurains
+un rue de l'Ascenseur, soixante-deux, cinq cent dix, Arques
+quinze rue Soubitez, soixante-deux, six cents à Berck
+Rue Mayeux, soixante-deux mille trois cents Lens
+Rue de l'As de Licques, soixante-deux, trois cent quatre-vingts Bouvelinghem
+Route de Mentque, Nort-Leulinghem
+Rue Maistre à Vendin-le-Vieil
+quarante-sept rue Edmond Mille
+Rue de Grosville au numéro soixante-douze
+trois cent trente boulevard Victor Poulain, soixante-deux mille sept cent quatre-vingts Cucq
+quatorze rue de Witrepin, soixante-deux, six cent trente, Frencq
+huit rue Achille Hibon, soixante-deux, cinq cent quarante à Lozinghem
+Rue de Trézennes, soixante-deux mille cent vingt Aire-sur-la-Lys
+Rue Henry Sainsard, soixante-deux, cent trente-sept Coulogne
+Rue de Campagne, Bourthes
+Allée Leo Delibes à Outreau
+huit rue de Guestreville
+Rue Édith Mary Garner au numéro cinq
+onze rue de l'Ancien Moulin Beaussaut, soixante-deux mille six cents Berck
+un résidence Les Chardonnerets, soixante-deux, huit cent quarante, Fleurbaix
+dix-sept rue Boussingault, soixante-deux, deux cent dix à Avion
+Rue de Matringhem, soixante-deux mille trois cent dix Hézecques
+Rue Joseph Mattéi, soixante-deux, huit cent quatre-vingts Annay
+Place Dalton, Boulogne-sur-Mer
+Rue Guillaume Cliton à Saint-Omer

--- a/server/data/fr/addresses-63.csv
+++ b/server/data/fr/addresses-63.csv
@@ -1,0 +1,70 @@
+neuf rue de la Bourchoune, soixante-trois mille sept cent trente Plauzat
+trente-quatre BIS rue du Rassat, soixante-trois, zéro zéro zéro, Clermont-Ferrand
+soixante et onze boulevard du Chauffour, soixante-trois, cinq cent quarante à Romagnat
+Rue du Pavin, soixante-trois mille huit cents Cournon-d'Auvergne
+Rue Alexis Piron, soixante-trois, zéro zéro zéro Clermont-Ferrand
+Allée Amélie Murat, Pont-du-Château
+Rue de la Mare Les Pioliers à Villeneuve-les-Cerfs
+cent treize rue des Chanelles
+Rue du Sioulet au numéro huit
+deux cent trente rue de l'Oradou, soixante-trois mille Clermont-Ferrand
+huit rue des Pradets, soixante-trois, cent quatorze, Montpeyroux
+un impasse de l'École Nadaillat, soixante-trois, cent vingt-deux à Saint-Genès-Champanelle
+Chemin de Treize Vents, soixante-trois mille trois cent quarante Le Breuil-sur-Couze
+Rue Frère Héribaud, soixante-trois, zéro zéro zéro Clermont-Ferrand
+Avenue D'Occitanie, Veyre-Monton
+Passage de la Gaité à Blanzat
+quinze rue Jean Grenier
+Rue Robert Oléon au numéro quatre
+vingt-cinq rue de la Côte Ferrandon, soixante-trois mille sept cents Saint-Éloy-les-Mines
+cinquante-sept rue de la Limagne Pontmort, soixante-trois, deux cents, Cellule
+un rue de la Fontaine Egaules, soixante-trois, cinq cent trente à Volvic
+Allée des Ribbes Le Lot, soixante-trois mille neuf cent soixante-dix Aydat
+Route de Chignat, soixante-trois, neuf cent dix Bouzel
+Rue de Beaupeyras, Clermont-Ferrand
+Rue de la Pavade à La Roche-Blanche
+neuf impasse des Sans Soucis
+Rue de la Fondette au numéro quatre
+onze lotissement Mègemont, soixante-trois mille trois cent soixante-dix Lempdes
+vingt-trois rue des Dômes, soixante-trois, deux cents, Riom
+dix-sept BIS avenue de Royat, soixante-trois, quatre cents à Chamalières
+Impasse de la Gravelotte Les Grosl, soixante-trois mille cent quarante Châtel-Guyon
+Rue Marcel Magard, soixante-trois, cent soixante-dix Pérignat-lès-Sarliève
+Route de Riom, Manzat
+Rue Ferdinand Phelut à Beaumont
+quatre-vingt-treize rue de la Pradat
+Rue des Thermes Saint-Pierre au numéro six
+six impasse Strauss, soixante-trois mille cent dix-huit Cébazat
+vingt rue Pierre Poisson, soixante-trois, quatre cents, Chamalières
+deux rue Francisque Gaillot, soixante-trois, deux cents à Saint-Bonnet-près-Riom
+Rue de la Virie, soixante-trois mille neuf cent dix Bouzel
+Allée du Point de Vue, soixante-trois, zéro zéro zéro Clermont-Ferrand
+Rue des Cartelades, La Monnerie-le-Montel
+Impasse des Bartriers à Pont-du-Château
+cinq impasse de Tordes
+Route de Manson au numéro seize
+deux place Saint-Avit, soixante-trois mille cinq cents Issoire
+quarante-quatre rue de Chancrole, soixante-trois, cent dix-huit, Cébazat
+huit BIS rue du Puy Vineux, soixante-trois, zéro zéro zéro à Clermont-Ferrand
+Avenue de Volvic, soixante-trois mille cinq cent trente Sayat
+Rue du Courage, soixante-trois, zéro zéro zéro Clermont-Ferrand
+Rue Gonod, Clermont-Ferrand
+Quai d'Aubary à Champeix
+treize rue des Cuvages
+Rue Côte Blatin au numéro dix
+quatre cent soixante-sept rue Marc-Antoine Bargoin, soixante-trois mille deux cent soixante-dix Vic-le-Comte
+douze avenue du Puy de Dôme, soixante-trois, cent trente, Royat
+six mille dix chemin de la Dore, soixante-trois, neuf cent vingt à Peschadoires
+Rue de la Quéré, soixante-trois mille sept cent trente Mirefleurs
+Route de Saint-Beauzire, soixante-trois, deux cents Ménétrol
+Route de Vensat, Aigueperse
+Rue de Marmillat à Clermont-Ferrand
+quatre-vingt-dix-huit impasse Jean Mouly
+Rue des Petits Capucins au numéro neuf
+un impasse du Moulin de Saint-Pierre, soixante-trois mille six cent soixante-dix Orcet
+trente-deux chemin des Dagonnes, soixante-trois, huit cents, Saint-Georges-sur-Allier
+trois rue du Rivial, soixante-trois, sept cent trente à Mirefleurs
+Rue de la Chaloux, soixante-trois mille huit cent soixante-dix Orcines
+Rue du Docteur Pierre Balme, soixante-trois, zéro zéro zéro Clermont-Ferrand
+Impasse de Chaberot, Mirefleurs
+Rue Saint-Clement à Saint-Germain-Lembron

--- a/server/data/fr/addresses-64.csv
+++ b/server/data/fr/addresses-64.csv
@@ -1,0 +1,70 @@
+un rue Ramon de Carbonnieres, soixante-quatre mille Pau
+soixante-dix-huit rue Raymond et Marcel Glize, soixante-quatre, trois cent quarante, Boucau
+cinquante-deux avenue de la Pioche, soixante-quatre, deux cents à Biarritz
+Rue Raymond Sousbielle, soixante-quatre mille cent Bayonne
+Chemin du Carrérot, soixante-quatre, quatre cents Goès
+Rue Jean Mendiondou, Oloron-Sainte-Marie
+Lotissement Arrougen à Montaut
+sept rue du Docteur Constant Colbert
+Route de Pontacq au numéro quatre
+cinquante chemin de Batchalette, soixante-quatre mille cinq cent vingt Bidache
+trois rue Jean-Baptiste Castaings, soixante-quatre, trois cent quarante, Boucau
+sept place Cezaire, soixante-quatre, trois cent soixante-dix à Arthez-de-Béarn
+Allée de Sensacq, soixante-quatre mille deux cent trente Aussevielle
+Chemin de Pey, soixante-quatre, cinq cent trente Pontacq
+Rue des Prés de Julie, Andoins
+Rue de Souhara à Bidart
+trente-deux chemin de Chauron
+Impasse Naçay au numéro quarante-sept
+vingt-deux chemin de Jouandic, soixante-quatre mille trois cent quarante Boucau
+vingt-trois route de Brassalay, soixante-quatre, trois cents, Biron
+cinq chemin du Clos du Balanh, soixante-quatre, quatre cent cinquante à Navailles-Angos
+Rue Monréjau, soixante-quatre mille cent Bayonne
+Lotissement de Bayne, soixante-quatre, cinq cent dix Assat
+Allée du Domaine du Parc, Biarritz
+Chemin du Coustalat à Coarraze
+cinq rue de Maillarenea
+Allée de la Bécassine au numéro vingt-trois
+soixante-dix chemin de l'Arriec, soixante-quatre mille trois cents Orthez
+trois cent soixante-douze route de Morlaàs, soixante-quatre, cent soixante, Buros
+six mille deux cent seize chemin Legarreta, soixante-quatre, trois cent dix à Saint-Pée-sur-Nivelle
+Rue de Moleressenia, soixante-quatre mille cinq cents Saint-Jean-de-Luz
+Chemin de Riche, soixante-quatre, trois cents Baigts-de-Béarn
+Rue Dibildos, Hasparren
+Route de Maucor à Saint-Castin
+neuf cent quatre-vingt-dix route des Cretes / d'deux cent trente-trois
+Rue Auguste Peyre au numéro huit
+trente et un TER rue de la Ribère, soixante-quatre mille huit cents Beuste
+trois impasse Comet, soixante-quatre, six cents, Anglet
+trois cent vingt chemin de la Hondine, soixante-quatre, deux cent quarante à Urt
+Boulevard des Frères Farman, soixante-quatre mille cent quarante Lons
+Chemin de Crémendy, soixante-quatre, cinq cent vingt Bidache
+Rue Iraty, Billère
+Route de Doazon à Serres-Sainte-Marie
+dix-huit allée Recalde
+Rue du Poundet au numéro vingt et un
+onze allée Fontaine de Lartigaou, soixante-quatre mille cent Bayonne
+cinq chemin de Suberbie, soixante-quatre, cent cinquante, Lahourcade
+trois chemin de Bié, soixante-quatre, cent soixante à Saint-Armou
+Rue Lapas, soixante-quatre mille six cent quatre-vingts Buziet
+Allée Pottoroa, soixante-quatre, cinq cents Saint-Jean-de-Luz
+Rue Arnaud de Maytie, Mauléon-Licharre
+Chemin de Gendre à Daban à Morlaàs
+quatorze rue Georges Messier
+Route de Rivehaute au numéro cinq
+quarante chemin Dous Balens, soixante-quatre mille cent soixante Gabaston
+cent cinquante rue Mundustenea, soixante-quatre, deux cent dix, Bidart
+quatorze rue Séraphin Haulon, soixante-quatre, cent à Bayonne
+Chemin Chinou, soixante-quatre mille deux cent quatre-vingt-dix Aubertin
+Avenue Las Bordes, soixante-quatre, quatre cent vingt Soumoulou
+Route de Lembeye, Saint-Jammes
+Avenue de Montardon à Pau
+huit chemin Capbat
+Rue Barthèque au numéro seize
+trois rue Marguerite Cugnos, soixante-quatre mille Pau
+cent trois rue du Balaïtous, soixante-quatre, cinq cent dix, Boeil-Bezing
+trente-deux chemin de Roundelle, soixante-quatre, deux cent trente à Bougarber
+Rue des Fleuristes, soixante-quatre mille six cents Anglet
+Chemin du Griffet, soixante-quatre, trois cent soixante Monein
+Chemin d'Etxehandikoborda, Ustaritz
+Chemin d'Unamendi à Urrugne

--- a/server/data/fr/addresses-65.csv
+++ b/server/data/fr/addresses-65.csv
@@ -1,0 +1,70 @@
+deux cent onze BIS rue de la Galave, soixante-cinq mille trois cents Lannemezan
+quatre chemin de Cachalet, soixante-cinq, deux cent trente, Castelnau-Magnoac
+huit rue de la Graouette, soixante-cinq, trois cent dix à Laloubère
+Route de Layrisse, soixante-cinq mille deux cents Loucrup
+Rue Cabos, soixante-cinq, cent quarante Rabastens-de-Bigorre
+Route de Jarret, Lourdes
+Rue de Roquette Buisson à Argelès-Gazost
+trente marque Debat
+Rue du Nid Bigourdan au numéro neuf
+dix-sept rue de Traynès, soixante-cinq mille Tarbes
+neuf chemin du Trounc, soixante-cinq, cent, Bartrès
+vingt-neuf BIS chemin Clair, soixante-cinq, zéro zéro zéro à Tarbes
+Rue de Perseigna, soixante-cinq mille Tarbes
+Chemin de Mespoux, soixante-cinq, deux cents Bagnères-de-Bigorre
+Place Peyramale, Lourdes
+Rue de l'Oussouet à Trébons
+douze rue Raymond Peyrès
+Chemin de Perdigailh au numéro huit
+un impasse de la Geune, soixante-cinq mille deux cent quatre-vingt-dix Juillan
+vingt-six TER avenue Claude Chalin, soixante-cinq, cinq cents, Vic-en-Bigorre
+dix-neuf place Deras Laças, soixante-cinq, deux cents à Orignac
+Rue Charles Manciet, soixante-cinq mille quatre cent vingt Ibos
+Rue du Galor, soixante-cinq, trois cent quatre-vingts Orincles
+Impasse du Padouen, Bernadets-Debat
+Chemin de la Gouniou à Rabastens-de-Bigorre
+dix rue de la Bernède
+Avenue du Régiment de Bigorre au numéro trente-huit
+seize rue du Souy, soixante-cinq mille quatre cent vingt Ibos
+vingt-neuf rue François Marquès, soixante-cinq, zéro zéro zéro, Tarbes
+huit chemin des Loumagnes, soixante-cinq, deux cent vingt à Bernadets-Debat
+Cami de la Serre, soixante-cinq mille trois cent soixante Bernac-Dessus
+Rue de Lyouères, soixante-cinq, deux cent quarante Arreau
+Hameau Isaby, Pierrefitte-Nestalas
+Avenue des Hêtres à Odos
+vingt-cinq rue d'Escondeaux
+Rue Lanne-Dessus au numéro vingt
+neuf rue dets Labats, soixante-cinq mille cent vingt Luz-Saint-Sauveur
+deux place Marcadale, soixante-cinq, deux cent vingt, Trie-sur-Baïse
+quatre rue Lacrampe Loustau, soixante-cinq, cent quatre-vingt-dix à Tournay
+Impasse Urac, soixante-cinq mille quatre cent vingt Ibos
+Rue Jean Maumus, soixante-cinq, quatre cent trente Soues
+Route de Parabère, Larreule
+Impasse Lucie Sarthou à Ossun
+vingt-quatre rue de la Hountéte
+Lotissement Clairière au numéro quarante-deux
+trois chemin de Brousset, soixante-cinq mille trois cent soixante Vielle-Adour
+neuf chemin de la Bouderie, soixante-cinq, trois cent vingt, Lagarde
+dix rue de Langelle, soixante-cinq, cent à Lourdes
+Avenue du Pouey, soixante-cinq mille quatre cent vingt Ibos
+Chemin du Buala, soixante-cinq, cent quatre-vingt-dix Hitte
+Chemin de Juillan, Azereix
+Avenue de Besques à Argelès-Gazost
+trente et un route du Marmajou
+Route de Cantaous au numéro trente-huit
+huit quai de la Neste, soixante-cinq mille deux cent quarante Arreau
+soixante-six allées Labarnés, soixante-cinq, sept cents, Maubourguet
+douze résidence Array Dou Sou, soixante-cinq, zéro zéro zéro à Tarbes
+Rue Capdeville Cathala, soixante-cinq mille cent quatre-vingt-dix Tournay
+Rue de Silhac, soixante-cinq, cinq cents Vic-en-Bigorre
+Rue de Peyre Crabère, Lourdes
+Chemin du Comte Nord à Argelès-Gazost
+neuf cent quatre-vingt-dix-huit route de Cannet
+Rue du Général Menvielle au numéro trente
+cinquante-quatre rue de la Tour d'Oléac, soixante-cinq mille trois cent cinquante Boulin
+dix-neuf chemin des Artigaux, soixante-cinq, deux cents, Ordizan
+dix-neuf cami de Mességuères, soixante-cinq, trois cent soixante à Bernac-Debat
+Rue Lucien Pourxet, soixante-cinq mille cent Lourdes
+Rue d'Ossun, soixante-cinq, cent vingt Luz-Saint-Sauveur
+Rue des Bavarois, Luz-Saint-Sauveur
+Route de Las Poueyes à Aucun

--- a/server/data/fr/addresses-66.csv
+++ b/server/data/fr/addresses-66.csv
@@ -1,0 +1,70 @@
+vingt et un rue du Protocole de Kyoto, soixante-six mille trois cent trente Cabestany
+neuf avenue des Nidoleres, soixante-six, trois cents, Tresserre
+deux rue Jean Casanovas, soixante-six, deux cent quatre-vingts à Saleilles
+Rue des Millères, soixante-six mille deux cent quarante Saint-Estève
+Rue François Xavier Bichat, soixante-six, zéro zéro zéro Perpignan
+Rue d'en Cypria, Thuir
+Rue de la Mossenya à Canet-en-Roussillon
+quarante-deux avenue des Berges du Canal
+Rue Arnau de Vilanova au numéro un
+seize rue du Camp del Roc, soixante-six mille quatre cent cinquante Pollestres
+onze camin de Fontrabiosa, soixante-six, deux cent dix, Formiguères
+neuf route de Picaubeil, soixante-six, sept cent vingt à Cassagnes
+Rue Jean Lherminier, soixante-six mille deux cent cinquante Saint-Laurent-de-la-Salanque
+Rue Portal Dal Cim, soixante-six, cinq cents Prades
+Rue François Quesnay, Saint-Cyprien
+Impasse Ille Fruits à Ille-sur-Têt
+quatre avenue de Las Illas
+Rue de la Tour Auvergne au numéro dix
+quatre rue Héliopolis, soixante-six mille cent dix Amélie-les-Bains-Palalda
+vingt-neuf rue Midi-Soleil, soixante-six, six cent quatre-vingt-dix, Saint-André
+soixante-quatorze chemin de Torremila, soixante-six, zéro zéro zéro à Perpignan
+Route de Palau, soixante-six mille six cent quatre-vingt-dix Sorède
+Route de Sorède, soixante-six, six cent quatre-vingt-dix Saint-André
+Rue Paul Sejourné, Perpignan
+Rue Mal Joffre à Corbère-les-Cabanes
+sept carriera d'Amont
+Boulevard Henri Poincaré au numéro quatre
+sept rue San Vicens, soixante-six mille cent quatre-vingts Villeneuve-de-la-Raho
+vingt et un avenue du Canigou, soixante-six, cinq cent soixante, Ortaffa
+dix-neuf rue Joseph Sarda Garriga, soixante-six, trois cent soixante-dix à Pézilla-la-Rivière
+Avenue Edmond Puig, soixante-six mille quatre cents Céret
+Rue des Fabriques d'en Nadals, soixante-six, zéro zéro zéro Perpignan
+Boulevard François Desnoyer, Saint-Cyprien
+Avenue du Docteur Arrous à Prades
+vingt-six rue Armand Izarn
+Avenue de la Cantaranne au numéro quatre
+un allées de la Méditerranée, soixante-six mille deux cent cinquante Saint-Laurent-de-la-Salanque
+dix rue François Servent, soixante-six, zéro zéro zéro, Perpignan
+un rue Eugene Flachat, soixante-six, zéro zéro zéro à Perpignan
+Rue du Ribéral, soixante-six mille quatre cent trente Bompas
+Route de Terrats, soixante-six, trois cents Llupia
+Rue Joseph Xaupi, Perpignan
+Rue François Delcos à Perpignan
+cinq rue Ludovic Massé
+Rue de la Côte Vermeille au numéro dix-sept
+mille cent quatre-vingts chemin de Mailloles, soixante-six mille Perpignan
+vingt et un rue des Bergamotes, soixante-six, trois cents, Ponteilla
+vingt et un rue des Rois de Majorque, soixante-six, zéro zéro zéro à Perpignan
+Rue Tracy, soixante-six mille Perpignan
+Rue Le Clos des Vignes, soixante-six, quatre cents Céret
+Rue du Neulos, Laroque-des-Albères
+Avenue du Vallespir à Amélie-les-Bains-Palalda
+un avenue du Puigmal
+Rue Frédéric Saisset au numéro vingt et un
+dix-neuf impasse du Docteur Talairach, soixante-six mille Perpignan
+trente-huit route de Perpignan, soixante-six, deux cent quarante, Saint-Estève
+cinquante-quatre rue de la Rive Sud, soixante-six, deux cent quarante à Saint-Estève
+Rue Alexis Alquier, soixante-six mille Perpignan
+Rue Federico Fellini, soixante-six, zéro zéro zéro Perpignan
+Rue du Petit-Saint-Christophe, Perpignan
+Rue de Madeloc à Corneilla-del-Vercol
+trois rue du Puigmal
+Quai Alfred Nobel au numéro dix-huit
+vingt-cinq avenue de la Pierre Droite, soixante-six mille deux cent quarante Saint-Estève
+vingt et un rue Jean-Louis Forain, soixante-six, zéro zéro zéro, Perpignan
+trente-trois avenue de Brouilla, soixante-six, trois cents à Saint-Jean-Lasseille
+Impasse Cami de la Creu, soixante-six mille sept cent quarante Saint-Génis-des-Fontaines
+Boulevard du Cambre d'Aze, soixante-six, cent vingt Font-Romeu-Odeillo-Via
+Rue Gilbert Blanc, Ur
+Avenue Général Guillaut à Perpignan

--- a/server/data/fr/addresses-67.csv
+++ b/server/data/fr/addresses-67.csv
@@ -1,0 +1,70 @@
+trente et un lotissement Beau-Site, soixante-sept mille cent trente Wisches
+onze lotissement les Noisetiers, soixante-sept, trois cent soixante-dix, Berstett
+un rue Quellgraben, soixante-sept, trois cent quatre-vingt-dix à Bœsenbiesen
+Rue de la Haute-Vienne, soixante-sept mille sept cent soixante Gambsheim
+Route de Kintzheim, soixante-sept, six cents Sélestat
+Rue d'Ohlungen, Ohlungen
+Rue de Wolfisheim à Strasbourg
+trente-huit rue Courbée
+Rue de Gresswiller au numéro treize
+treize rue de Graufthal, soixante-sept mille trois cent vingt Schœnbourg
+vingt-trois place des Corbeaux, soixante-sept, cinq cent quatre-vingt-dix, Wintershouse
+quarante route de Weitbruch, soixante-sept, cinq cents à Haguenau
+Rue du Chanoine Rumpler, soixante-sept mille deux cent dix Obernai
+Rue du Leubuhl, soixante-sept, six cent cinquante Dambach-la-Ville
+Rue de Sarre-Union, Schopperten
+Route de Seltz à Beinheim
+cinquante-trois route du Polygone
+Rue des Marcaires au numéro quatorze
+quatre-vingt-quatorze chemin du Trouchy, soixante-sept mille cent trente Fouday
+quarante-cinq rue de Rosheim, soixante-sept, huit cent soixante-dix, Griesheim-près-Molsheim
+quinze A route de Brumath, soixante-sept, cinq cent cinquante à Vendenheim
+Route de Sainte-Marie-aux-Mines, soixante-sept mille sept cent trente Châtenois
+Rue de Neufchâteau, soixante-sept, trois cent cinquante Pfaffenhoffen
+Rue Finkwiller, Meistratzheim
+Cour Charles Spindler à Obernai
+vingt-six rue du Mont Sainte-Odile
+Rue de Sundenheim au numéro huit
+trente-cinq rue d'Ebersheim, soixante-sept mille six cents Sélestat
+trente et un rue du Climont, soixante-sept, cent vingt, Molsheim
+vingt-six rue Spiegelberg, soixante-sept, trois cent vingt à Weyer
+RUE DU ROSSLAUF, soixante-sept mille Strasbourg
+Rue de Gottenhouse, soixante-sept, sept cents Saverne
+Rue des Asperges, Oberhoffen-sur-Moder
+Rue de Wimmenau à Reipertswiller
+huit avenue Christian Pfister
+Rue du Haut-Barr au numéro dix
+vingt-six rue de Gambsheim, soixante-sept mille huit cent cinquante Herrlisheim
+vingt-six rue du Hahnenberg, soixante-sept, cent quatre-vingt-dix, Grendelbruch
+quinze rue Hechner, soixante-sept, zéro zéro zéro à Strasbourg
+Impasse du Zieselsberg, soixante-sept mille trois cent dix Westhoffen
+Rue de Laubach, soixante-sept, trois cent soixante Eschbach
+Rue de Durstel, Drulingen
+Rue Henri Schirmer à Dorlisheim
+dix-huit A rUE DU COUVENT
+Place des Chèvres au numéro six
+vingt-cinq rue Lacroix sur Meuse, soixante-sept mille cent dix Gundershoffen
+un rue de Poulouzat, soixante-sept, quatre cent quatre-vingts, Forstfeld
+vingt-huit rue de Dossenheim, soixante-sept, zéro zéro zéro à Strasbourg
+Rue de Soultz, soixante-sept mille cinq cent dix Climbach
+Rue de Schirmeck, soixante-sept, cinq cent soixante-dix Rothau
+Rue du Hattgau, Betschdorf
+Rue du Château Fiat à Haguenau
+sept rue Henri Meck
+Rue du Stade Saint-Paul au numéro vingt-neuf
+trente-trois rue de Wingersheim, soixante-sept mille cent soixante-dix Krautwiller
+quatre rue de Hochfelden, soixante-sept, deux cent soixante-dix, Lixhausen
+neuf rue du Docteur Deutsch, soixante-sept, deux cent cinquante à Surbourg
+Rue Langgarten, soixante-sept mille trois cent soixante-dix Pfulgriesheim
+Rue Tacite, soixante-sept, zéro zéro zéro Strasbourg
+Rue du Champ du Feu, Vendenheim
+Rue de Neubourg à Mertzwiller
+vingt rue d'Orbey
+Rue de l'Unterelsau au numéro soixante-six
+cinq rue David Gruber, soixante-sept mille Strasbourg
+dix-neuf rue de Lingolsheim, soixante-sept, huit cent dix, Holtzheim
+trois rue de Koenigsbruck, soixante-sept, cinq cents à Haguenau
+Rue de Bolsenheim, soixante-sept mille cent cinquante Schaeffersheim
+Rue Waldteufel, soixante-sept, huit cents Bischheim
+Route de Schirmeck, Strasbourg
+Chemin de la Fischhutte à Rosheim

--- a/server/data/fr/addresses-68.csv
+++ b/server/data/fr/addresses-68.csv
@@ -1,0 +1,70 @@
+treize rue Respel, soixante-huit mille trois cent quatre-vingts Muhlbach-sur-Munster
+quinze rue Alfred Jédélé, soixante-huit, cent trente, Altkirch
+dix-huit rue de la un E Armee, soixante-huit, deux cent quarante à Sigolsheim
+Rue de la Natte, soixante-huit mille quatre cent quarante Bruebach
+Rue de Richwiller, soixante-huit, cent vingt Pfastatt
+Rue Dollfus, Mulhouse
+Rue des Trois Epis à Niedermorschwihr
+un rue du Vontay
+Rue Adolphe Hirn au numéro dix-sept
+six chemin Weiher, soixante-huit mille six cent dix Lautenbachzell
+trente-trois rue Dr A Schweitzer, soixante-huit, cent quarante, Gunsbach
+vingt-deux rue de Sierentz, soixante-huit, cent à Mulhouse
+Rue du Widersbach, soixante-huit mille six cent dix Lautenbachzell
+Rue du Naegeleberg, soixante-huit, quatre cents Riedisheim
+Route d'Éguisheim, Ingersheim
+Rue Scheurer-Kestner à Mulhouse
+onze rue de l'Ohmbach
+Rue du Commandant O Connel au numéro neuf
+quatre-vingt-quatorze rue Herzog, soixante-huit mille neuf cent vingt Wettolsheim
+quatorze rue Jean-Jacques Scherrer, soixante-huit, quatre cent soixante, Lutterbach
+trente-trois route de Bâle, soixante-huit, sept cent quarante à Balgau
+Rue de Pfastatt, soixante-huit mille deux cent soixante Kingersheim
+Côteaux de l'Appenthal, soixante-huit, cinq cents Guebwiller
+Rue Vue des Alpes, Kruth
+Rue de Guewenheim à Soppe-le-Bas
+trente A rue de l'Île Napoléon
+Rue Saint Nicolas au numéro onze
+six rue de Huhnabuhl, soixante-huit mille deux cent trente Niedermorschwihr
+vingt-quatre résidence le Petit Bois, soixante-huit, sept cent trente, Michelbach-le-Bas
+quarante-deux rue de Luemschwiller, soixante-huit, cent trente à Walheim
+Rue du Stauffen, soixante-huit mille deux cent trente Wihr-au-Val
+Rue Beau Village, soixante-huit, sept cent trente Blotzheim
+Rue Marguerite Braun, Masevaux
+Rue de Ploudaniel à Fréland
+dix avenue de Riedisheim
+Place de Trzic au numéro trois
+un C rue du Général de Kleinenberg, soixante-huit mille trois cent vingt Fortschwihr
+cinq rue Martin Drolling, soixante-huit, cent vingt-sept, Oberhergheim
+vingt-huit rue André Clemessy, soixante-huit, deux cents à Mulhouse
+Route de Guémar, soixante-huit mille neuf cent soixante-dix Illhaeusern
+Rue du Faudé, soixante-huit, trois cent soixante-dix Orbey
+Rue d'Oberfeld, Ranspach-le-Bas
+Route de Rouffach à Colmar
+dix unterer Traenk Weg
+Rue du Ladhof au numéro soixante-quatre
+six A rue d'Ostheim, soixante-huit mille trois cent vingt Jebsheim
+douze rue du Docteur Marcel Hurst, soixante-huit, trois cents, Saint-Louis
+huit rue du Wasen, soixante-huit, six cent dix à Lautenbachzell
+Rue du Weckmund, soixante-huit mille Colmar
+Chemin de la Hingrie, soixante-huit, six cent soixante Rombach-le-Franc
+Rue du Damberg, Brunstatt
+Rue de l'Augraben à Kembs
+treize rue du Pflixbourg
+Rue de la Mine d'Argent au numéro quarante-six
+deux rue d'Orschwihr, soixante-huit mille cent dix Illzach
+vingt-six rue d'Elbach, soixante-huit, deux cent dix, Retzwiller
+quatorze rue Neubruck, soixante-huit, cinq cent trente à Buhl
+Avenue du Drucksess, soixante-huit mille sept cent trente Blotzheim
+Rue d'Ottmarsheim, soixante-huit, cent dix Illzach
+Route d'Eschentzwiller, Dietwiller
+Rue Bigarreau à Kingersheim
+huit A rue de Willer
+Rue de Lepuix au numéro quatre B
+quatre rue Roger Hoffarth, soixante-huit mille trois cent quatre-vingt-dix Sausheim
+quatre rue de Dietwiller, soixante-huit, quatre cents, Riedisheim
+quarante-neuf rue du Général Bourgeois, soixante-huit, cent soixante à Sainte-Marie-aux-Mines
+Route du Wahlweg, soixante-huit mille trois cent dix Wittelsheim
+Rue André Lichtlé, soixante-huit, cent vingt Pfastatt
+Rue d'Azur, Burnhaupt-le-Haut
+Rue du Rod à Soultzeren

--- a/server/data/fr/addresses-69.csv
+++ b/server/data/fr/addresses-69.csv
@@ -1,0 +1,70 @@
+neuf allée du Mont Cindre, soixante-neuf mille trois cents Caluire-et-Cuire
+deux chemin du Bois de Longe, soixante-neuf, cinq cent soixante-dix, Dardilly
+vingt-sept rue Élie Rochette, soixante-neuf, zéro zéro sept à Lyon
+Passage Tolozan, soixante-neuf mille un Lyon
+Rue de Fontanières, soixante-neuf, cent Villeurbanne
+Rue de la Haute-Valois, Millery
+Allée Thalie à Saint-Genis-Laval
+treize chemin de l'Araire
+Cours Tolstoï au numéro vingt-six
+sept allée Joséphine Bardon, soixante-neuf mille trois cent dix Pierre-Bénite
+mille quatre cent soixante-dix-neuf route de Theizé, soixante-neuf, quatre cents, Pouilly-le-Monial
+cent vingt-huit avenue Lacassagne, soixante-neuf, zéro zéro trois à Lyon
+Route de Anse, soixante-neuf mille quatre cent quatre-vingts Lucenay
+Avenue de Montmartin, soixante-neuf, neuf cent soixante Corbas
+Allée B des Santons, Sainte-Foy-lès-Lyon
+Square Huguette Bois à Saint-Priest
+vingt rue Tronchet
+Passage Lamure au numéro onze
+trente-six rue des Confins du Château, soixante-neuf mille sept cents Chassagny
+douze rue Antoine Ferraud, soixante-neuf, deux cent vingt, Belleville
+dix-neuf chemin de la Ferlatière, soixante-neuf, trois cent soixante-dix à Saint-Didier-au-Mont-d'Or
+Rue des Deux Amants, soixante-neuf mille neuf Lyon
+Rue Paul Huvelin, soixante-neuf, cent dix Sainte-Foy-lès-Lyon
+Allée Françoise Buffeton, Dardilly
+Rue du Château de la Duchère à Lyon
+un place Camille Georges
+Rue Loyson de Chastelus au numéro cinq cent trente et un
+quatre rue Victor Subit, soixante-neuf mille cent Villeurbanne
+soixante-quinze impasse du Suel, soixante-neuf, sept cents, Échalas
+vingt-quatre rue Jacques Reynaud, soixante-neuf, huit cents à Saint-Priest
+Allée de la Piscine, soixante-neuf mille cinq cent trente Brignais
+Rue Cité de l'Abbé Pierre, soixante-neuf, huit cents Saint-Priest
+Boulevard Castellane, Sathonay-Camp
+Chemin de Revaison à Saint-Priest
+un rue Maxime Lalouette
+Rue Capitaine Julien au numéro mille un
+neuf avenue Jean Moos, soixante-neuf mille cinq cent cinquante Amplepuis
+quatre impasse du Docteur Pénard, soixante-neuf, six cent trente, Chaponost
+trente-cinq rue Albert Falsan, soixante-neuf, zéro zéro neuf à Lyon
+Chemin de Crépieux, soixante-neuf mille trois cents Caluire-et-Cuire
+Rue des Frères Caudron, soixante-neuf, trois cent trente Meyzieu
+Rue du Clos des Coquilles, Francheville
+Rue Ferdinand Perrier à Saint-Priest
+quatre mille cent vingt-sept route du Grisard
+Rue Marcel Merieux au numéro soixante-douze D
+cent soixante-douze montée des Tiers, soixante-neuf mille quatre cents Liergues
+trente-six rue Marie Mas, soixante-neuf, sept cents, Givors
+dix-sept rue René Chapard, soixante-neuf, six cent trente à Chaponost
+Rue Édouard Rochet, soixante-neuf mille huit Lyon
+Quai Docteur Gailleton, soixante-neuf, zéro zéro deux Lyon
+Allée du Val de Serres, Dardilly
+Rue Benoit Badoil à Chaponost
+vingt et un rue Antoine Vacher
+Route des Monts d'Or au numéro deux cent huit
+six cent quatre-vingt-deux H route du Bas Privas, soixante-neuf mille trois cent quatre-vingt-dix Charly
+cent quarante et un rue Joannès Sabot, soixante-neuf, quatre cents, Villefranche-sur-Saône
+cent vingt-cinq rue d'Anse, soixante-neuf, quatre cents à Villefranche-sur-Saône
+Route de la Vauxonne, soixante-neuf mille quatre cent soixante Saint-Étienne-des-Oullières
+Rue des Rivetières, soixante-neuf, deux cent vingt Dracé
+Rue Hippolyte Côte, Tarare
+Rue Fulgencio Gimenez à Vaulx-en-Velin
+cent cinquante-trois chemin d'Apinost
+Route de Toussieu au numéro quatorze
+cinq chemin de Tholomé, soixante-neuf mille neuf cent soixante-dix Chaponnay
+cinq avenue de Réaumur, soixante-neuf, cent cinquante, Décines-Charpieu
+vingt-quatre quai de Charézieux, soixante-neuf, deux cent soixante-dix à Saint-Romain-au-Mont-d'Or
+Chemin du Vallombrey, soixante-neuf mille cent trente Écully
+Rue Pierre Brunier, soixante-neuf, trois cents Caluire-et-Cuire
+Rue Bonnefond, Givors
+Allée du Baraillon à Tassin-la-Demi-Lune

--- a/server/data/fr/addresses-70.csv
+++ b/server/data/fr/addresses-70.csv
@@ -1,0 +1,70 @@
+quarante rue de la Fontaine Anneau, soixante-dix mille trois cent vingt Corbenay
+dix route de Rioz, soixante-dix, cent quatre-vingt-dix, Aulx-lès-Cromary
+sept rue de la Roichotte, soixante-dix, quatre cents à Saulnot
+Rue des Cités Tournesac, soixante-dix mille quatre cents Héricourt
+Rue de Cresancey, soixante-dix, cent Champtonnay
+Route du Creux Chêne, Amage
+Rue du Général Poncet à Pesmes
+dix BIS route d'Esprels
+Rue du Grand Coteau au numéro dix-sept
+douze A rue de Bauffremont, soixante-dix mille cent quatre-vingt-dix Vandelans
+six rue de les Aynans, soixante-dix, deux cents, Vouhenans
+deux rue Pauléon Fournot, soixante-dix, cent soixante à Saint-Remy
+Rue de la Grand Combe, soixante-dix mille deux cent trente Bouhans-lès-Montbozon
+Rue Marcel Hacquard, soixante-dix, zéro zéro zéro Noidans-lès-Vesoul
+Rue du Pré Perney, Genevrey
+Rue de Loulans à Montbozon
+vingt-neuf impasse de la l'Aviation
+Impasse Marie Richard au numéro onze
+six rue de la Duremanne, soixante-dix mille deux cent dix Saponcourt
+huit rue du Champ Mercey, soixante-dix, zéro zéro zéro, Navenne
+six rue d'Auxon, soixante-dix, cent soixante-dix à Bougnon
+Rue du Messager, soixante-dix mille deux cents Le Val-de-Gouhenans
+Rue Saint-Valère, soixante-dix, cent soixante-dix Port-sur-Saône
+Rue Georges et Pierre Henry, Corbenay
+Rue du Capitaine Blandin à Vesoul
+trois rue Dagnan Bouveret
+Rue Henry Guy au numéro neuf
+trente-neuf rue de la Gare d'Aillevillers, soixante-dix mille trois cent vingt Corbenay
+vingt-sept rue Roberte Luzet, soixante-dix, huit cents, Saint-Loup-sur-Semouse
+quinze vieille Route de Boult, soixante-dix, cent quatre-vingt-dix à Voray-sur-l'Ognon
+Le Prémourey, soixante-dix mille deux cent vingt Fougerolles
+Rue Sous Saroche, soixante-dix, quatre cents Héricourt
+Rue de la Corvée Neuve, Pusey
+Rue du Mont de Roche à Vellefaux
+trois chemin de la Ronde Besse
+Le Volvet au numéro soixante-six
+sept avenue René Fouquet, soixante-dix mille cent soixante-dix Port-sur-Saône
+onze route de Vauvillers, soixante-dix, deux cent dix, Mailleroncourt-Saint-Pancras
+douze rue de la Mechelle, soixante-dix, deux cents à Magny-Vernois
+Rue de Traves, soixante-dix mille cent trente Noidans-le-Ferroux
+Rue des Champs La Devant, soixante-dix, deux cents Clairegoutte
+Route de Bourguignon, Bassigney
+Blanzey à Fougerolles
+trente et un rue de la Gode Biche
+Rue André Thiebaut au numéro six
+huit rue Juliot-Curie, soixante-dix mille deux cents Lure
+dix-neuf rue de Fourouze, soixante-dix, cent trente, Fretigney-et-Velloreille
+deux cent soixante-cinq le Grand Fays, soixante-dix, deux cent vingt à Fougerolles
+Rue Marcel Garret, soixante-dix mille cent soixante Menoux
+Rue Jean Sainty, soixante-dix, quatre cents Héricourt
+Rue de Cognières, Bouhans-lès-Montbozon
+Rue de Dampvalley à Colombe-lès-Vesoul
+dix rue Meillier
+Rue Miroudot Saint-Ferjeux au numéro vingt-deux A
+neuf rue En Saumon, soixante-dix mille quatre cents Coisevaux
+deux BIS grande Rue de Corcelles, soixante-dix, quatre cents, Saulnot
+un rue du Paquit, soixante-dix, sept cents à Frasne-le-Château
+Place Léon Jacquey, soixante-dix mille huit cents Saint-Loup-sur-Semouse
+Sentier de la Jus, soixante-dix, deux cents Saint-Germain
+Impasse des Planchottes, Vy-lès-Rupt
+Rue d'Orière à Ronchamp
+trente et un rue de Plombières-les-Bains
+Route de Faucogney au numéro un BIS
+six route de Luxeuil, soixante-dix mille huit cents Conflans-sur-Lanterne
+huit rue des Danvions, soixante-dix, zéro zéro zéro, Vesoul
+trente-trois rue Henri Duhaut, soixante-dix, trois cent vingt à Corbenay
+Place du Trau, soixante-dix mille Vesoul
+Rue Charles Chevillard, soixante-dix, zéro zéro zéro Quincey
+Avenue du Maréchal Turenne, Luxeuil-les-Bains
+Impasse Michel Brocard à Magny-Vernois

--- a/server/data/fr/addresses-71.csv
+++ b/server/data/fr/addresses-71.csv
@@ -1,0 +1,70 @@
+trois rue Desire Gilot, soixante et onze mille cent Saint-Rémy
+vingt-huit rue Henri Mugnier, soixante et onze, quatre cent vingt, Ciry-le-Noble
+six rue Colonel Rol Tanguy, soixante et onze, deux cent trente à Saint-Vallier
+Route du Pierry, soixante et onze mille cinq cents Saint-Usuge
+Rue Bouteiller, soixante et onze, quatre cents Autun
+Route de Demigny, Fragnes
+Rue Jean-Baptiste Perrusson à Écuisses
+quarante-six route de Bourbon Lancy
+Rue du Normandie au numéro quatorze
+un rue Harold de Fontenay, soixante et onze mille quatre cents Autun
+trois cent trente-six rue Auguste Varmancourt, soixante et onze, quatre cent cinquante, Blanzy
+quarante-neuf rue des Drémeaux, soixante et onze, quatre cents à Autun
+Rue Jacques Guéritaine, soixante et onze mille deux cent cinquante Cluny
+Rue de Saint-Eusebe, soixante et onze, quatre cent cinquante Blanzy
+Route de Lusigny, Sornay
+Route de Messey-le-Bois à Messey-sur-Grosne
+soixante-treize BIS rue des Rompois
+Levée du Canal au numéro six
+vingt-deux rue Odette Dauxois, soixante et onze mille deux cent cinquante Salornay-sur-Guye
+dix-huit rue du Quart Pichet, soixante et onze, deux cent soixante, Saint-Albain
+cinquante-trois rue du Pont de Bourbon, soixante et onze, cent soixante à Digoin
+Rue Pierre Bridet, soixante et onze mille cent Chalon-sur-Saône
+Route de Lessu, soixante et onze, cinq cent quatre-vingt-dix Gergy
+Montée Renaud, Sassenay
+Voie Communale Les Prés Saint-Martin à Perrecy-les-Forges
+neuf cent trente-cinq route de Juif
+Rue du vingt-deux e BMNA au numéro dix BIS
+quatre impasse Les Farges, soixante et onze mille cent soixante-dix Chauffailles
+soixante-dix rue Ernest Carrier, soixante et onze, six cents, Paray-le-Monial
+quatre lotissement Le Hameau du Moulin, soixante et onze, cinq cent soixante-dix à La Chapelle-de-Guinchay
+Rue du Gothard, soixante et onze mille huit cents La Clayette
+Avenue du quatre Septembre mille neuf cent quarante-quatre, soixante et onze, deux cent quarante Sennecey-le-Grand
+Route de Davayé, Charnay-lès-Mâcon
+Avenue des Granges Forestiers à Chalon-sur-Saône
+trois cent soixante-huit rue des Collots
+Route du Molard au numéro quarante-six
+seize route de Ruère, soixante et onze mille deux cent quarante Saint-Cyr
+trois rue du Lieutenant Albert Schmitt, soixante et onze, deux cent cinquante, Cluny
+trois rue du Champ de la Maison, soixante et onze, trois cent soixante-dix à Ouroux-sur-Saône
+Grande Rue Marosse, soixante et onze mille trois cent soixante-dix Saint-Germain-du-Plain
+Chemin de l'Ambutelière, soixante et onze, cinq cents Vincelles
+Rue Charles Dodille, Saint-Rémy
+Route de Dracy Saint-Loup à Saint-Léger-du-Bois
+un BIS rue du Docteur Jeannin
+Rue d'Herne au numéro six
+quatorze avenue du Morvan, soixante et onze mille quatre cents Autun
+six place Claude Bernard, soixante et onze, cent, Chalon-sur-Saône
+cinquante avenue de Mortières, soixante et onze, six cent quarante à Givry
+Route de Châlon, soixante et onze mille quatre cents Autun
+Rue du Pré Peutot, soixante et onze, six cent vingt Saint-Didier-en-Bresse
+Route des Chambards, Saint-Martin-du-Mont
+Rue des Hauts de Charon à Mellecey
+douze impasse Marguerite de Vienne
+Impasse du Champ Pommier au numéro soixante-cinq
+vingt et un rue de Ménincourt, soixante et onze mille quatre cents Autun
+dix rue des Bernauds, soixante et onze, six cent soixante-dix, Saint-Pierre-de-Varennes
+deux place du Pont-Paron, soixante et onze, cent à Saint-Rémy
+Chemin des Vincents, soixante et onze mille cinq cents Ratte
+Rue de Saint-Eusèbe, soixante et onze, deux cent dix Saint-Laurent-d'Andenay
+Rue Claude Dorleans, Blanzy
+Impasse Frachet à Mâcon
+cinq cent dix rue des Ravarys
+Chemin de la Ronge au numéro quatre-vingt-treize
+trois rue Louis Guepey, soixante et onze mille trois cent cinquante Allerey-sur-Saône
+cinq B rue de la Collonge, soixante et onze, trois cent quatre-vingt-dix, Granges
+sept rue du Buet, soixante et onze, six cent quarante à Dracy-le-Fort
+Rue du Matray, soixante et onze mille cinq cent vingt Matour
+Route de Laives, soixante et onze, deux cent quarante Sennecey-le-Grand
+Chemin du Petit Lavoir, Saint-Jean-de-Vaux
+Rue de Bourbon Lancy à Montceau-les-Mines

--- a/server/data/fr/addresses-72.csv
+++ b/server/data/fr/addresses-72.csv
@@ -1,0 +1,70 @@
+quatre-vingt-dix boulevard du Général de Négrier, soixante-douze mille Le Mans
+trente-quatre rue du Pavois, soixante-douze, cent cinquante, Le Grand-Lucé
+trente et un hameau de la Lijonnière, soixante-douze, cinq cent dix à Requeil
+Rue de Balyver, soixante-douze mille Le Mans
+Rue de Gallerande, soixante-douze, huit cents Luché-Pringé
+Allée du Pont des Arts, Changé
+Impasse Armand Saffray au Mans
+vingt-quatre rue de Cinq Ans
+Impasse du Viaduc de Millau au numéro six
+quarante-sept rue de Claircigny, soixante-douze mille Le Mans
+quinze cité de la Croix, soixante-douze, six cent cinquante, Trangé
+vingt-huit rue Jean Courtois, soixante-douze, quatre cents à La Ferté-Bernard
+Rue Bouttevin Boullay, soixante-douze mille trois cent soixante Mayet
+Rue Louatron, soixante-douze, cent soixante-dix Beaumont-sur-Sarthe
+Impasse Hellé-Desjardins, Saint-Calais
+Chemin du Ceux à Notre-Dame-du-Pé
+douze C rue du Patis Saint-Germain
+Rue de Woodhall-Spa au numéro neuf
+cinq B rue de la Presche, soixante-douze mille Le Mans
+cent dix rue Guillemare, soixante-douze, zéro zéro zéro, Le Mans
+sept chemin d'Aillande, soixante-douze, cent quatre-vingt-dix à Neuville-sur-Sarthe
+Chemin de Vezin, soixante-douze mille trois cent soixante Mayet
+Boulevard René Levasseur, soixante-douze, zéro zéro zéro Le Mans
+Rue de Richedoué, Le Mans
+Rue du Cormeret à Saint-Symphorien
+cinquante et un route des Fondus
+Route de Lombron au numéro trente et un BIS
+deux rue du Velaert, soixante-douze mille huit cents Le Lude
+un rue du Clotereau, soixante-douze, deux cent soixante, Thoigné
+six hameau de la Fréardière, soixante-douze, deux cent trente à Mulsanne
+Avenue Rubillard, soixante-douze mille Le Mans
+Clos de la Vairie, soixante-douze, trois cents Précigné
+Rue de la Cannetiere, Bonnétable
+Rue de Pastière au Mans
+vingt-trois rue de la Terroirie
+Allée Renault au numéro dix-sept
+trois avenue de Kirch Dorf, soixante-douze mille cent vingt Saint-Calais
+deux cent quarante-trois avenue Léon Bollée, soixante-douze, zéro zéro zéro, Le Mans
+quatorze rue de la Fromentière, soixante-douze, trois cents à Juigné-sur-Sarthe
+Rue Henri Maubert, soixante-douze mille cent vingt Saint-Calais
+Rue de Pruillé, soixante-douze, sept cents Rouillon
+Chemin Léon Besnardeau, Saint-Rémy-de-Sillé
+Rue de l'Abord au Chanvre au Mans
+trois chemin de Saint-Père
+Rue de la Sirouanne au numéro quatre
+sept rue Chalot, soixante-douze mille cent cinquante Le Grand-Lucé
+sept rue Alexandre Besnard, soixante-douze, huit cents, Aubigné-Racan
+neuf rue de La Perrière, soixante-douze, quatre cents à Cormes
+Rue Joël Sadeler, soixante-douze mille Le Mans
+Route de la Lainerie, soixante-douze, deux cent vingt Saint-Ouen-en-Belin
+Hameau de la Foucaudière, Mulsanne
+Chemin de Chêne Neuf à Cérans-Foulletourte
+trois promenade du Grand Mail
+Rue du Port à l'Abbesse au numéro neuf
+quatre cent vingt-trois avenue Georges Durand, soixante-douze mille cent Le Mans
+vingt-trois avenue André Cerisay, soixante-douze, trois cents, Sablé-sur-Sarthe
+soixante-quatre rue Georges Boullet, soixante-douze, cent au Mans
+Route des Guérinières, soixante-douze mille deux cent vingt Écommoy
+Rue Albert Guérin, soixante-douze, deux cent trente Arnage
+Rue de Funay, Le Mans
+Route du Rasnay à Saint-Gervais-en-Belin
+quatre hameau de Lorraine
+Allée de Courchet au numéro quatorze
+un A rue de la Guyonnière, soixante-douze mille cent quarante Mont-Saint-Jean
+quatre allée Haute, soixante-douze, cinq cent trente, Yvré-l'Évêque
+douze rue Bablot, soixante-douze, cent au Mans
+Rue de Viez, soixante-douze mille deux cents La Flèche
+Boulevard de l'Hospice, soixante-douze, huit cents Le Lude
+Rue Marie Louise Bodin, Le Grand-Lucé
+Impasse des Rodiveaux à Changé

--- a/server/data/fr/addresses-73.csv
+++ b/server/data/fr/addresses-73.csv
@@ -1,0 +1,70 @@
+onze avenue des Ducs de Savoie, soixante-treize mille Chambéry
+soixante-dix A route de la Bridoire, soixante-treize, trois cent trente, Domessin
+deux cent soixante-quinze chemin de Carsine, soixante-treize, trois cent dix à Serrières-en-Chautagne
+Route des Grandes Côtes, soixante-treize mille cinq cent vingt La Bridoire
+Montée des Charmettes, soixante-treize, trois cent trente Domessin
+Route de Motz, Serrières-en-Chautagne
+Route du Meyrieux à La Biolle
+soixante et onze allée des Louises-Bonnes
+Chemin du Grand Péchu au numéro deux cent vingt
+cent quatre chemin de Chiron, soixante-treize mille Chambéry
+quatorze rue Saint-Pierre Aux Liens, soixante-treize, quatre cent soixante, Grésy-sur-Isère
+quatre-vingt-trois route d'Annecy, soixante-treize, quatre cents à Ugine
+Route des Jeux Olympiques, soixante-treize mille cinq cent quatre-vingt-dix Crest-Voland
+Route de Yenne, soixante-treize, deux cent quarante Saint-Genix-sur-Guiers
+Rue du Plan Champ, Saint-Jeoire-Prieuré
+Allée du Champ de Bois à Tresserve
+deux cent vingt et un montée du Coin
+Rue de la Croix Saint-Maurice au numéro neuf
+cent trente-quatre rue des Chauvets, soixante-treize mille cent Grésy-sur-Aix
+sept cent trente-neuf rue du Pré de l'Âne, soixante-treize, zéro zéro zéro, Chambéry
+cent soixante-seize B rue Au Carré, soixante-treize, huit cents à Sainte-Hélène-du-Lac
+Allée du Clos Mercier, soixante-treize mille deux cent soixante Aigueblanche
+Chemin des Molettes, soixante-treize, deux cents Albertville
+Rue Bonrieux, Saint-Jean-de-Maurienne
+Rue Amélie Gex à Challes-les-Eaux
+six cent quarante-quatre route de Mollardurand
+Chemin du Frettey au numéro cent quatre-vingt-neuf
+cinquante-cinq rue de la Terre Sainte, soixante-treize mille cent dix Arvillard
+trente-six clos du Revard, soixante-treize, trois cent soixante-dix, Le Bourget-du-Lac
+mille cinq cent quinze chemin du Gâteau, soixante-treize, cinq cent quatre-vingt-dix à Flumet
+Chemin des Fromagets, soixante-treize mille huit cents Les Marches
+Avenue Charles Albert, soixante-treize, deux cent quatre-vingt-dix La Motte-Servolex
+Rue de la Leysse, La Motte-Servolex
+Boulevard du Port aux Filles à Aix-les-Bains
+six cent vingt-neuf chemin des Bogeys
+Allée Jean Eustache au numéro quatre
+trois cent quatre allée de la Muraille, soixante-treize mille deux cents Mercury
+un rue Paul Bonna, soixante-treize, cent, Aix-les-Bains
+quatorze route de Pugny, soixante-treize, cent à Aix-les-Bains
+Allée Haute du Chateau, soixante-treize mille deux cent trente Saint-Jean-d'Arvey
+Allée des Signères, soixante-treize, quatre cent vingt Drumettaz-Clarafond
+Montée de Charpignat, Le Bourget-du-Lac
+Chemin de la Grimotière à Aix-les-Bains
+mille huit cent cinquante-neuf route de Trévignin
+Chemin de la Croix de Bissy au numéro cent trente-sept
+cent soixante-deux quai de la Rize, soixante-treize mille Chambéry
+cent vingt place de la Saint-Marcel, soixante-treize, deux cent soixante, Aigueblanche
+dix rue de la Curtane, soixante-treize, trois cent quatre-vingt-dix à Villard-Léger
+Chemin de Pré Quenard, soixante-treize mille huit cents Myans
+Rue Sergent J-Revel, soixante-treize, zéro zéro zéro Jacob-Bellecombette
+Rue du Petit Clos de l'Échaud, La Ravoire
+Chemin de Memard à Aix-les-Bains
+cent trente-deux allée du Goléron
+Route de Champlaurent au numéro dix-huit
+cent quarante-six rue du Champ Collomb, soixante-treize mille trois cent dix Chindrieux
+deux cent soixante-treize rue du Pont Levant, soixante-treize, trois cents, Pontamafrey-Montpascal
+deux cent quarante route de Bunand, soixante-treize, deux cent quarante à Avressieux
+Rue Richard Curt, soixante-treize mille deux cent soixante Aigueblanche
+Impasse Route de Yenne, soixante-treize, deux cent quarante Saint-Genix-sur-Guiers
+Rue de Chavières, Modane
+Rue Antoine Montagnole à Viviers-du-Lac
+trois cent trente-trois rue Charles Cabaud
+Chemin du Mont Pezard au numéro cent soixante
+mille deux cents route de la Frasse, soixante-treize mille deux cents Mercury
+sept cent soixante-douze route de Montaugier, soixante-treize, deux cent quatre-vingt-dix, La Motte-Servolex
+deux cent soixante-quinze avenue de la Combe de Savoie, soixante-treize, quatre cent soixante à Grésy-sur-Isère
+Rue du Chef-Lieu, soixante-treize mille trois cent trente Domessin
+Rue Jean-Pierre Veyrat, soixante-treize, zéro zéro zéro Chambéry
+Route des Bons Prés, La Croix-de-la-Rochette
+Impasse la Vapeur à Barberaz

--- a/server/data/fr/addresses-74.csv
+++ b/server/data/fr/addresses-74.csv
@@ -1,0 +1,70 @@
+mille sept cent soixante-sept route de Deyrier, soixante-quatorze mille trois cent cinquante Cruseilles
+dix avenue de Brogny, soixante-quatorze, zéro zéro zéro, Annecy
+quarante-six chemin du Pre de la Croix, soixante-quatorze, deux cent quatre-vingt-dix à Bluffy
+Route de la Villaz, soixante-quatorze mille quatre cent trente Saint-Jean-d'Aulps
+Chemin de la Coutire, soixante-quatorze, quatre cents Chamonix-Mont-Blanc
+Route de Bonnaz, Fillinges
+Route de Crevin à Bossey
+huit cent quatre-vingt-six route de Chez Pilloux
+Impasse Chanteneige au numéro seize
+deux cent quatre-vingt-onze rue des Bairiers, soixante-quatorze mille cent trente Bonneville
+cent cinquante-cinq allée du Mont Blanc, soixante-quatorze, cent vingt, Praz-sur-Arly
+quatre cent vingt-sept chemin du Grand Pré de Melan, soixante-quatorze, quatre cent quarante à Taninges
+Impasse des Tarteriaz, soixante-quatorze mille deux cent vingt La Clusaz
+Route du Jaillet, soixante-quatorze, cent vingt Megève
+Allée Francois Fauconnet, Évian-les-Bains
+Clos les Primevères à Viuz-en-Sallaz
+trois mille deux route de Notre-Dame de la Gorge
+Avenue de Montigny au numéro cent trois
+cent quarante-six taille de Mas du Pleney, soixante-quatorze mille cent dix Morzine
+cent six route des Vieux Rotets, soixante-quatorze, trois cent trente, La Balme-de-Sillingy
+deux avenue du Vernay, soixante-quatorze, deux cents à Thonon-les-Bains
+Impasse de Beffarol, soixante-quatorze mille huit cent quatre-vingt-dix Bons-en-Chablais
+Chemin de Jovet, soixante-quatorze, sept cents Cordon
+Chemin des Storts, Passy
+Chemin des Nicodeins à Saint-Martin-Bellevue
+mille sept cent quatorze route du Crêt du Merle
+Chemin du Pont Noir au numéro trois cent soixante-treize
+cent quatre-vingt-deux route du Pré Chatelain, soixante-quatorze mille deux cent soixante-dix Chessenaz
+soixante-quatorze route du Pont de l'Hermance, soixante-quatorze, cent quarante, Veigy-Foncenex
+cent vingt-quatre chemin Alfred Le Renard, soixante-quatorze, cent vingt à Megève
+Grande Rue d'Aléry, soixante-quatorze mille neuf cent soixante Cran-Gevrier
+Rue des Eplanes, soixante-quatorze, cent soixante Beaumont
+Rue des Moulins d'Avulligoz, Publier
+Chemin du Lavoussé à Chamonix-Mont-Blanc
+cinquante route des Balmettes
+Route de Moussy au numéro trois cent treize
+cent chemin du Châble, soixante-quatorze mille quatre cents Chamonix-Mont-Blanc
+cinquante-trois route de la Savoyarde, soixante-quatorze, neuf cent vingt, Combloux
+cent cinquante H chemin de Savouille, soixante-quatorze, cent quarante à Veigy-Foncenex
+Avenue du Môle, soixante-quatorze mille quatre cent soixante Marnaz
+Route de Taninges, soixante-quatorze, trois cent quatre-vingts Cranves-Sales
+Boulevard Pierre Monod, Bonneville
+Route des Grandes Alpes aux Gets
+sept cent quatre-vingt-quatre route des Voirons
+Route de Morgenex au numéro deux mille soixante-sept
+onze chemin du Champ à Carrier, soixante-quatorze mille trois cent dix Les Houches
+vingt-huit avenue de Corzent, soixante-quatorze, deux cents, Thonon-les-Bains
+deux cent cinquante-trois avenue de Verlagny, soixante-quatorze, cinq cents à Neuvecelle
+Route de la Nussance, soixante-quatorze mille trois cent quatre-vingts Cranves-Sales
+Chemin des Côteaux du Castran, soixante-quatorze, deux cent soixante-dix Frangy
+Route de Valleiry, Vers
+Route de Cordon à Cordon
+cent dix impasse de Soucy
+Route du Chinaillon au numéro cent quatre-vingt-dix
+deux rue de la Capetaz, soixante-quatorze mille cinq cent quarante Alby-sur-Chéran
+soixante-quatorze chemin d'Anterne, soixante-quatorze, cent soixante-dix, Saint-Gervais-les-Bains
+cent quatre-vingt-huit route de Sarzin, soixante-quatorze, deux cent soixante-dix à Contamine-Sarzin
+Route des Charmottes d'en Bas, soixante-quatorze mille huit cent quatre-vingt-dix Bons-en-Chablais
+Route des Blaves, soixante-quatorze, deux cents Allinges
+Chemin du Plan Cabaret, Armoy
+Allée des Pres Verts à Sciez
+deux mille soixante-cinq route de l'Étale
+Chemin du Plantez au numéro dix B
+cinq cent vingt-deux avenue d'Aix les Bains, soixante-quatorze mille six cents Seynod
+quatre-vingts chemin de Bionnaz, soixante-quatorze, deux cent soixante-dix, Musièges
+deux avenue de Filly, soixante-quatorze, cent quarante à Sciez
+Route de Chez Jacquet, soixante-quatorze mille cent cinquante Versonnex
+Clos de Barmerousse, soixante-quatorze, cent quatre-vingt-dix Passy
+Chemin du Port des Choseaux, Sévrier
+Route de Marceau à Lathuile

--- a/server/data/fr/addresses-75.csv
+++ b/server/data/fr/addresses-75.csv
@@ -1,0 +1,70 @@
+quatre hameau Michel-Ange, soixante-quinze mille seize Paris
+quinze avenue Boutroux, soixante-quinze, zéro treize, Paris
+neuf rue de l'Exposition, soixante-quinze, zéro zéro sept à Paris
+Boulevard Davout, soixante-quinze mille vingt Paris
+Rue Poliveau, soixante-quinze, zéro zéro cinq Paris
+AV DE LA REPUBLIQUE, Paris
+Rue Barbet de Jouy à Paris
+sept rue Robert Turquan
+CITE DE LA CHAPELLE au numéro cinq BIS
+deux rue Auguste Chapuis, soixante-quinze mille vingt Paris
+quatorze cité du Palais-Royal de Belleville, soixante-quinze, zéro dix-neuf, Paris
+sept rUE DU POLE NORD, soixante-quinze, zéro dix-huit à Paris
+Rue Monsieur le Prince, soixante-quinze mille six Paris
+Rue Malar, soixante-quinze, zéro zéro sept Paris
+Passage du Prado, Paris
+Boulevard de Grenelle à Paris
+un square Gaston Bertandeau
+Rue des Saints-Pères au numéro quatre-vingt-cinq
+quinze villa des Falaises, soixante-quinze mille vingt Paris
+trente-huit quai des Célestins, soixante-quinze, zéro zéro quatre, Paris
+sept aV DE LA PORTE DES LILAS, soixante-quinze, zéro dix-neuf à Paris
+AV FELIX FAURE, soixante-quinze mille quinze Paris
+Impasse du Labrador, soixante-quinze, zéro quinze Paris
+PAS DU MONTENEGRO, Paris
+Boulevard Richard Lenoir à Paris
+dix-huit villa Saint-Charles
+Rue du Vertbois au numéro trente-deux
+deux rue Bréa, soixante-quinze mille six Paris
+douze rue Michel le Comte, soixante-quinze, zéro zéro trois, Paris
+vingt-deux rue Rouelle, soixante-quinze, zéro quinze à Paris
+PL VALHUBERT, soixante-quinze mille treize Paris
+Rue du Faubourg Saint-Honoré, soixante-quinze, zéro zéro huit Paris
+Quai de Bourbon, Paris
+Rue Boyer-Barret à Paris
+cent soixante-neuf rue du Château des Rentiers
+AV JEAN JAURES au numéro vingt-six
+sept rue des Lyanes, soixante-quinze mille vingt Paris
+cent sept bD NEY, soixante-quinze, zéro dix-huit, Paris
+soixante-seize rue Rodier, soixante-quinze, zéro zéro neuf à Paris
+RUE DE NAPLES, soixante-quinze mille huit Paris
+Quai de Grenelle, soixante-quinze, zéro quinze Paris
+RUE DES TAPISSERIES, Paris
+Rue Frédérick Lemaître à Paris
+cinq rue de Montenotte
+Rue des Belles Feuilles au numéro vingt-huit
+cinquante-quatre rue Doudeauville, soixante-quinze mille dix-huit Paris
+cinquante-quatre bD DE MONTMORENCY, soixante-quinze, zéro seize, Paris
+trois pL GERTRUDE STEIN, soixante-quinze, zéro douze à Paris
+Villa Boileau, soixante-quinze mille seize Paris
+RUE LAGILLE, soixante-quinze, zéro dix-huit Paris
+Rue Cail, Paris
+Rue Laurence Savart à Paris
+un voie H/dix-sept
+Rue Boissière au numéro trente-neuf
+vingt-sept rue de la Forge Royale, soixante-quinze mille onze Paris
+quarante-sept rue du Sahel, soixante-quinze, zéro douze, Paris
+douze avenue Bosquet, soixante-quinze, zéro zéro sept à Paris
+RUE HENRY DE BOURNAZEL, soixante-quinze mille quatorze Paris
+Avenue de la Porte de Saint-Cloud, soixante-quinze, zéro seize Paris
+Square Eugène Hatton, Paris
+Rue du Faubourg Poissonnière à Paris
+dix-sept rUE DE FONTARABIE
+RUE HENRI DUVERNOIS au numéro quinze
+cent boulevard de Charonne, soixante-quinze mille vingt Paris
+deux rUE DES MACONNAIS, soixante-quinze, zéro douze, Paris
+deux rue Paul Meurice, soixante-quinze, zéro vingt à Paris
+Boulevard de Rochechouart, soixante-quinze mille dix-huit Paris
+RUE DU MONT CENIS, soixante-quinze, zéro dix-huit Paris
+RUE ETEX, Paris
+Rue Rennequin à Paris

--- a/server/data/fr/addresses-76.csv
+++ b/server/data/fr/addresses-76.csv
@@ -1,0 +1,70 @@
+trente-sept route d'Orcher, soixante-seize mille sept cents Harfleur
+seize rue Léon Salva, soixante-seize, trois cents, Sotteville-lès-Rouen
+quatre-vingt-trois rue de Greenock, soixante-seize, quatre cent cinquante à Veulettes-sur-Mer
+Impasse du Chant d'Oisel, soixante-seize mille cinq cent vingt La Neuville-Chant-d'Oisel
+Rue du Beau Panorama, soixante-seize, sept cents Gonfreville-l'Orcher
+Rue du Bout des Marettes, Blosseville
+Rue Paul Hurier au Grand-Quevilly
+neuf rue Pierre Jean de Béranger
+Rue Déménitroux au numéro cinq
+trois cent quarante-quatre rue de Vila Verde, soixante-seize mille six cent cinquante Petit-Couronne
+mille quatre-vingt-douze route de Grande-Rue, soixante-seize, cent quatre-vingt-dix, Écalles-Alix
+quatre-vingt-quatre rue d'Ignauval, soixante-seize, trois cent dix à Sainte-Adresse
+Rue des Chouquettes, soixante-seize mille cent quatre-vingt-dix Yvetot
+Rue Ferdinand Cartier, soixante-seize, neuf cent soixante Notre-Dame-de-Bondeville
+Rue Louis Bouilhet, Rouen
+Route du Val de la Chaux à Fontaine-sous-Préaux
+neuf cent quatre-vingt-dix route de Saint-Sauveur d'Emallevill
+Rue Suzanne Savale au numéro dix
+huit rue Augustin Henry, soixante-seize mille cinq cents Elbeuf
+soixante-neuf BIS rue de la Ville du Bois, soixante-seize, six cent trente, Sauchay
+vingt et un rue Lucien Fromage, soixante-seize, cent soixante à Darnétal
+Rue de la Petite Riviere, soixante-seize mille trois cent quatre-vingts Canteleu
+Impasse Morel Fatio, soixante-seize, zéro zéro zéro Rouen
+Rue Raoul Anquetil, Triquerville
+Rue des Hautes Haies à Bonsecours
+cinquante-sept route d'Eslettes
+Rue des Prés du Cailly au numéro vingt-trois
+un TER rue Ferdinand Koechlin, soixante-seize mille trois cent dix Sainte-Adresse
+trente-quatre lotissement Les Hetres, soixante-seize, cinq cent cinquante, Hautot-sur-Mer
+quatre-vingt-trois route de Newton Longville, soixante-seize, cinq cent quatre-vingt-dix à Longueville-sur-Scie
+Rue Paul Marion, soixante-seize mille six cents Le Havre
+D six mille quinze, soixante-seize, quatre cent trente Saint-Romain-de-Colbosc
+Rue Aspirant Bizien, Dieppe
+Allée de la Hetraie à Canteleu
+dix-huit rue Thomas Dubosc
+Rue des Frères Duret au numéro quatorze
+sept route de Bec de Mortagne, soixante-seize mille cent dix Annouville-Vilmesnil
+six ancienne Route de Duclair, soixante-seize, trois cent quatre-vingts, Canteleu
+deux cent onze rue du Plis, soixante-seize, cent soixante à Saint-Jacques-sur-Darnétal
+Route de la Carpenterie, soixante-seize mille cent quatre-vingt-dix Valliquerville
+Rue de la Noble Épine, soixante-seize, deux cent trente Bois-Guillaume
+Promenade Front de Mer, Le Tréport
+Quai du Hâble à Dieppe
+mille deux cent soixante-dix-sept route d'Yvetot
+Route de Morgny au numéro neuf cent trente-huit
+vingt-deux rue Paul Lambard, soixante-seize mille cent vingt Le Grand-Quevilly
+un rue Jean Titelouze, soixante-seize, cent trente, Mont-Saint-Aignan
+vingt-trois rue Michel Corroy, soixante-seize, cent vingt au Grand-Quevilly
+Rue Oursel, soixante-seize mille cinq cents Elbeuf
+Sente de l'Église, soixante-seize, neuf cent quarante Notre-Dame-de-Bliquetuit
+Rue Victor Bertel, Sotteville-lès-Rouen
+Rue Jacques Bourgeois à Dieppe
+trente-quatre rue du Docteur Lepec
+Rue Édouard Dupray au numéro sept
+huit résidence la Paradis, soixante-seize mille quatre cent quarante Sommery
+cinq cent quarante-neuf allée des Deux Fermes, soixante-seize, cent soixante, Saint-Martin-du-Vivier
+deux cent quatre-vingt-onze rue Eugénie Watteel, soixante-seize, cinq cent vingt à Montmain
+Rue de la Côte d'Albatre, soixante-seize mille quatre cent cinquante Saint-Martin-aux-Buneaux
+Allée de la Cédraie, soixante-seize, cent trente Mont-Saint-Aignan
+Rue de la Gauboudiere, Morgny-la-Pommeraye
+Rue Joseph Heuzé à Saint-Martin-aux-Buneaux
+cinquante-sept rue Alcide Damboise
+Rue du Commandant Roquigny au numéro quarante-trois
+quatre impasse du Grainvallet, soixante-seize mille quatre cents Saint-Léonard
+quatorze escalier Legrand, soixante-seize, six cents, Le Havre
+un sentier du Ruisseau, soixante-seize, cent soixante-dix à Lillebonne
+Place de la Cour Souveraine, soixante-seize mille cent soixante Saint-Martin-du-Vivier
+Route de Drosay, soixante-seize, quatre cent cinquante Saint-Vaast-Dieppedalle
+La Nos Robin, Tourville-la-Rivière
+Route du Mont Saint à Maulévrier-Sainte-Gertrude

--- a/server/data/fr/addresses-77.csv
+++ b/server/data/fr/addresses-77.csv
@@ -1,0 +1,70 @@
+vingt boulevard Marivaux, soixante-dix-sept mille six cent quatre-vingts Roissy-en-Brie
+cinquante-cinq avenue d'Esbly, soixante-dix-sept, cent cinquante, Lésigny
+un avenue de Rothschild, soixante-dix-sept, quatre cents à Lagny-sur-Marne
+Rue des Grillottes, soixante-dix-sept mille deux cent cinquante Veneux-les-Sablons
+Rue de l'Orme des Herses, soixante-dix-sept, cent soixante-dix Brie-Comte-Robert
+Boulevard de l'Ourcq, Villeparisis
+Promenade du Rouge Gorge à Nandy
+treize square François Boucher
+Cour Albert Jugon au numéro douze
+trois rue des Prêches, soixante-dix-sept mille cinq cent quatre-vingts Guérard
+treize boulevard de l'Amiral Courbet, soixante-dix-sept, cinq cent quarante, Rozay-en-Brie
+vingt-deux rue Saint-Faron, soixante-dix-sept, cent à Meaux
+Rue d'Emerainville, soixante-dix-sept mille cent quatre-vingt-trois Croissy-Beaubourg
+Ruelle du Maître d'École, soixante-dix-sept, cinq cents Chelles
+Rue Passeroux, Fleury-en-Bière
+Rue de Mortry à Guignes
+treize place du Champivert
+Avenue Firmin Bidard au numéro douze
+six allée Georges Blot, soixante-dix-sept mille six cents Bussy-Saint-Georges
+vingt-trois rue Alphonse Combe, soixante-dix-sept, trois cent trente, Ozoir-la-Ferrière
+vingt-cinq rue des Jardins Anglais, soixante-dix-sept, quatre cent dix à Claye-Souilly
+Rue R Mercier, soixante-dix-sept mille deux cent quatre-vingt-dix Compans
+Rue Léon Glaize, soixante-dix-sept, deux cent soixante La Ferté-sous-Jouarre
+Boulevard Etienne Hardy, Fontenay-Trésigny
+Rue du Clos de Bailly à Vert-Saint-Denis
+vingt-six rue Albert Salmon
+Rue des Basses Buternes au numéro douze
+quarante-six rue du Chevalier Galeran, soixante-dix-sept mille cent vingt-sept Lieusaint
+deux rue de Georgevilliers, soixante-dix-sept, cinq cent quatre-vingts, Guérard
+deux rue Mademoiselle Poulet, soixante-dix-sept, quatre cent cinquante à Esbly
+Rue d'Esse, soixante-dix-sept mille cinq cent quinze Saint-Augustin
+Rue de la Garenne Basse, soixante-dix-sept, cent quarante-huit Salins
+Rue de Ruzé, Villeparisis
+Quai du Gen Leclerc à Chartrettes
+vingt-trois avenue Jules Valles
+Avenue Laroche au numéro neuf
+six allée des Nymphes, soixante-dix-sept mille cent vingt-sept Lieusaint
+six B rue de Lepuy Fonteneilles, soixante-dix-sept, quatre cent soixante, Souppes-sur-Loing
+dix-sept rue de la Rochambeau, soixante-dix-sept, six cent quatre-vingts à Roissy-en-Brie
+Rue de Barneau, soixante-dix-sept mille cent onze Solers
+Ruelle du Moulin Brulé, soixante-dix-sept, trois cent vingt Jouy-sur-Morin
+Sen des Fossés, Sognolles-en-Montois
+Rue Paul Jacquemin à Lesches
+huit rue de la Solidarité Ouvrière
+Boulevard Chamblain au numéro huit BIS
+cinq rue Madame Renoux Prieux, soixante-dix-sept mille cinq cent dix Doue
+vingt-six rue de la Terre des Roches, soixante-dix-sept, cinq cent quatre-vingt-dix, Bois-le-Roi
+treize rue des Pins Noirs, soixante-dix-sept, cent vingt-quatre à Villenoy
+Chemin des Robineaux, soixante-dix-sept mille six cent trente Arbonne-la-Forêt
+Rue Ganneval, soixante-dix-sept, deux cent trente Dammartin-en-Goële
+Rue de la Tour Beaufort, Coulommiers
+Rue du Pré de la Ferme à Cesson
+quatre-vingt-un rue de la Cristallerie
+Rue du Général de Baltus au numéro dix
+quarante-cinq rue de Beaubourg, soixante-dix-sept mille trois cent quarante Pontault-Combault
+quatre route de Pierre Le Sault, soixante-dix-sept, cent soixante-sept, Poligny
+cinquante-deux rue de Hulay, soixante-dix-sept, huit cent quatre-vingts à Grez-sur-Loing
+Rue des Pies Vagabondes, soixante-dix-sept mille six cents Guermantes
+Trait d'Union, soixante-dix-sept, cent vingt-sept Lieusaint
+Rue de la Mardotte, Mouroux
+Boulevard Olympe de Gouges à Lieusaint
+dix-huit rue Path
+Chemin du Pont des Roises au numéro cinq
+quatre avenue du Beau Site, soixante-dix-sept mille quatre cents Lagny-sur-Marne
+dix-neuf rue René Benoist, soixante-dix-sept, huit cent soixante, Quincy-Voisins
+deux cent trente-sept rue Gouas, soixante-dix-sept, huit cent soixante à Couilly-Pont-aux-Dames
+Quai René Richard, soixante-dix-sept mille cinq cent quatre-vingt-dix Fontaine-le-Port
+Allée des Bocages, soixante-dix-sept, trois cent soixante Vaires-sur-Marne
+Rue de Libernon, Crécy-la-Chapelle
+Rue Bacot à Lognes

--- a/server/data/fr/addresses-78.csv
+++ b/server/data/fr/addresses-78.csv
@@ -1,0 +1,70 @@
+cinq rue de la Croix Mi Voie, soixante-dix-huit mille quatre cent quarante Issou
+huit TER rue de Montalet, soixante-dix-huit, quatre cent quarante, Issou
+quinze route d'Épernon, soixante-dix-huit, cent vingt-cinq à Hermeray
+Avenue Bouvet, soixante-dix-huit mille cent douze Fourqueux
+Square Vincent Scotto, soixante-dix-huit, cent vingt Rambouillet
+Sente de Poigny, Gazeran
+Clos d'Houel à Condé-sur-Vesgre
+onze chemin du Val Hébert
+Rue de l'Yveline au numéro dix BIS
+cinquante-trois C avenue Fourcault de Pavant, soixante-dix-huit mille Versailles
+huit rue Louis Bellan, soixante-dix-huit, huit cent quatre-vingt-dix, Garancières
+dix-neuf rue des Cailloys, soixante-dix-huit, sept cents à Conflans-Sainte-Honorine
+Allée de la Barbacane, soixante-dix-huit mille trois cent quarante Les Clayes-sous-Bois
+Rue du Docteur Vinaver, soixante-dix-huit, cinq cent vingt Limay
+Avenue de Briens, Villennes-sur-Seine
+Rue Francine à Villepreux
+sept rue de la Chabourne
+Route de Versailles A Pontoise au numéro cent quatre-vingt-quatre
+trente-sept rue des Mifaucons, soixante-dix-huit mille deux cent soixante-dix Blaru
+vingt-quatre rue de la Panicale, soixante-dix-huit, trois cent vingt, La Verrière
+treize rue des Océanides, soixante-dix-huit, cent quatre-vingts à Montigny-le-Bretonneux
+Résidence de la Gaillarderie, soixante-dix-huit mille cinq cent quatre-vingt-dix Noisy-le-Roi
+Impasse du Petit Boeuf, soixante-dix-huit, sept cent trente Saint-Arnoult-en-Yvelines
+Chemin de Poissy, Maule
+Rue du Petit Poirier à Ablis
+dix-huit rue du Docteur Audigier
+Avenue du Louvre au numéro trente-huit
+deux TER avenue du Pavillon de Sully, soixante-dix-huit mille deux cent trente Le Pecq
+quatre cent cinquante rue de la Clémenterie, soixante-dix-huit, six cent soixante-dix, Villennes-sur-Seine
+quinze rue Clairbois, soixante-dix-huit, huit cent dix à Feucherolles
+Sentier des Epinettes, soixante-dix-huit mille cinq cent quarante Vernouillet
+Square du Roumois, soixante-dix-huit, trois cent dix Maurepas
+Impasse Quentin La Tour, Montigny-le-Bretonneux
+Rue René Renault à Buchelay
+dix-huit grande Rue de Pissefontaine
+Rue du Docteur Bravy au numéro trente-cinq
+trois rue du Haut Martin, soixante-dix-huit mille cent vingt-cinq Émancé
+dix-sept allée de la Serfouette, soixante-dix-huit, trois cent dix, Coignières
+deux square du Ternois, soixante-dix-huit, trois cent dix à Maurepas
+Quai de l'Île du Bac, soixante-dix-huit mille sept cents Conflans-Sainte-Honorine
+Rue des Coteaux de Chatron, soixante-dix-huit, six cent quarante Saint-Germain-de-la-Grange
+Rue Nicolas Coustou, Noisy-le-Roi
+Route de la Recette à Lévis-Saint-Nom
+quatre route de Poigny
+Sente de la Voirie au numéro six
+treize route de Coudreuse, soixante-dix-huit mille neuf cent dix Béhoust
+deux BIS rue André Mojard, soixante-dix-huit, deux cent soixante-dix, Cravent
+neuf rue des Saints Martin, soixante-dix-huit, cinq cent vingt à Limay
+Route de Saint-Nom, soixante-dix-huit mille six cent vingt L'Étang-la-Ville
+Chemin du Clos Fleury, soixante-dix-huit, neuf cent cinquante Gambais
+Rue de la Giroderie, Rambouillet
+Rue de Noncienne à Bullion
+vingt-six rue de Fourqueux
+Chemin de la Melotterie au numéro vingt et un
+quatre-vingt-cinq chemin de Cormeilles, soixante-dix-huit mille trois cent soixante Montesson
+six avenue Charles Tellier, soixante-dix-huit, huit cents, Houilles
+mille quatre cent seize rue de la Bretéchelle, soixante-dix-huit, trois cent soixante-dix à Plaisir
+Rond Point Point du Lac, soixante-dix-huit mille six cent quatre-vingts Épône
+Rue Léon Michel, soixante-dix-huit, deux cent soixante Achères
+Rocade de Camargue, Maurepas
+Rue J F Chalgrin à Versailles
+cinquante-six boulevard des Fossés
+Route de Versailles au numéro cinquante
+six rue Auguste Moutié, soixante-dix-huit mille cent vingt Rambouillet
+huit BIS rue de la Mérantaise, soixante-dix-huit, neuf cent soixante, Voisins-le-Bretonneux
+deux rue de Nézel, soixante-dix-huit, quatre cent dix à Aubergenville
+Avenue Gaston Boissier, soixante-dix-huit mille deux cent vingt Viroflay
+Louareux, soixante-dix-huit, cent vingt Sonchamp
+Route de Guerville, Mantes-la-Ville
+Rue Henri Spysschaert à Conflans-Sainte-Honorine

--- a/server/data/fr/addresses-79.csv
+++ b/server/data/fr/addresses-79.csv
@@ -1,0 +1,70 @@
+vingt-cinq rue du Grand Bousseau, soixante-dix-neuf mille trois cent soixante Prissé-la-Charrière
+vingt-huit rue Prosper Jouneau, soixante-dix-neuf, deux cents, Parthenay
+vingt-cinq route de Cherveux, soixante-dix-neuf, zéro zéro zéro à Niort
+Impasse Jean Dere, soixante-dix-neuf mille Niort
+Avenue Yann Roullet, soixante-dix-neuf, trois cent soixante-dix Mougon
+Route du Chiron, Fors
+Impasse de l'Abreuvoir Maulais à Taizé
+vingt-huit rue des Quatre Vents Jaunay
+Rue Maurice Béguin au numéro six
+quinze impasse des Equarts, soixante-dix-neuf mille Niort
+quatre rue de la Buzarderie, soixante-dix-neuf, zéro zéro zéro, Niort
+un rue Samson François, soixante-dix-neuf, zéro zéro zéro à Niort
+Rue des Deffends, soixante-dix-neuf mille cent quatre-vingts Chauray
+Impasse du Pignon -Fontenay, soixante-dix-neuf, cent Mauzé-Thouarsais
+Rue Raymond Migaud, L'Absie
+Rue Jacqueline Cochran à Niort
+deux route d'Alzom
+Route de Lezay au numéro cent vingt-huit
+douze rue du Raffou, soixante-dix-neuf mille cent quarante Cerizay
+dix-neuf boulevard Jean Cocteau, soixante-dix-neuf, zéro zéro zéro, Niort
+quinze route de Mougon, soixante-dix-neuf, trois cent soixante-dix à Fressines
+Boulevard Canton Coutain, soixante-dix-neuf mille cent quatre-vingts Chauray
+Rue Abel Gody, soixante-dix-neuf, quatre cent trente La Chapelle-Saint-Laurent
+Rue du Fief Carillon, Niort
+Chemin de la Chataigneraie Batail à Gournay-Loizé
+trois rue France Langoet
+Cite du Pinson au numéro six
+huit chemin de Vilert, soixante-dix-neuf mille trois cent soixante-dix Thorigné
+soixante-dix route du Bourg Joly, soixante-dix-neuf, deux cent quatre-vingt-dix, Saint-Martin-de-Sanzay
+quarante-sept rue Chabaudy, soixante-dix-neuf, zéro zéro zéro à Niort
+Rue François Lorioux, soixante-dix-neuf mille Bessines
+Cité Jacques de Beaumont, soixante-dix-neuf, trois cents Bressuire
+Impasse des Eaux, Mougon
+Rue de l'Ousane à Saint-Martin-de-Bernegoue
+quinze rue Alphonse Rougier
+Chemin d'Artoreau au numéro treize
+quatorze rue du Bois du Château Gros Bo, soixante-dix-neuf mille trois cent soixante-dix Prailles
+quatorze impasse du Hameau des Graines, soixante-dix-neuf, cent, Thouars
+deux rue de la Chapelle Seguin, soixante-dix-neuf, deux cent quarante à L'Absie
+Place Jean Louis Noel, soixante-dix-neuf mille deux cent quatre-vingt-dix Saint-Martin-de-Sanzay
+Rue du Vieux Puit, soixante-dix-neuf, cent vingt Chey
+Impasse des Tertres Loizé, Gournay-Loizé
+Rue Taillepied à Parthenay
+sept chemin de l'Ardila Cerzeau
+Rue Jean-Honoré de Fragonard au numéro neuf
+quatre-vingt-trois C rue de la Blauderie, soixante-dix-neuf mille Niort
+douze allée du Pré Goderie, soixante-dix-neuf, trois cents, Bressuire
+trois cent trente-sept rue d'Androlet, soixante-dix-neuf, quatre cent dix à Échiré
+Rue Léopold Marolleau, soixante-dix-neuf mille trois cents Bressuire
+Route de Clavé, soixante-dix-neuf, quatre cents Exireuil
+Venelle du Couchant, Niort
+Rue du Stade . La Ronde à La Forêt-sur-Sèvre
+cinq impasse des Ourneaux
+Rue de la Boutetrie au numéro six
+cent trente et un impasse de la Petite Isle, soixante-dix-neuf mille quatre cent dix Saint-Gelais
+six rue des Bois de Fonzay, soixante-dix-neuf, cent, Missé
+vingt-six rue Porte de Saint-Jean, soixante-dix-neuf, zéro zéro zéro à Niort
+Rue de la Sauzaie, soixante-dix-neuf mille deux cent quarante L'Absie
+Grande Rue d'Irleau, soixante-dix-neuf, deux cent soixante-dix Le Vanneau-Irleau
+Rue du Champ Lameraud, Ardin
+Rue de l'Hometrou à Niort
+vingt et un rue Emile du Tiers
+Route de Bressuire au numéro seize
+vingt route de Chauray, soixante-dix-neuf mille deux cent soixante François
+un route de Tillou, soixante-dix-neuf, cent soixante-dix, Luché-sur-Brioux
+quarante-huit rue André Gastel, soixante-dix-neuf, quatre cent cinquante à Saint-Aubin-le-Cloud
+Rue Gaston Métois, soixante-dix-neuf mille trois cent quarante Ménigoute
+Rue des Ouzines, soixante-dix-neuf, cent vingt Sepvret
+Rue Du Bief Du Lac, Vallans
+Rue Paterne à Sainte-Gemme

--- a/server/data/fr/addresses-80.csv
+++ b/server/data/fr/addresses-80.csv
@@ -1,0 +1,70 @@
+six rue de Marcelcave, quatre-vingt mille huit cents Villers-Bretonneux
+quatre rue de Falvy, quatre-vingts, deux cents, Ennemain
+deux cent vingt-cinq boulevard Chateaudun, quatre-vingts, zéro zéro zéro à Amiens
+Impasse des Argillières, quatre-vingt mille cent Abbeville
+Rue de Naours, quatre-vingts, deux cent soixante Flesselles
+Clos des Violettes, Chépy
+Rue Raoul Trocmé à Épehy
+onze rue Manasses Barbier
+Rue d'Herbécourt au numéro dix
+seize rue Saint-Fursy, quatre-vingt mille deux cents Péronne
+quarante rue André Lamarre, quatre-vingts, trois cents, Albert
+quatre-vingt-neuf rue Léon Dupontreué, quatre-vingts, zéro zéro zéro à Amiens
+Ruelle d'Herbecourt, quatre-vingt mille deux cents Flaucourt
+Rue Fursy Lesage, quatre-vingts, huit cents Cachy
+Rue Marcel Thomas, Contoire
+Rue Raphaël Duprez à Bernaville
+six rue d'Ophélie
+Rue Geneviève Blandin au numéro cent cinq
+dix-huit rue de Coppegueule, quatre-vingt mille cent quarante Saint-Léger-sur-Bresle
+onze rue au Feurre, quatre-vingts, deux cent trente, Saint-Valery-sur-Somme
+trente et un rue Jules Digeon, quatre-vingts, cent soixante-dix à Rosières-en-Santerre
+Rue du Prayel, quatre-vingt mille cent Abbeville
+Rue Charles Flet, quatre-vingts, quatre cent cinquante Camon
+Rue Janvier, Amiens
+Résidence Paul Rudet à Doullens
+soixante-douze rue de Saveuse
+Lotissement des Meuniers au numéro treize
+douze rue Saint-Phocas, quatre-vingt mille deux cents Doingt
+quinze rue Irène Leroy, quatre-vingts, deux cent vingt, Gamaches
+vingt et un rue Roland Douay, quatre-vingts, zéro zéro zéro à Amiens
+Rue René Boileau, quatre-vingt mille Amiens
+Route des Polonais, quatre-vingts, cent Abbeville
+Boulevard de Beauvillé, Amiens
+Rue Caussin De Perceval à Amiens
+onze rue Fauvettes
+Chaussée d'Hocquet au numéro soixante-dix-neuf
+trois cent soixante-trois chaussée de Rouvroy, quatre-vingt mille cent Abbeville
+quatre rue Hotton, quatre-vingts, cinq cent dix, Long
+deux cent seize place Maurice Blondel, quatre-vingts, quatre cent soixante-dix à Saint-Sauveur
+Rue Émile Bauchart, quatre-vingt mille cent vingt-deux Heudicourt
+Rue de Daours, quatre-vingts, six cent cinquante Vignacourt
+Rue Herèques, Le Boisle
+Rue d'Ercourt à Tours-en-Vimeu
+quarante et un rue du Petit Selve
+Rue d'Offoy au numéro seize
+vingt rue Lignier, quatre-vingt mille quatre cents Eppeville
+cent douze rue Dehaussy, quatre-vingts, deux cents, Péronne
+quarante milly, quatre-vingts, six cents à Doullens
+Rue Blin de Bourdon, quatre-vingt mille Amiens
+Place Gilbert Gaffet, quatre-vingts, cent cinquante Crécy-en-Ponthieu
+Boulevard des Célestins, Amiens
+Rue Moise Delouard à Amiens
+trente-neuf rue Lucien Leducq
+Route d'Arry au numéro neuf
+vingt-deux rue de Sailly le Sec, quatre-vingt mille huit cents Sailly-Laurette
+cent soixante-trois rue d'Herlicourt, quatre-vingts, deux cent trente, Lanchères
+quarante rue Robert Degroote, quatre-vingts, cent trente et un à Harbonnières
+Rue Jules Barni, quatre-vingt mille Amiens
+Rue du Pré Bégond, quatre-vingts, deux cent soixante Talmas
+Rue de Froyelles, Fontaine-sur-Maye
+Rue du Petit Rond à Conty
+six rue Le Domaine de la Roche
+Rue Jules Vacandard Prolongée au numéro treize
+cent quatre-vingt-sept BIS rue Baudrez, quatre-vingt mille Amiens
+six chemin Saint-Éloi, quatre-vingts, quatre cents, Ham
+quarante-neuf rue Sire Bernard, quatre-vingts, zéro zéro zéro à Amiens
+Rue Pinsard, quatre-vingt mille Amiens
+Rue de Moreuil, quatre-vingts, cent dix Moreuil
+Rue de Boulan, Albert
+Rue Vascosan à Amiens

--- a/server/data/fr/addresses-81.csv
+++ b/server/data/fr/addresses-81.csv
@@ -1,0 +1,70 @@
+quatre cent soixante-cinq côte de Lespare, quatre-vingt-un mille cinq cents Labastide-Saint-Georges
+cent vingt-cinq rue Plaine Saint-Martin, quatre-vingt-un, zéro zéro zéro, Albi
+soixante-neuf avenue Lieutenant J Desplats, quatre-vingt-un, cent à Castres
+Rue de Rudel, quatre-vingt-un mille Albi
+Sans Souci, quatre-vingt-un, cinq cent quarante Sorèze
+Route de Parisot, Coufouleux
+Impasse Métairie de l'Eglise à Loupiac
+trois village de Lafontasse
+Route de Navès au numéro vingt-trois
+vingt place du Plô de Rustan, quatre-vingt-un mille trois cent soixante-dix Saint-Sulpice-la-Pointe
+neuf rue du Champ de la Roume, quatre-vingt-un, deux cents, Aiguefonde
+vingt-deux hameau de la Verdarié, quatre-vingt-un, cent à Castres
+Route de Gachou, quatre-vingt-un mille trois cents Graulhet
+Rue Pierre et François Crouzet, quatre-vingt-un, deux cent soixante-dix Labastide-Rouairoux
+Chemin de Castelvert, Lavaur
+Chemin Toulze à Gaillac
+cinq rue de la Franconie
+Rue de la Passe au numéro quarante-neuf
+quatre rue d'Empare, quatre-vingt-un mille cent Castres
+vingt-trois rue Mahuzies, quatre-vingt-un, cent, Castres
+cent trente-sept route de la Drêche, quatre-vingt-un, zéro zéro zéro à Albi
+Route de Verdalle, quatre-vingt-un mille deux cent quatre-vingt-dix Viviers-lès-Montagnes
+Boulevard Albert Gaches, quatre-vingt-un, deux cents Aussillon
+Avenue de Revel, Puylaurens
+Impasse Plaine de Bise à Sémalens
+dix-neuf rue En Froment
+Petite Rue des Clauzades au numéro dix
+soixante-quinze rue Croix de la Paix, quatre-vingt-un mille Albi
+trente-huit rue Gustave de Clausade, quatre-vingt-un, huit cents, Rabastens
+quatre rue de Gourjade, quatre-vingt-un, cent à Castres
+Rue Marthe Condat, quatre-vingt-un mille trois cents Graulhet
+Chemin de Côte Rousse, quatre-vingt-un, cent Castres
+Avenue du Doul, Pont-de-Larn
+Chemin de Bicoq à Carmaux
+onze chemin de la Jardinie
+Rue Docteur Louis Vignolles au numéro vingt
+trente-quatre allée des Eperviers, quatre-vingt-un mille quatre cents Saint-Benoît-de-Carmaux
+dix impasse Gérard Philipe, quatre-vingt-un, quatre cents, Blaye-les-Mines
+trois chemin de Jean Thomas, quatre-vingt-un, cent cinquante à Terssac
+Rue du Docteur Puech, quatre-vingt-un mille deux cent dix Roquecourbe
+Rue Edouard Julien, quatre-vingt-un, zéro zéro zéro Albi
+Avenue de la Trémoulède, Payrin-Augmontel
+Rue Polydore Barbey à Mazamet
+vingt-six rue d'En Béral
+Rue Marcel Briguiboul au numéro cent quatorze
+treize chemin des Agals, quatre-vingt-un mille sept cent dix Saïx
+trois avenue de la Légion Etrangère, quatre-vingt-un, trois cent dix, Lisle-sur-Tarn
+dix-huit rue de l'Acampadou, quatre-vingt-un, cent soixante-dix à Cordes-sur-Ciel
+Impasse Docteur Gradels, quatre-vingt-un mille quatre cents Carmaux
+Rue de Jarlard, quatre-vingt-un, zéro zéro zéro Albi
+Chemin du Rival Escur, Rabastens
+Rue de la Portanelle à Gaillac
+douze chemin de Peyre Ficade
+Chemin de Matens au numéro vingt-cinq
+vingt-huit boulevard Henri Sizaire, quatre-vingt-un mille cent Castres
+trente-sept route de Puycheval, quatre-vingt-un, huit cents, Rabastens
+six rue du Saltre, quatre-vingt-un, cent soixante à Arthès
+Chemin du Sicardas, quatre-vingt-un mille six cent soixante Bout-du-Pont-de-Larn
+Chemin des Arquiés, quatre-vingt-un, cinq cent soixante-dix Sémalens
+Route d'Aupillac, Labruguière
+Chemin de Burgayrols à Albi
+trois rue Jean Baptiste Cavaillés
+Rue de Lévizac au numéro trente
+huit route de Belherbette, quatre-vingt-un mille deux cent dix Lacrouzette
+huit chemin de la Maurole, quatre-vingt-un, huit cents, Rabastens
+neuf rue Le Floride, quatre-vingt-un, six cents à Gaillac
+Rue Ernest Ichanson, quatre-vingt-un mille cent cinquante Sainte-Croix
+Le Chemin Haut, quatre-vingt-un, cinq cent quarante Sorèze
+Rue du Garric, Albi
+Rue Louis Ichard à Albi

--- a/server/data/fr/addresses-82.csv
+++ b/server/data/fr/addresses-82.csv
@@ -1,0 +1,70 @@
+vingt-six chemin de Marieu, quatre-vingt-deux mille quatre cent quarante Réalville
+quatorze avenue du Roc Deymie, quatre-vingt-deux, cent quarante, Saint-Antonin-Noble-Val
+quatre-vingt-quinze rue Morin-Védrines, quatre-vingt-deux, zéro zéro zéro à Montauban
+Route de Vignarnaud, quatre-vingt-deux mille Montauban
+Route de Verlhaguet, quatre-vingt-deux, deux cent quatre-vingt-dix Montbeton
+Impasse Maginot, Golfech
+Chemin de Fayence à Montauban
+cent cinquante-trois côte du Gasaillant
+Chemin de Brial au numéro cent quatre-vingt-quinze C
+mille trois cent quarante-cinq B chemin de Cascaret, quatre-vingt-deux mille sept cent dix Bressols
+quatre lotissement Des Bastides de Gillac, quatre-vingt-deux, cinq cents, Beaumont-de-Lomagne
+cent vingt-cinq chemin de Tarayre, quatre-vingt-deux, trois cents à Monteils
+Chemin des Gascous, quatre-vingt-deux mille Montauban
+Avenue Auguste Grèze, quatre-vingt-deux, quatre cents Valence
+Rue Ernest Mercadier, Montauban
+Route de Saint-Porquier aux Barthes
+sept avenue Saturne
+Chemin de Lafaderie au numéro cinq cent quatre-vingt-quatorze
+mille cent quatre-vingt-un voie Communale de Saint-Nicolas de la Grave, quatre-vingt-deux mille deux cents Moissac
+mille deux cent un chemin de Prévost, quatre-vingt-deux, zéro zéro zéro, Montauban
+deux mille trente route de Trixe, quatre-vingt-deux, sept cent dix à Bressols
+Rue de Marchet, quatre-vingt-deux mille trois cent quarante Auvillar
+Avenue de Courbieu, quatre-vingt-deux, cent Castelsarrasin
+Chemin de Lapeyriere, Bessens
+Chemin des Jaquettes à Monteils
+deux mille six cent trente route de Corbarieu
+Route de Bonnanech au numéro trois mille cinquante-deux
+quatorze impasse du Cassé, quatre-vingt-deux mille sept cents Montech
+quarante et un rue du Général Gras, quatre-vingt-deux, deux cents, Moissac
+cent soixante-seize chemin de Falgayrines, quatre-vingt-deux, zéro zéro zéro à Montauban
+Route de Saint-Nauphary, quatre-vingt-deux mille trois cent soixante-dix Villebrumier
+Impasse de Bernuze, quatre-vingt-deux, deux cent quatre-vingt-dix La Ville-Dieu-du-Temple
+Départementale huit cent treize de Toulouse, Saint-Porquier
+Chemin des Ariaux à Donzac
+cent onze route de Lizac
+Rue des Ardeilles au numéro quarante-cinq
+sept rue des Donateurs, quatre-vingt-deux mille deux cents Moissac
+mille deux cent quatre-vingt-treize route de Cornillas, quatre-vingt-deux, quatre cents, Valence
+quatre-vingt-deux chemin de la Vallée du Tordre, quatre-vingt-deux, deux cent trente à Léojac
+Chemin de Débat, quatre-vingt-deux mille deux cent dix Saint-Nicolas-de-la-Grave
+Rue du Plantié, quatre-vingt-deux, cinq cents Beaumont-de-Lomagne
+Avenue des Anciens Combattants d'Indochine, Nègrepelisse
+Rue Cabarrot à Golfech
+seize rue Fortuné Cantecor
+Chemin de Bro au numéro mille cinq cent cinquante
+mille cent cinq route de la Brive, quatre-vingt-deux mille huit cents Vaïssac
+un rue Léon Lemartin, quatre-vingt-deux, trois cent quarante, Dunes
+treize rue de l'Union Compagnonnique, quatre-vingt-deux, zéro zéro zéro à Montauban
+Chemin de Carrayrou, quatre-vingt-deux mille cent trente Montastruc
+Chemin Clos de Lauzin, quatre-vingt-deux, zéro zéro zéro Montauban
+Chemin de Travaux, Nohic
+Avenue de Larché à Molières
+soixante-huit route des Brels
+Chemin des Lebrats au numéro mille huit cent dix-sept
+mille cent cinquante-trois route de Reyniès, quatre-vingt-deux mille trois cent soixante-dix Saint-Nauphary
+dix-neuf impasse Georges Herment, quatre-vingt-deux, zéro zéro zéro, Montauban
+mille deux cent vingt-deux route de Montbartier, quatre-vingt-deux, zéro zéro zéro à Montauban
+Chemin des Gardios, quatre-vingt-deux mille huit cents Nègrepelisse
+Route d'Auty, quatre-vingt-deux, deux cent soixante-dix Montpezat-de-Quercy
+Rue de Cayssac, Saint-Antonin-Noble-Val
+Chemin de Sainte-Livrade à Labastide-du-Temple
+quarante chemin de Finelle
+Chemin de Mondot au numéro deux cent quatre-vingt-quatre
+deux cent trente-huit chemin de Saint-Coufan, quatre-vingt-deux mille deux cent dix Castelmayran
+mille deux cent vingt-deux chemin de Pousinies, quatre-vingt-deux, quatre cent dix, Saint-Étienne-de-Tulmont
+mille quatre-vingt-six route des Courounets, quatre-vingt-deux, trois cent cinquante à Albias
+Impasse Mespoulié, quatre-vingt-deux mille cent soixante-dix Dieupentale
+Avenue de Léojac, quatre-vingt-deux, zéro zéro zéro Montauban
+Chemin du Moulin de Gandalou, Castelsarrasin
+Plateau des Gascous à Montauban

--- a/server/data/fr/addresses-83.csv
+++ b/server/data/fr/addresses-83.csv
@@ -1,0 +1,70 @@
+deux cent quatre rue Victorin Philip, quatre-vingt-trois mille quatre cents Hyères
+trois rue de la Siagnole, quatre-vingt-trois, quatre cent quarante, Montauroux
+un carriera Dei Quinsoun, quatre-vingt-trois, deux cent dix à Solliès-Pont
+Boulevard de l'Escaillon, quatre-vingt-trois mille Toulon
+Chemin du Defends, quatre-vingt-trois, quatre cent quarante Montauroux
+Rue Capitaine Colonna, Toulon
+Rue Henri Pardigon à Vinon-sur-Verdon
+dix-neuf avenue Maximin Martin
+Rue Henri Vienne au numéro deux cent trente-sept
+seize chemin des Bancaous, quatre-vingt-trois mille deux cent dix Solliès-Pont
+cent vingt-quatre rue Léo Poupart, quatre-vingt-trois, cent trente, La Garde
+seize boulevard de l'Hélvétie, quatre-vingt-trois, zéro zéro zéro à Toulon
+Route des Loubes, quatre-vingt-trois mille quatre cents Hyères
+Avenue Estelle, quatre-vingt-trois, zéro zéro zéro Toulon
+Raccourci du Col de l'Ange, Draguignan
+Rue Jean Baptiste Aimard à Toulon
+soixante-treize rue du Lot Les Acacias
+Avenue des Roches Rouges au numéro trois cent trente-trois
+mille sept cent trente-six boulevard Jean-Baptiste Abel, quatre-vingt-trois mille Toulon
+neuf cent trente et un chemin des Souquiers, quatre-vingt-trois, cent trente-six, Garéoult
+six avenue de la Tartane, quatre-vingt-trois, quatre cents à Hyères
+Boulevard Edgar Amigas, quatre-vingt-trois mille Toulon
+Avenue de Valensole, quatre-vingt-trois, trois cent dix Cogolin
+Rue Louis Lumiére, Signes
+Boulevard de Calypso à Roquebrune-sur-Argens
+quatre cent dix chemin de la Vanade
+Rue Jean Bremond au numéro deux
+cent quatre-vingt-trois allée Carmen, quatre-vingt-trois mille cent dix Sanary-sur-Mer
+sept rue Aymard, quatre-vingt-trois, neuf cent vingt, La Motte
+trente-cinq allée Miramar, quatre-vingt-trois, deux cent quarante à Cavalaire-sur-Mer
+Montée Soeur Vincent, quatre-vingt-trois mille cent dix Sanary-sur-Mer
+Chemin des Peliquant, quatre-vingt-trois, cinq cent dix Lorgues
+Boulevard Uranus, Bormes-les-Mimosas
+Rue des Sirenes à La Londe-les-Maures
+cent cinq traverse de la Courtaude
+Chemin de la Peyranne au numéro trois cent cinquante-cinq
+soixante rue Pilote Pierre Reboul, quatre-vingt-trois mille Toulon
+onze route du Plan de la Tour, quatre-vingt-trois, cent vingt, Sainte-Maxime
+cent soixante-dix-neuf chemin Jean Court, quatre-vingt-trois, trois cent quatre-vingt-dix à Pierrefeu-du-Var
+Rue Louis Fille, quatre-vingt-trois mille trois cent quatre-vingt-dix Cuers
+Route de Sauveclare, quatre-vingt-trois, cinq cent dix Lorgues
+Avenue de la Muscadière, Fréjus
+Rue Le Cabidourle Pin La Lègue à Fréjus
+seize lotissement Darbousson
+Montée Casse-Cou au numéro vingt-six
+trente-neuf B rue Notos, quatre-vingt-trois mille Toulon
+vingt-neuf rue Réhel, quatre-vingt-trois, zéro zéro zéro, Toulon
+vingt et un place de Palayson, quatre-vingt-trois, quatre cent quatre-vingt-dix au Muy
+Chemin du Gabron, quatre-vingt-trois mille quatre cent quatre-vingts Puget-sur-Argens
+Chemin Ricord, quatre-vingt-trois, zéro zéro zéro Toulon
+Chemin du Tremaillon, Ollioules
+Panorama Saint-Bernard à Trans-en-Provence
+douze rue du Hameau de Vignaubière
+Rue des Nertas au numéro quatre-vingt-trois
+cinquante-deux montée des Arbousiers, quatre-vingt-trois mille neuf cent quatre-vingts Le Lavandou
+deux cent soixante-six vieux Chemin Vieux Che des Sablettes, quatre-vingt-trois, cinq cents, La Seyne-sur-Mer
+dix-huit rue Louis Pélassy, quatre-vingt-trois, quatre cent quarante à Mons
+Avenue de Sainte-Roseline, quatre-vingt-trois mille neuf cent vingt La Motte
+Rue du Lot Azuréa, quatre-vingt-trois, deux cent soixante La Crau
+Rue du Val Gapeau, Solliès-Toucas
+Boulevard de la Suane à Grimaud
+quatre impasse du Mas de la Beaussière
+Allée de l'Ancien Train des Pignes au numéro cent quatre-vingt-onze
+trente-trois rue Gueit, quatre-vingt-trois mille Toulon
+quatorze rue Sere de Rivière, quatre-vingt-trois, quatre cents, Hyères
+deux cent quarante-sept BIS voie Communale Bonaparte, quatre-vingt-trois, cinq cents à La Seyne-sur-Mer
+Avenue Bernard Blua, quatre-vingt-trois mille neuf cent quatre-vingt-dix Saint-Tropez
+Traverse du Pinson, quatre-vingt-trois, cent soixante La Valette-du-Var
+Rue Docteur Louis Marcon, Bandol
+Avenue Regrutto à Toulon

--- a/server/data/fr/addresses-84.csv
+++ b/server/data/fr/addresses-84.csv
@@ -1,0 +1,70 @@
+cinq cent soixante-neuf chemin de la Fauconnette, quatre-vingt-quatre mille deux cents Carpentras
+cent quinze montée de la Madeleine, quatre-vingt-quatre, quatre cents, Apt
+deux mille cent vingt et un route de Carpentras, quatre-vingt-quatre, huit cents à L'Isle-sur-la-Sorgue
+Chemin de Saint-Labre, quatre-vingt-quatre mille deux cents Carpentras
+Chemin de Pied Marin n°deux, quatre-vingt-quatre, trois cent quatre-vingts Mazan
+Chemin des Imbardes, Apt
+Chemin de Teste à Cavaillon
+vingt-quatre rue du Relarguier
+Route d'Aubignan au numéro cinq cent trente-trois
+quinze place du Pan Carré, quatre-vingt-quatre mille trois cent vingt Entraigues-sur-la-Sorgue
+cinq route des Petits Cléments, quatre-vingt-quatre, quatre cents, Villars
+mille huit cent trente-neuf petite Route de Carpentras, quatre-vingt-quatre, deux cent dix à Pernes-les-Fontaines
+Cours du Luberon, quatre-vingt-quatre mille cinq cent trente Villelaure
+Voie Communale quatre-vingt-cinq des Prés, quatre-vingt-quatre, quatre cent vingt Piolenc
+Chemin Tépu, Le Thor
+Route de Gordes à Robion
+cent trente lotissement la Chêneraie
+Impasse des Hors au numéro trente-six
+dix lotissement Li Carrignan, quatre-vingt-quatre mille deux cent cinquante Le Thor
+trois mille quatre cent cinquante route Départementale neuf cent un, quatre-vingt-quatre, huit cents, Lagnes
+cinquante-sept rue Yole, quatre-vingt-quatre, zéro zéro zéro à Avignon
+Allée Raimbaud d'Orange, quatre-vingt-quatre mille trois cent cinquante Courthézon
+Impasse Marcel Sadaillan, quatre-vingt-quatre, trois cents Cavaillon
+Rue du Bon Martinet, Avignon
+Avenue Saint-Ruf à Avignon
+neuf cite Saint-Sébastien
+Chemin d'Entraigues au numéro trois cent quarante-huit
+quarante impasse du Florilège, quatre-vingt-quatre mille sept cents Sorgues
+cent quatre-vingt-quinze allée du Barbaroux, quatre-vingt-quatre, trois cent vingt, Entraigues-sur-la-Sorgue
+deux cent trente route de Malemort, quatre-vingt-quatre, trois cent quatre-vingts à Mazan
+Chemin du Trentin, quatre-vingt-quatre mille deux cent cinquante Le Thor
+Lotissement Terrasses de la Peyriere, quatre-vingt-quatre, cent vingt Pertuis
+Rue Albert Chabaud, Avignon
+Cours du Berteuil à Valréas
+six mille trois cent soixante-seize F rue Gaston Gévaudan
+Chemin du Moure au numéro deux cent cinquante et un
+dix-huit rue du Phénix, quatre-vingt-quatre mille Avignon
+deux cent soixante-sept rue René Seyssaud, quatre-vingt-quatre, deux cents, Carpentras
+trois cent vingt allée des Névons, quatre-vingt-quatre, huit cents à L'Isle-sur-la-Sorgue
+Route de Flassan, quatre-vingt-quatre mille quatre cent dix Bédoin
+Rue Comtadine, quatre-vingt-quatre, cent dix Vaison-la-Romaine
+Rue Paul Bagnol, Avignon
+Route de Bédarrides à Monteux
+deux mille cent cinquante-trois chemin des Palladaux
+Chemin des Nesquières au numéro cent vingt-trois B
+huit cent dix chemin Rural dix-huit de Saint-Baldou, quatre-vingt-quatre mille trois cents Cavaillon
+cent six rue Vinolly, quatre-vingt-quatre, cent vingt, Pertuis
+vingt-cinq hameau du Coudoulet, quatre-vingt-quatre, cent à Orange
+Avenue Louis Daillant, quatre-vingt-quatre mille Avignon
+Boulevard Alfred Rogier, quatre-vingt-quatre, deux cents Carpentras
+Lotissement Eissero, Monteux
+Boulevard André Delorme à Avignon
+vingt-quatre lotissement des Chênes Blancs
+Avenue Pierre Thomas au numéro onze
+douze lotissement les Pléiades, quatre-vingt-quatre mille huit cents L'Isle-sur-la-Sorgue
+cinq rue Philippe Cabassole, quatre-vingt-quatre, zéro zéro zéro, Avignon
+vingt rue Auguste Bédoin, quatre-vingt-quatre, sept cents à Sorgues
+Avenue d'Avignon, quatre-vingt-quatre mille sept cents Sorgues
+Rue Paul Monition, quatre-vingt-quatre, huit cents L'Isle-sur-la-Sorgue
+Rue Simon de Chalons, Bédoin
+Lotissement Aguilon à Orange
+deux mille deux cent dix chemin des Traversiers
+Route de l'Isle Sur Sorgue au numéro quatre-vingt-six
+quatre cent cinquante-neuf B chemin de Coutchougus, quatre-vingt-quatre mille sept cents Sorgues
+deux cent quarante-six avenue Joseph Anselme, quatre-vingt-quatre, quatre cents, Gargas
+cent quarante-huit impasse de Châteauneuf-du-Pape, quatre-vingt-quatre, sept cents à Sorgues
+Rue Faure Aymard, quatre-vingt-quatre mille Avignon
+Impasse Li Cigaloun, quatre-vingt-quatre, quatre cent cinquante Saint-Saturnin-lès-Avignon
+Impasse de la Lupuline, Avignon
+Impasse du Clos des Daulands à Sorgues

--- a/server/data/fr/addresses-85.csv
+++ b/server/data/fr/addresses-85.csv
@@ -1,0 +1,70 @@
+trente-neuf rue de Banzeau, quatre-vingt-cinq mille trois cent trente Noirmoutier-en-l'Île
+dix-huit rue René Couzinet, quatre-vingt-cinq, quatre cent trente, Aubigny
+deux la Traverserie, quatre-vingt-cinq, cinq cent quatre-vingt-dix à Saint-Mars-la-Réorthe
+Route de Moricq, quatre-vingt-cinq mille sept cent cinquante Angles
+Rue de Grasla, quatre-vingt-cinq, cent quarante Chauché
+Rue Abbé Barbedette, Nieul-le-Dolent
+Avenue Monseigneur Jean Batiot à Chantonnay
+dix-neuf rue de Chelbert
+Route de la Mothe Achard au numéro mille cent soixante-quinze
+un impasse de la Grainette, quatre-vingt-cinq mille six cent quatre-vingt-dix Notre-Dame-de-Monts
+deux impasse de la Vergnaie, quatre-vingt-cinq, deux cent quatre-vingt-dix, Mortagne-sur-Sèvre
+treize rue du Port du Bec, quatre-vingt-cinq, deux cent trente à Bouin
+Rue des Pièces Franches, quatre-vingt-cinq mille trois cent quarante Olonne-sur-Mer
+Lotissement de l'Écluse, quatre-vingt-cinq, deux cent trente Bouin
+Rue Léon Aude, La Roche-sur-Yon
+Rue Pierre Monnier à Noirmoutier-en-l'Île
+dix route des Sicardières
+Le Retail au numéro quatre
+cinq allée des Portes Vertes, quatre-vingt-cinq mille cent soixante Saint-Jean-de-Monts
+trois cent douze la Bourolerie, quatre-vingt-cinq, deux cent cinquante, Saint-Fulgent
+neuf square Jean Launois, quatre-vingt-cinq, trois cents à Challans
+Rue du Fondouet, quatre-vingt-cinq mille six cents La Boissière-de-Montaigu
+Le Rorthais, quatre-vingt-cinq, trois cents Froidfond
+Avenue Maurice Samson, La Tranche-sur-Mer
+Rue de la Messandrie à Noirmoutier-en-l'Île
+dix-neuf chemin du Frinaud
+Route de la Fénicière au numéro cent quatre-vingt-trois
+dix rue du Haut Fradet, quatre-vingt-cinq mille six cent dix Cugand
+cinq la Treillardière, quatre-vingt-cinq, trois cent quatre-vingt-dix, Chavagnes-les-Redoux
+un rue des Emeriettes, quatre-vingt-cinq, cinq cent quatre-vingts à Grues
+Impasse du Clos des Alouettes, quatre-vingt-cinq mille quatre cent quatre-vingt-dix Benet
+Rue de la Pâqueraie, quatre-vingt-cinq, six cent quatre-vingts La Guérinière
+Résidence du Petit Champ, Noirmoutier-en-l'Île
+Rue de la Poctière à Challans
+trente-huit avenue de la Mine
+Rue de Villebon au numéro soixante-trois
+deux rue du Chemin de Sèvre, quatre-vingt-cinq mille cinq cent quatre-vingt-dix Saint-Malô-du-Bois
+onze rue Eugène Charrier, quatre-vingt-cinq, cinq cent dix, Le Boupère
+soixante-quatre route du Château d'Olonne, quatre-vingt-cinq, cent aux Sables-d'Olonne
+Rue de Ker Pierre Borny, quatre-vingt-cinq mille trois cent cinquante L'Île-d'Yeu
+Impasse des Rocardières, quatre-vingt-cinq, quatre cent quarante Talmont-Saint-Hilaire
+Rue de Merisier, Saint-Laurent-sur-Sèvre
+Allée du Clos Thorel à Saint-Vincent-sur-Jard
+dix-neuf rue Elisabeth de Montsorbier
+Rue du Champ Buchet au numéro un
+onze résidence Veillon Plage, quatre-vingt-cinq mille quatre cent quarante Talmont-Saint-Hilaire
+sept rue de Pré Chatelot, quatre-vingt-cinq, quatre cent soixante-dix, Bretignolles-sur-Mer
+onze rue des Giraudelles, quatre-vingt-cinq, six cent dix à Cugand
+Allée Valentin Craipeau, quatre-vingt-cinq mille quatre cent trente Aubigny
+Route de Saint-Révérend, quatre-vingt-cinq, huit cents Le Fenouiller
+Cité de la Promenade, Tiffauges
+Rue de Puydreau à Mouzeuil-Saint-Martin
+treize rue Ferdinand Jauffrineau
+Rue de la Jolie Baie au numéro six mille deux cent quarante-six
+cinq rue du Porte-Bonheur, quatre-vingt-cinq mille deux cent soixante-dix Saint-Hilaire-de-Riez
+soixante et onze rue de la Marion, quatre-vingt-cinq, cent, Les Sables-d'Olonne
+six rue des Genôts, quatre-vingt-cinq, cent soixante-dix au Poiré-sur-Vie
+Rue du Tigre, quatre-vingt-cinq mille cinq cent dix Rochetrejoux
+Chemin du Niaisois, quatre-vingt-cinq, six cent trente Barbâtre
+Rue du Bois Martineau, Saint-Jean-de-Monts
+Chemin de la Bergeresse à L'Île-d'Yeu
+vingt-cinq rue de la Canarde
+Rue de la Vigne à la Croix au numéro neuf
+vingt-quatre rue Jean de Tinguy, quatre-vingt-cinq mille sept cents Saint-Michel-Mont-Mercure
+cinq impasse Benjamin Bouquet, quatre-vingt-cinq, cent dix, Chantonnay
+deux BIS rue Fauchard, quatre-vingt-cinq, trois cent vingt à Mareuil-sur-Lay-Dissais
+Avenue Henri Louis Julien Rondeau, quatre-vingt-cinq mille cinq cents Les Herbiers
+Chemin de la Conge, quatre-vingt-cinq, deux cent soixante-dix Saint-Hilaire-de-Riez
+Route des Goffineaux, Jard-sur-Mer
+Rue du Bourdaisy au Poiré-sur-Vie

--- a/server/data/fr/addresses-86.csv
+++ b/server/data/fr/addresses-86.csv
@@ -1,0 +1,70 @@
+trente et un allée de Chaix, quatre-vingt-six mille cent trente Dissay
+neuf rue de l'Abbé Longer, quatre-vingt-six, cent, Châtellerault
+quatre BIS rue Firmin Petit, quatre-vingt-six, cinq cent quatre-vingts à Vouneuil-sous-Biard
+Rue Camille Demarçay, quatre-vingt-six mille quatre cent quarante Migné-Auxances
+Avenue de la Croix Merlet, quatre-vingt-six, cent Châtellerault
+Rue Féodor Jelenc, Châtellerault
+Allée des Davitaires à Mignaloux-Beauvoir
+six chemin des Greles
+Rue d'Antran au numéro quatre-vingt-un
+vingt-sept rue de la Pilardière, quatre-vingt-six mille Poitiers
+un rUE MARIE-LOUISE DUBREUIL-JACOTIN, quatre-vingt-six, zéro zéro zéro, Poitiers
+cent quatorze rue de Quinçay, quatre-vingt-six, zéro zéro zéro à Poitiers
+Chemin de la Botte Molle, quatre-vingt-six mille Poitiers
+Route de Lencloître, quatre-vingt-six, cent Châtellerault
+Boulevard du Pont Joubert, Poitiers
+Rue de Bonnoy à Scorbé-Clairvaux
+huit avenue de Charles De Gaulle
+Boulevard Blossac au numéro vingt-six
+cinquante-trois rue des Terriers Moutons, quatre-vingt-six mille trois cents Chauvigny
+seize boulevard des Rocs, quatre-vingt-six, zéro zéro zéro, Poitiers
+cent soixante-quatorze rue du Clos Beilhoir, quatre-vingt-six, cent trente à Dissay
+Route de la Puye, quatre-vingt-six mille trois cent dix La Bussière
+Rue Maillochon, quatre-vingt-six, zéro zéro zéro Poitiers
+Rue Alphonse Plault, Neuville-de-Poitou
+Allée Pierre Blanchard à Migné-Auxances
+sept rue de la Nourasse
+Route de Chincé au numéro cinq BIS
+trente rue Champlan, quatre-vingt-six mille cent quatre-vingt-dix Quinçay
+quatorze chemin de la Brunetterie, quatre-vingt-six, huit cents, Sèvres-Anxaumont
+dix rue Bigeon Croisil, quatre-vingt-six, sept cents à Couhé
+Route de Crémille, quatre-vingt-six mille deux cent soixante-dix La Roche-Posay
+Rue Fernand Guérin, quatre-vingt-six, cent trente Saint-Georges-lès-Baillargeaux
+Boulevard Anatole-France, Poitiers
+Allée des Chevaux de Bois à Coulonges
+quatre-vingt-onze BIS rue Robert Gaillard
+Rue Charles Tillon Résistant au numéro quatre-vingt-quatre
+vingt-trois rue des Gautreaux, quatre-vingt-six mille trois cent quatre-vingts Ouzilly
+un route des Tessonnières, quatre-vingt-six, cent quarante, Saint-Genest-d'Ambière
+sept route des Pallus, quatre-vingt-six, quatre cent quatre-vingt-dix à Colombiers
+La Gorlière, quatre-vingt-six mille cent quatre-vingt-dix Latillé
+Rue du Moncro, quatre-vingt-six, six cents Saint-Sauvant
+Route d'Adriers, L'Isle-Jourdain
+Résidence de la Croix Carrée à Latillé
+quatre sous Le Petit Grand Champ
+Chemin du Vieux Mur au numéro six
+sept place du Chataigner, quatre-vingt-six mille trois cent vingt Gouex
+cent soixante-six route de Chaix, quatre-vingt-six, cent trente, Dissay
+sept allée de la Brandinière, quatre-vingt-six, trois cent quarante à Fleuré
+Allée de la Grand'Maison, quatre-vingt-six mille cinq cent cinquante Mignaloux-Beauvoir
+Route de la Bougrière, quatre-vingt-six, quatre cent quatre-vingt-dix Colombiers
+Rue de la Chauffetiere, Leigné-les-Bois
+Rue des Meures à Loudun
+vingt-cinq rue de Taupinet
+Route de la Vauceau au numéro dix-sept
+neuf rue Turquand, quatre-vingt-six mille cinq cent quatre-vingts Biard
+soixante-dix rue des Hautes Perrières, quatre-vingt-six, cent, Châtellerault
+cinq piedegrolle, quatre-vingt-six, huit cents à Lavoux
+Rue Anne Jolly, quatre-vingt-six mille cinq cent quatre-vingts Vouneuil-sous-Biard
+Rue Georges David, quatre-vingt-six, cent dix Mirebeau
+Rue Guille Belette, Migné-Auxances
+Rue Thibaudeau à Poitiers
+vingt-cinq rue Eugène Landais
+Route de Mirebinet au numéro quarante-trois
+quinze rue du Chanoine Chollet, quatre-vingt-six mille Poitiers
+soixante-quatorze rue Charles Plessard, quatre-vingt-six, cent, Châtellerault
+cent trente-cinq rue de la Bugellerie, quatre-vingt-six, zéro zéro zéro à Poitiers
+Allée des Trèfles d'Eau, quatre-vingt-six mille cinq cent quatre-vingts Vouneuil-sous-Biard
+Rue de Chef de Ville, quatre-vingt-six, trois cent quatre-vingts Vendeuvre-du-Poitou
+Venelle de la Salamandre, Saint-Clair
+Allée de Vayres à Poitiers

--- a/server/data/fr/addresses-87.csv
+++ b/server/data/fr/addresses-87.csv
@@ -1,0 +1,70 @@
+sept rue de Champagnac, quatre-vingt-sept mille six cents Rochechouart
+sept route de Masmonède, quatre-vingt-sept, cinq cents, Ladignac-le-Long
+trois impasse du Mas du Puy, quatre-vingt-sept, quatre cent trente à Verneuil-sur-Vienne
+Rue du Puy Las Rodas, quatre-vingt-sept mille Limoges
+Rue de Romanet, quatre-vingt-sept, zéro zéro zéro Limoges
+Avenue des Ruchoux, Limoges
+Rue de la Trahison à La Jonchère-Saint-Maurice
+vingt et un rue Porte Panet
+Route de Veyrinas au numéro dix
+quatorze chemin des Congeries, quatre-vingt-sept mille deux cent trente Dournazac
+quinze alléE Villagory, quatre-vingt-sept, zéro zéro zéro, Limoges
+dix-neuf rue de la Vige, quatre-vingt-sept, zéro zéro zéro à Limoges
+Rue de la Briance, quatre-vingt-sept mille cent dix Bosmie-l'Aiguille
+Place Léon Litaud, quatre-vingt-sept, trois cent dix Saint-Laurent-sur-Gorre
+Route de la Meyze, Nexon
+Route de Limont à Saint-Laurent-sur-Gorre
+deux rue du Pont de Nedde
+Rue du Clos Gaspard au numéro trois
+cinq alléE Maréchal Fayolle, quatre-vingt-sept mille Limoges
+trente-quatre rue Docteur Raymond, quatre-vingt-sept, zéro zéro zéro, Limoges
+douze passage de Latterie, quatre-vingt-sept, trois cent dix à Saint-Laurent-sur-Gorre
+Rue Henri d'Aguesseau, quatre-vingt-sept mille cent soixante-dix Isle
+Rue des Marchands de Vin, quatre-vingt-sept, deux cent quatre-vingt-dix Rancon
+Avenue Bernard de Ventadour, Oradour-sur-Vayres
+Rue Alain Grafeuil à Limoges
+sept route du Moulin de la Ribière
+Chemin du Château Authier au numéro cinq
+cent quatorze BIS avenue Montjovis, quatre-vingt-sept mille Limoges
+cent trois route du Mas des Landes, quatre-vingt-sept, cent soixante-dix, Isle
+douze rue Pétiniaud-Dubos, quatre-vingt-sept, zéro zéro zéro à Limoges
+Impasse des Ruchoux, quatre-vingt-sept mille Limoges
+Rue Docteur Desourteaux, quatre-vingt-sept, zéro zéro zéro Limoges
+Allée Léopold Gimié, Rilhac-Rancon
+Rue de Pouloueix à Oradour-sur-Vayres
+soixante-quatre rue Armand Dutreix
+Allée de la Vignerie au numéro sept
+dix-huit route des Lèzes, quatre-vingt-sept mille cinq cent dix Saint-Jouvent
+quatre route de la Croix Sénamaud, quatre-vingt-sept, cinq cent dix, Saint-Jouvent
+vingt alléE des Erables, quatre-vingt-sept, zéro zéro zéro à Limoges
+Avenue Roland Dorgelès, quatre-vingt-sept mille Limoges
+Rue de la Croix de Cramaux, quatre-vingt-sept, deux cents Chaillac-sur-Vienne
+Rue des Rosiers Negrelat, Cussac
+Rue de l'Aurence à Chaptelat
+huit avenue Diogène Bertrand
+Route du Dérot au numéro cinquante-cinq
+douze rue du Grand Rouvre, quatre-vingt-sept mille quatre cents Royères
+soixante-deux avenue de Louyat, quatre-vingt-sept, zéro zéro zéro, Limoges
+soixante et un rue de Brouillebas, quatre-vingt-sept, zéro zéro zéro à Limoges
+Place Marcelin Berthelot, quatre-vingt-sept mille trois cent cinquante Panazol
+Avenue Michel Gondinet, quatre-vingt-sept, cinq cents Saint-Yrieix-la-Perche
+Rue d'Arliquet, Aixe-sur-Vienne
+Rue Pierre Duditlieu à Bessines-sur-Gartempe
+trente et un route d'Aureil
+Rue Général du Bessol au numéro trois
+un chemin du Moulin de Razès-Bas, quatre-vingt-sept mille six cent quarante Razès
+deux impasse de Lasfond, quatre-vingt-sept, cinq cent quatre-vingt-dix, Saint-Just-le-Martel
+vingt-sept boulevard du Vigenal, quatre-vingt-sept, zéro zéro zéro à Limoges
+Route de la Gaudine, quatre-vingt-sept mille deux cents Saint-Brice-sur-Vienne
+Rue de Saint Gence, quatre-vingt-sept, zéro zéro zéro Limoges
+Rue des Geoffres, Verneuil-sur-Vienne
+Rue du Cercler à Limoges
+six route de la Longe
+Route de Mouret au numéro neuf
+un rue des Ligures, quatre-vingt-sept mille cent dix Le Vigen
+vingt-neuf rue Fonvieille-Alquier, quatre-vingt-sept, zéro zéro zéro, Limoges
+huit rue du Cramouloux, quatre-vingt-sept, cent dix à Bosmie-l'Aiguille
+AlléE des Eglantiers, quatre-vingt-sept mille Limoges
+Rue de Fontbouillant, quatre-vingt-sept, six cents Rochechouart
+Passage du Caroussel, Feytiat
+Avenue du Sablard à Limoges

--- a/server/data/fr/addresses-88.csv
+++ b/server/data/fr/addresses-88.csv
@@ -1,0 +1,70 @@
+quarante-sept rue du cent quarante-neuf e R.un., quatre-vingt-huit mille Épinal
+vingt-sept chemin du Bas de la Rayée, quatre-vingt-huit, quatre cents, Gérardmer
+quatre chemin du Pré du Lait, quatre-vingt-huit, cent vingt à Sapois
+Rue du Haut de l'Âtre, quatre-vingt-huit mille cinq cents Rouvres-en-Xaintois
+Rue de l'Avière, quatre-vingt-huit, trois cent quatre-vingt-dix Domèvre-sur-Avière
+Rue de Maximont, Golbey
+Chemin des Bas Rupts à Gérardmer
+vingt-quatre chemin de l'Allegrerie
+Chemin du Tandenet au numéro quinze
+dix chemin de la Claye, quatre-vingt-huit mille six cents Girecourt-sur-Durbion
+mille cent quatre-vingts rue du Val de Meurthe, quatre-vingt-huit, six cent cinquante, Anould
+quarante-sept chemin de l'École des Xettes, quatre-vingt-huit, quatre cents à Gérardmer
+Rue de Mamoine, quatre-vingt-huit mille quatre cent vingt Moyenmoutier
+Rue du Lieutenant Seidel, quatre-vingt-huit, cent cinquante Thaon-les-Vosges
+Rue Marcel Goulette, Charmes
+Route de Senones à Denipaire
+quatre chemin du Couchetat
+Rue Charles Levy au numéro trente-huit
+huit rue du Commandant Saint-Sernin, quatre-vingt-huit mille deux cent vingt Xertigny
+quatre martimpré, quatre-vingt-huit, quatre cent trente, Gerbépal
+huit place Oberkampf, quatre-vingt-huit, cent cinquante à Thaon-les-Vosges
+Le Harcholet, quatre-vingt-huit mille deux cent dix Le Saulcy
+Rue Max D'Ollone, quatre-vingt-huit, cent Saint-Dié-des-Vosges
+Faubourg d'Ambrail, Épinal
+Chemin de Labémont à Aumontzey
+trois chemin Jules Méline
+Rue Robert Marcillat au numéro quinze
+cinq BIS route d'Essey-la-Côte, quatre-vingt-huit mille trois cent trente Damas-aux-Bois
+six cent cinquante-trois rue des Savrons, quatre-vingt-huit, trois cent quatre-vingts, Archettes
+vingt-six impasse des Chalets du Lac, quatre-vingt-huit, quatre cents à Xonrupt-Longemer
+Rue de la Bolle, quatre-vingt-huit mille cent Saint-Dié-des-Vosges
+Rue de la Xavée, quatre-vingt-huit, deux cents Remiremont
+Rue de Lorima, Vittel
+Rue de Genazeville à Granges-sur-Vologne
+deux cent quatre-vingt-treize rue de Rabiémont
+Derrière La Chapelle au numéro un
+quatre cent un rue de Brehimont, quatre-vingt-huit mille quatre cent soixante-dix Saint-Michel-sur-Meurthe
+vingt route de Saint-Dié, quatre-vingt-huit, six cents, Fontenay
+cent vingt rue des Chartons, quatre-vingt-huit, cinq cent cinquante à Pouxeux
+Rue de Blanchefeigne, quatre-vingt-huit mille six cent quarante Granges-sur-Vologne
+Rue des Fusillés du dix-huit Novembre mille neuf cent quarante-quatre, quatre-vingt-huit, cent Saint-Dié-des-Vosges
+Allée de la Bautremois, Crainvilliers
+Rue d'Urbainroche à Rochesson
+cinq cent six route de Rambervillers
+Route de Hardemont au numéro deux
+dix-huit rue de Foucharupt, quatre-vingt-huit mille cent Saint-Dié-des-Vosges
+soixante et un rue de Saint-Ferjeux, quatre-vingt-huit, huit cents, Haréville
+dix-huit D chemin de la Droite des Rupts, quatre-vingt-huit, quatre cents à Gérardmer
+Route de Renauvoid, quatre-vingt-huit mille trois cent quatre-vingt-dix Sanchey
+Route du Chapis, quatre-vingt-huit, quatre cent quatre-vingt-dix Combrimont
+Rue de la Meix Aubry, Bazien
+Chemin du Chaud Côté à Saint-Étienne-lès-Remiremont
+six cent trente-neuf rue du Saut du Broc
+Route de Madonne au numéro cent vingt
+deux cent soixante-six rue de Rougibois, quatre-vingt-huit mille huit cents Vittel
+quatre-vingt-dix-huit route de la Médelle, quatre-vingt-huit, deux cent quatre-vingt-dix, Saulxures-sur-Moselotte
+cinq rue du Prèchamp, quatre-vingt-huit, cent cinquante à Oncourt
+Rue de la Peute Pierre, quatre-vingt-huit mille six cents Bruyères
+Rue Joseph Thiéry, quatre-vingt-huit, deux cent trente Ban-sur-Meurthe-Clefcy
+Passage du Gai Soleil, Épinal
+Rue Calouche à Vittel
+six mille trois cent quatre-vingt-seize route Départementale quarante-deux Fleurchamp
+Rue d'Olima au numéro quarante
+dix chemin du Liernat, quatre-vingt-huit mille deux cent cinquante La Bresse
+cent vingt-huit la Moiselle, quatre-vingt-huit, huit cents, Mandres-sur-Vair
+soixante-dix-sept sous Le Bois, quatre-vingt-huit, zéro zéro zéro à Dogneville
+Rue Juliette Ménéteau, quatre-vingt-huit mille cent quarante Bulgnéville
+Route du Séchenat, quatre-vingt-huit, cinq cent quarante Bussang
+Rue des Meix Beillia, Fresse-sur-Moselle
+Place Alexis Ignace à Épinal

--- a/server/data/fr/addresses-89.csv
+++ b/server/data/fr/addresses-89.csv
@@ -1,0 +1,70 @@
+quatre rue Guilbert Latour, quatre-vingt-neuf mille deux cent soixante-dix Vermenton
+un chemin des Grivaux, quatre-vingt-neuf, deux cents, Girolles
+vingt et un rue de l'Île aux Plaisirs, quatre-vingt-neuf, zéro zéro zéro à Auxerre
+Rue d'Arces, quatre-vingt-neuf mille sept cent soixante-dix Bœurs-en-Othe
+Chemin du Ponceau, quatre-vingt-neuf, cinq cents Dixmont
+Avenue Président Doumer, Avallon
+Place Max Blondat à Crain
+dix-neuf rue de la Cour au Sire
+Rue du Lt Colonel Jacques Boutet au numéro vingt-deux
+neuf rue de la Chasserelle, quatre-vingt-neuf mille cent soixante-dix Saint-Fargeau
+vingt rue Champbertrand, quatre-vingt-neuf, cent, Sens
+dix route Paris-Genève, quatre-vingt-neuf, trois cent vingt à Vaumort
+Rue Gibault André, quatre-vingt-neuf mille deux cent dix Brienon-sur-Armançon
+Rue de la Croix Saint-Vincent, quatre-vingt-neuf, cent cinquante Dollot
+Rue du Val des Vaux, Avallon
+Rue de la Côte Sainte-Anne à Mercy
+quinze route de Saint-Florentin
+Route de Montillot au numéro neuf
+quatre rue du Grand Carroir, quatre-vingt-neuf mille deux cent quarante Escamps
+quarante-deux boulevard Pierre Larousse, quatre-vingt-neuf, cent trente, Toucy
+huit rue de Charentenay, quatre-vingt-neuf, cinq cent soixante à Courson-les-Carrières
+Rue du Monjou, quatre-vingt-neuf mille deux cent dix Venizy
+Rue de la Vigne du Château, quatre-vingt-neuf, deux cent quarante Parly
+Rue de Champmorlin, Sainte-Magnance
+Rue du Port Renard à Chaumont
+quatre cent quatre-vingt-dix-huit rue du Champ Pussin
+Route de Marrault au numéro seize
+cent vingt-cinq rue du Vezeau, quatre-vingt-neuf mille huit cents Saint-Cyr-les-Colons
+neuf rue de la Vossière, quatre-vingt-neuf, cent, Collemiers
+trois rue des Soeurs Lecoq, quatre-vingt-neuf, trois cents à Joigny
+Rue de l'Archèvre, quatre-vingt-neuf mille quatre cent quarante Massangis
+Rue Besan, quatre-vingt-neuf, zéro zéro zéro Auxerre
+Ruelle du Bec d'Oie, Flogny-la-Chapelle
+Rue Émile Tissier à Gy-l'Évêque
+quatre rue des Frères Challe
+Enceinte de Digogne au numéro vingt et un dix
+trois ruelle Berthoux, quatre-vingt-neuf mille deux cents Tharot
+onze chemin des Peaux Daims, quatre-vingt-neuf, cent, Sens
+neuf rue des Poches, quatre-vingt-neuf, sept cents à Épineuil
+Rue du Port Bodot, quatre-vingt-neuf mille cent Sens
+Allée de Konen, quatre-vingt-neuf, cent vingt Charny
+Avenue Galifranc, Ligny-le-Châtel
+Rue Glacée à Jaulges
+un BIS ruelle Darnus
+Rue de Vaudru au numéro sept
+treize dix rue de la Vierge des Aides, quatre-vingt-neuf mille cinq cent trente Saint-Bris-le-Vineux
+quarante-trois H rue des Gauzys, quatre-vingt-neuf, quatre cents, Cheny
+trois rue du Parc du Chêne, quatre-vingt-neuf, sept cent soixante-dix à Chailley
+Impasse Fouchard, quatre-vingt-neuf mille deux cents Sauvigny-le-Bois
+Allée de Bel Étain, quatre-vingt-neuf, zéro zéro zéro Auxerre
+Avenue de la Côte Saint-Jacques, Joigny
+Chemin de Valprofondes à Tonnerre
+soixante-quinze rue Bellocier
+Rue de la Côte d'Oson au numéro huit
+quatre chemin des Misois, quatre-vingt-neuf mille cinq cents Dixmont
+dix rue des Vieux Bouchers, quatre-vingt-neuf, deux cent dix, Brienon-sur-Armançon
+sept allée de la Croix de Long, quatre-vingt-neuf, cinq cent cinquante à Héry
+Rue Lazare Bertrand, quatre-vingt-neuf mille cent Sens
+Rue Sous Murs, quatre-vingt-neuf, zéro zéro zéro Auxerre
+Rue Fernand Lamide, Brienon-sur-Armançon
+Route de Villechétive à Dixmont
+deux impasse du Gazon
+Chemin de l'Étang et de la Malmaison au numéro trois
+douze rue des Senons, quatre-vingt-neuf mille Auxerre
+six rue des Vaux Renards, quatre-vingt-neuf, cent, Saligny
+quinze rue de Méluzien, quatre-vingt-neuf, deux cents à Avallon
+Rue de Vallangis, quatre-vingt-neuf mille trois cent trente Villevallier
+Allée des Bergeronettes, quatre-vingt-neuf, trois cent quatre-vingts Appoigny
+Rue des Roubdeaux, Étais-la-Sauvin
+Rue du Val Serein à Gland

--- a/server/data/fr/addresses-90.csv
+++ b/server/data/fr/addresses-90.csv
@@ -1,0 +1,70 @@
+neuf rue Neuhauser, quatre-vingt-dix mille huit cent cinquante Essert
+douze rue Engel Gros, quatre-vingt-dix, zéro zéro zéro, Belfort
+vingt-sept rue d'Étueffont, quatre-vingt-dix, cent soixante-dix à Anjoutey
+Impasse Gaston Grelat, quatre-vingt-dix mille cent Delle
+Allée du Verdoyeux, quatre-vingt-dix, trois cents Éloie
+Rue du Paon Bleu, Larivière
+Rue du Général Roussel à Belfort
+quatorze rue de Froidefontaine
+Rue du Docteur Petitjean au numéro sept
+vingt-deux rue des Commandos d'Afrique, quatre-vingt-dix mille trois cents Cravanche
+cinq rue de Dorans, quatre-vingt-dix, quatre cents, Botans
+cinq via du Mont, quatre-vingt-dix, zéro zéro zéro à Belfort
+Rue de Leval, quatre-vingt-dix mille cent dix Rougemont-le-Château
+Rue des Greppes, quatre-vingt-dix, cent Fêche-l'Église
+Rue Lucien Gardey, Belfort
+Rue Georges Mercklé à Valdoie
+dix-huit quartier de la Gonfle
+Rue Le Vernois au numéro trente-neuf
+douze rue du Bringard, quatre-vingt-dix mille deux cents Rougegoutte
+un rue du Pré de Gill, quatre-vingt-dix, cent soixante, Denney
+trente-trois rue Édouard Frossard, quatre-vingt-dix, trois cents à Cravanche
+Rue du Docteur Julg, quatre-vingt-dix mille cinq cents Beaucourt
+Rue Jules Oriez, quatre-vingt-dix, trois cents Éloie
+Rue Pierre Sellier, Beaucourt
+Rue Général Gaulard à Belfort
+vingt rue des Champs des Côtes
+Rue d'Urcerey au numéro quinze
+cinquante-sept faubourg des Ancêtres, quatre-vingt-dix mille Belfort
+quatre rUE VIE DE LA CROZE, quatre-vingt-dix, huit cents, Argiésans
+cinq BIS rue de Sermamagny, quatre-vingt-dix, trois cents à Éloie
+Rue du Commandant Dufay, quatre-vingt-dix mille Belfort
+Rue du Phanitor, quatre-vingt-dix, deux cents Lepuix
+Rue des Commandos de France, Essert
+Rue du Chénois à Felon
+trois impasse sur le Rupt
+Rue de l'Adjoint Fernand Bègue au numéro quarante-cinq
+vingt-quatre rue des Bois Sarclés, quatre-vingt-dix mille cent soixante-dix Étueffont
+vingt-huit rue de la Pointée, quatre-vingt-dix, trois cent cinquante, Évette-Salbert
+six rue de Grone, quatre-vingt-dix, cent trente à Bretagne
+Rue Jules Heidet, quatre-vingt-dix mille cent dix Rougemont-le-Château
+Rue des Champs Grenier, quatre-vingt-dix, huit cents Bavilliers
+Rue Émile Parrot, Belfort
+Rue de Danjoutin à Andelnans
+vingt-six B rue de la Genêtre
+Rue de la Pouchotte au numéro quatorze
+un rue Georges Helminger, quatre-vingt-dix mille cent trente Montreux-Château
+quatre rue de Boron, quatre-vingt-dix, cent, Faverois
+quinze rue Georges Monin, quatre-vingt-dix, zéro zéro zéro à Belfort
+Avenue de Schwabmünchen, quatre-vingt-dix mille deux cents Giromagny
+Rue de la Beucinière, quatre-vingt-dix, deux cents Lepuix
+Chemin de Seppois, Réchésy
+Rue d'Argiésans à Banvillars
+quatre rue Jacques d'Aumale
+Rue de Thiancourt au numéro huit
+vingt-trois TER rue d'Éloie, quatre-vingt-dix mille cent soixante-dix Étueffont
+six rue de la Noie, quatre-vingt-dix, deux cents, Lepuix
+vingt-deux des Planchettes, quatre-vingt-dix, deux cents à Giromagny
+Lotissement de la Praie, quatre-vingt-dix mille quatre cents Meroux
+Rue du Margrabant, quatre-vingt-dix, cent cinquante Larivière
+Rue Albert Raspiller, Essert
+Rue Émile Marlin à Bavilliers
+vingt-trois rue des Champs de la Belle
+Rue Jean Debrot au numéro cinq
+six rue de l'Ancienne Frontière, quatre-vingt-dix mille cent trente Montreux-Château
+trente-trois rue Marcel Pangon, quatre-vingt-dix, trois cents, Cravanche
+dix-huit rue du Sous Lieutenant Cadinot, quatre-vingt-dix, huit cent cinquante à Essert
+Cité Querry, quatre-vingt-dix mille cent Faverois
+Rue Pierre Beucler, quatre-vingt-dix, cinq cents Beaucourt
+Rue des Frères Géhant, Châtenois-les-Forges
+Clos des Chevreuils à Offemont

--- a/server/data/fr/addresses-91.csv
+++ b/server/data/fr/addresses-91.csv
@@ -1,0 +1,70 @@
+quinze rue Albert Mercier, quatre-vingt-onze mille cent Corbeil-Essonnes
+quarante et un allée de la Pièce du Lavoir, quatre-vingt-onze, cent quatre-vingt-dix, Gif-sur-Yvette
+un voie du Marquis de Nattes, quatre-vingt-onze, zéro soixante-dix à Bondoufle
+Avenue de la Grande Brosse, quatre-vingt-onze mille trois cent quatre-vingt-dix Morsang-sur-Orge
+Rue du Lieutenant Gayot, quatre-vingt-onze, deux cent vingt Brétigny-sur-Orge
+Rue Olivier Lefebvre, Étampes
+Rue Nicolas Vaudin à Épinay-sur-Orge
+trente-deux square Joachim du Bellay
+Allée de la Croix Saint-Pierre au numéro soixante-six
+sept BIS chemin du Bois Badeau, quatre-vingt-onze mille deux cent vingt Brétigny-sur-Orge
+vingt-six rue Jean Bouyer, quatre-vingt-onze, six cents, Savigny-sur-Orge
+treize rue de l'Ariscotel, quatre-vingt-onze, quatre cent dix à Dourdan
+Rue Jean Argeliès, quatre-vingt-onze mille deux cent soixante Juvisy-sur-Orge
+Rue de Vilgénis, quatre-vingt-onze, trois cents Massy
+Rue Fegui, Limours
+Avenue de la Mutualité à Bures-sur-Yvette
+cent route de la Ruchère
+Rue de Fitte au numéro douze
+cinq clos de Bonainville, quatre-vingt-onze mille sept cent soixante-dix Saint-Vrain
+treize place des Plaquères, quatre-vingt-onze, zéro quatre-vingts, Courcouronnes
+soixante-quinze rue Jean-Jacques Frugier, quatre-vingt-onze, deux cents à Athis-Mons
+Avenue de la Futaye, quatre-vingt-onze mille trois cent quatre-vingt-dix Morsang-sur-Orge
+Rue des Pitourées, quatre-vingt-onze, deux cents Athis-Mons
+Avenue de la Passerelle, Ris-Orangis
+Rue de Roussigny aux Molières
+cent un avenue Robert Leuthreau
+Chemin sous le Bief au numéro sept
+soixante et un rue Émile Berthier, quatre-vingt-onze mille deux cent quarante Saint-Michel-sur-Orge
+cinq BIS rue des Hauts Fresnais, quatre-vingt-onze, cent soixante, Ballainvilliers
+douze rue Montgeron-Ville, quatre-vingt-onze, deux cent trente à Montgeron
+Rue de Malassis, quatre-vingt-onze mille six cent cinquante Breuillet
+Rue de la Roche Plate, quatre-vingt-onze, cent cinquante Étampes
+Rue de la Furetière, Villemoisson-sur-Orge
+Allée des Deux Sources à Yerres
+seize rue Jean Lagrive
+Rue Dauvilliers au numéro vingt
+quatorze A rue de la Ferté-Alais, quatre-vingt-onze mille huit cent quarante Soisy-sur-École
+quatre-vingt-un avenue du Jardinet, quatre-vingt-onze, trois cent quatre-vingt-dix, Morsang-sur-Orge
+treize allée du Croc-Martin, quatre-vingt-onze, huit cent vingt à Boutigny-sur-Essonne
+Rue Richard Vian, quatre-vingt-onze mille cinq cent trente Saint-Chéron
+Villa Poincaré, quatre-vingt-onze, cinq cent quatre-vingts Étréchy
+Rue du Roussay, Étréchy
+Rue Ruotte à Marcoussis
+quarante-trois rue Geneviève Anthonioz-de Gaulle
+Route de la Ferté-Alais au numéro douze
+trente-quatre route de Vert le Grand, quatre-vingt-onze mille cinq cent quarante Écharcon
+cinq rue Émile Mignon, quatre-vingt-onze, cinq cent quarante, Mennecy
+onze boulevard Crete, quatre-vingt-onze, cent à Corbeil-Essonnes
+Rue Henri Cherrière, quatre-vingt-onze mille cent Corbeil-Essonnes
+Rue Samuel Debordes, quatre-vingt-onze, deux cents Athis-Mons
+Rue de Machery, Angervilliers
+Rue du Trou Grillon à Saint-Pierre-du-Perray
+douze allée de Chasse
+Rue de l'Abbé Picard au numéro deux
+trente-huit A rue de Renonval, quatre-vingt-onze mille six cent soixante Méréville
+huit rue de la Rapasse Madame, quatre-vingt-onze, quatre cent dix, Corbreuse
+neuf rue de la Belle de Fontenay, quatre-vingt-onze, six cent quarante à Fontenay-lès-Briis
+Rue de la Sente Manicroche, quatre-vingt-onze mille six cent soixante Méréville
+Avenue de Morangis, quatre-vingt-onze, deux cents Athis-Mons
+Rue Jean Coureau, Étampes
+Rue de Gérofosse à Étampes
+quatre hameau de la Caravelle
+Chemin du Gigot au numéro vingt
+seize allée d'Ozonville, quatre-vingt-onze mille deux cents Athis-Mons
+quatre allée Tamaris, quatre-vingt-onze, trois cent soixante-dix, Verrières-le-Buisson
+trois chemin des Grous d'Aubin, quatre-vingt-onze, sept cent soixante à Itteville
+Rue Georges Coubard, quatre-vingt-onze mille huit cents Boussy-Saint-Antoine
+Rue du Milieu des Vignes du Nouzet, quatre-vingt-onze, deux cent trente Montgeron
+Boulevard Joseph Bara, Palaiseau
+Rue Georges Didier à Wissous

--- a/server/data/fr/addresses-92.csv
+++ b/server/data/fr/addresses-92.csv
@@ -1,0 +1,70 @@
+trente-deux avenue des Grésillons, quatre-vingt-douze mille six cents Asnières-sur-Seine
+mille sept cent vingt-huit allée du Vieux Pont de Sèvres, quatre-vingt-douze, cent, Boulogne-Billancourt
+trente-quatre avenue du Président Pompidou, quatre-vingt-douze, cinq cents à Rueil-Malmaison
+Avenue Marguerite Renaudin, quatre-vingt-douze mille cent quarante Clamart
+Rue Marius Jacotot, quatre-vingt-douze, huit cents Puteaux
+Rue du Champ Faucillon, Clamart
+Avenue Houlet à Colombes
+six rue du Pas Saint-Maurice
+Sentier des Alains au numéro quatre
+cinquante rue Louis Castel, quatre-vingt-douze mille deux cent trente Gennevilliers
+deux cent cinq rue des Gros Grès, quatre-vingt-douze, sept cents, Colombes
+neuf rue Ravon, quatre-vingt-douze, trois cent quarante à Bourg-la-Reine
+Ruelle des Ménagères, quatre-vingt-douze mille cent quatre-vingt-dix Meudon
+Rue de la Porte de Trivaux, quatre-vingt-douze, cent quarante Clamart
+Rue François Charles Ostyn, Colombes
+Rue Les Enfants du Paradis à Boulogne-Billancourt
+vingt et un avenue Alphonse de Neuville
+Avenue Duval Le Camus au numéro dix-neuf
+quinze rue des Lampes, quatre-vingt-douze mille cent quatre-vingt-dix Meudon
+deux villa Marie-Justine, quatre-vingt-douze, cent, Boulogne-Billancourt
+cinq impasse de la Tranquilité, quatre-vingt-douze, cent quarante à Clamart
+Avenue Henri Ravera, quatre-vingt-douze mille deux cent vingt Bagneux
+Rue Adolphe Pajeaud, quatre-vingt-douze, cent soixante Antony
+Rue Rivay, Levallois-Perret
+Rue Pierre Midrin à Sèvres
+vingt-sept chemin Renaudin
+Rue Mordillat au numéro vingt-trois
+six rue des Imbergères, quatre-vingt-douze mille trois cent trente Sceaux
+deux BIS rue Gossin, quatre-vingt-douze, cent vingt, Montrouge
+douze rue René Vauthier, quatre-vingt-douze, deux cent soixante à Fontenay-aux-Roses
+Rue Emilien Colin, quatre-vingt-douze mille cent cinquante Suresnes
+Mail Ambroise Croizat, quatre-vingt-douze, zéro zéro zéro Nanterre
+Square de la Côte Saint-Thibault, Bois-Colombes
+Rue Renée Gallot à Gennevilliers
+cent trente-six boulevard Rodin
+Avenue du Petit Clamart au numéro vingt-quatre
+cent quatre-vingt-dix quai de la Bataille de Stalingrad, quatre-vingt-douze mille cent trente Issy-les-Moulineaux
+dix-huit rue Maurice Labrousse, quatre-vingt-douze, cent soixante, Antony
+cinq rue Georges Quiqueré, quatre-vingt-douze, deux cent trente à Gennevilliers
+Rue Eugène Besançon, quatre-vingt-douze mille sept cents Colombes
+Avenue de Rivoli, quatre-vingt-douze, cent quatre-vingt-dix Meudon
+Rue Félicie, Gennevilliers
+Rue Hispano Suiza à Bois-Colombes
+dix-neuf BIS rue de la Lisette
+Rue Louise Cadoret au numéro huit
+six avenue Baudard, quatre-vingt-douze mille deux cent soixante-dix Bois-Colombes
+deux allée Véronèse, quatre-vingt-douze, quatre cents, Courbevoie
+vingt-huit rue des Petites Murailles, quatre-vingt-douze, deux cent trente à Gennevilliers
+Avenue Humbert, quatre-vingt-douze mille sept cents Colombes
+Avenue du Bois de Verrières, quatre-vingt-douze, deux cent quatre-vingt-dix Châtenay-Malabry
+Rue Claude Burgod, Suresnes
+Rue des Chéneaux à Sceaux
+trente-quatre avenue de Garlande
+Cours Aquitaine au numéro cent quatre-vingt-dix-huit
+trente-cinq avenue Léon Renault, quatre-vingt-douze mille sept cents Colombes
+treize rue Lelégard, quatre-vingt-douze, deux cent dix, Saint-Cloud
+cinquante boulevard Desgranges, quatre-vingt-douze, trois cent trente à Sceaux
+Rue des Chailliers, quatre-vingt-douze mille Nanterre
+Rue André Doucet, quatre-vingt-douze, zéro zéro zéro Nanterre
+Rue des Bas Tillets, Sèvres
+Rue Lily à Clamart
+vingt-quatre rue Ernest Deloison
+Villa Francisco Ferrer au numéro quatorze
+quarante-neuf rue du Docteur Thore, quatre-vingt-douze mille trois cent trente Sceaux
+quatre rue Roque de Fillol, quatre-vingt-douze, huit cents, Puteaux
+trente-sept rue Tilly, quatre-vingt-douze, sept cents à Colombes
+Villa des Sorbiers, quatre-vingt-douze mille cent quatre-vingt-dix Meudon
+Avenue des Trois Frères, quatre-vingt-douze, six cents Asnières-sur-Seine
+Villa Félicie, Bois-Colombes
+Rue Sintes à Châtenay-Malabry

--- a/server/data/fr/addresses-93.csv
+++ b/server/data/fr/addresses-93.csv
@@ -1,0 +1,70 @@
+trois BIS rue Philibert Hoffmann, quatre-vingt-treize mille cent dix Rosny-sous-Bois
+dix-neuf rue Albert Walter, quatre-vingt-treize, quatre cent trente, Villetaneuse
+quarante-huit avenue André Kervazo, quatre-vingt-treize, cent cinquante au Blanc-Mesnil
+Rue de la Croix Biche, quatre-vingt-treize mille cent soixante Noisy-le-Grand
+Sixième Avenue, quatre-vingt-treize, deux cent quatre-vingt-dix Tremblay-en-France
+Rue Saint-John Perse Alexis Léger, Villepinte
+Impasse Pelletier aux Lilas
+dix rue Alexandre Boucher
+Place Pluton au numéro dix
+dix-sept BIS rue Victor Aubry, quatre-vingt-treize mille deux cent vingt Gagny
+vingt-deux chemin Latéral Nord, quatre-vingt-treize, trois cents, Aubervilliers
+douze rue Nicolas Becker, quatre-vingt-treize, deux cent cinquante à Villemomble
+Rue Gasset, quatre-vingt-treize mille sept cents Drancy
+Rue du Docteur Delafontaine, quatre-vingt-treize, deux cents Saint-Denis
+Rue Roger Lemaire, Aulnay-sous-Bois
+Rue Gaston Noreux à Villetaneuse
+six impasse Mousseau
+Avenue de la Gare de Gargan au numéro seize
+onze rue Danquechin Dorval, quatre-vingt-treize mille cent trente Noisy-le-Sec
+treize huitième Avenue, quatre-vingt-treize, deux cent quatre-vingt-dix, Tremblay-en-France
+cent quatre-vingt-quatorze boulevard Théophile Sueur, quatre-vingt-treize, cent à Montreuil
+Rue Lucien Guillou, quatre-vingt-treize mille huit cents Épinay-sur-Seine
+Rue des Renouillères, quatre-vingt-treize, deux cents Saint-Denis
+Villa Berthe, Livry-Gargan
+Rue Kléber-Albouy à Stains
+quarante-quatre avenue Jacques Demolin
+Rue de l'Amiral Caillard au numéro dix
+vingt-trois rue Jean Pomier, quatre-vingt-treize mille sept cents Drancy
+vingt-cinq route d'Argenteuil, quatre-vingt-treize, huit cents, Épinay-sur-Seine
+six allée Fauré, quatre-vingt-treize, deux cent soixante-dix à Sevran
+Promenade Hermann Régnier, quatre-vingt-treize mille quatre cent soixante Gournay-sur-Marne
+Rue Adrien Froment, quatre-vingt-treize, sept cents Drancy
+Rue de la Philosophie, Bondy
+Place du Docteur Dupuytren à Aulnay-sous-Bois
+quatorze square du Bélier
+Boulevard Souchet au numéro vingt-six
+cinquante-deux rue Veuve Aublet, quatre-vingt-treize mille deux cent trente Romainville
+soixante-trois BIS avenue Paul Dupont, quatre-vingt-treize, cent quatre-vingt-dix, Livry-Gargan
+quarante-neuf rue Douy-Delcupe, quatre-vingt-treize, cent à Montreuil
+Rue André Joineau, quatre-vingt-treize mille trois cent dix Le Pré-Saint-Gervais
+Rue Émile Cossonneau, quatre-vingt-treize, trois cent trente Neuilly-sur-Marne
+Rue Henri Pescarolo, Montfermeil
+Allée Bruley-Chrétien à Drancy
+treize rue des Frères Noger
+Rue du Commandant Baroche au numéro trente-cinq
+quatorze rue des Villegranges, quatre-vingt-treize mille deux cent soixante Les Lilas
+cent trente-sept chemin de Groslay, quatre-vingt-treize, zéro zéro zéro, Bobigny
+dix-huit rue Fred Joliot Curie, quatre-vingt-treize, cent vingt à La Courneuve
+Avenue Charles Infroit, quatre-vingt-treize mille deux cent vingt Gagny
+Sentier des Grammonts, quatre-vingt-treize, cent soixante Noisy-le-Grand
+Rue Georges Bouchet, Villemomble
+Avenue Pierre Colongo à Tremblay-en-France
+vingt rue Remondet Lacroix
+Rue René Thuillier au numéro treize
+trente-trois allée Etienne Dolet, quatre-vingt-treize mille cent quatre-vingt-dix Livry-Gargan
+vingt-six rue Louis Larivière, quatre-vingt-treize, deux cents, Saint-Denis
+cinquante-sept rue Jules Mailly, quatre-vingt-treize, sept cents à Drancy
+Impasse Riboulet, quatre-vingt-treize mille deux cents Saint-Denis
+Avenue Lelièvre, quatre-vingt-treize, six cents Aulnay-sous-Bois
+Rue Fernand Sanglier, Neuilly-Plaisance
+Allée Micheline aux Pavillons-sous-Bois
+vingt-sept rue Lucie-Aubrac
+Allée des Brûlis au numéro vingt BIS
+quatre allée de Guise, quatre-vingt-treize mille deux cent vingt Gagny
+quatorze rue Nicolas Rayer, quatre-vingt-treize, trois cents, Aubervilliers
+quatre rue Villa des Roses, quatre-vingt-treize, deux cent quarante à Stains
+Avenue Houette, quatre-vingt-treize mille cent soixante Noisy-le-Grand
+Avenue Firmin Didot, quatre-vingt-treize, cent quatre-vingt-dix Livry-Gargan
+Boulevard Guy Môquet, Gournay-sur-Marne
+Rue Laugier Villars à Gagny

--- a/server/data/fr/addresses-94.csv
+++ b/server/data/fr/addresses-94.csv
@@ -1,0 +1,70 @@
+cent cinq avenue Lemerle Vetter, quatre-vingt-quatorze mille quatre cents Vitry-sur-Seine
+quatre-vingt-six avenue Busteau, quatre-vingt-quatorze, sept cents, Maisons-Alfort
+cinquante-quatre voie Fragonard, quatre-vingt-quatorze, quatre cents à Vitry-sur-Seine
+Chemin du Bas Gagny, quatre-vingt-quatorze mille quatre cent cinquante Limeil-Brévannes
+Rue Jarry Guérin, quatre-vingt-quatorze, quatre cent cinquante Limeil-Brévannes
+Rue du deux Décembre mille huit cent soixante-dix, Bry-sur-Marne
+Quai de la Baronnie à Ablon-sur-Seine
+dix cité Fernet
+Rue des Moines Saint-Martin au numéro trente-neuf
+vingt-deux rue René Thibault, quatre-vingt-quatorze mille cinq cent vingt Mandres-les-Roses
+huit allée Raymond Nègre, quatre-vingt-quatorze, trois cent quarante, Joinville-le-Pont
+cent huit quai de l'Artois, quatre-vingt-quatorze, cent soixante-dix au Perreux-sur-Marne
+Rue de Chalais, quatre-vingt-quatorze mille deux cent quarante L'Haÿ-les-Roses
+Avenue de Bonneuil, quatre-vingt-quatorze, trois cent soixante-dix Sucy-en-Brie
+Rue Boschot, Fontenay-sous-Bois
+Rue Labourse à Gentilly
+dix-neuf rue Eugène Nicot
+Rue de Raspail au numéro trente-quatre
+neuf rue Henri Cretté, quatre-vingt-quatorze mille cinq cent cinquante Chevilly-Larue
+cinq rue Daunot, quatre-vingt-quatorze, cent quarante, Alfortville
+trente-trois avenue Beaurepaire, quatre-vingt-quatorze, cent à Saint-Maur-des-Fossés
+Rue Musselburgh, quatre-vingt-quatorze mille cinq cents Champigny-sur-Marne
+Rue Léon Geffroy, quatre-vingt-quatorze, quatre cents Vitry-sur-Seine
+Avenue Mélina, Champigny-sur-Marne
+Rue John Steinbeck à Thiais
+vingt-quatre allée des Porcherets
+Avenue des Elzévirs au numéro neuf
+neuf rue de la Piple, quatre-vingt-quatorze mille cinq cents Champigny-sur-Marne
+quinze avenue de la Villa Trévise, quatre-vingt-quatorze, quatre cent vingt, Le Plessis-Trévise
+vingt-sept rue Leforestier, quatre-vingt-quatorze, deux cent quarante à L'Haÿ-les-Roses
+Rue du Pré Aux Merles, quatre-vingt-quatorze mille trois cent soixante Bry-sur-Marne
+Chemin du Pré de l'Etang Prolongé, quatre-vingt-quatorze, cinq cents Champigny-sur-Marne
+Chemin des Boutareines, Villiers-sur-Marne
+Cité Montjean à Fresnes
+quatorze rue de Bry
+Avenue du Groupe Manouchian au numéro quarante-deux
+quarante-quatre rue Epoigny, quatre-vingt-quatorze mille cent vingt Fontenay-sous-Bois
+quatre-vingt-trois rue de Cécile, quatre-vingt-quatorze, sept cents, Maisons-Alfort
+quarante-neuf avenue des Grands Godets, quatre-vingt-quatorze, cinq cents à Champigny-sur-Marne
+Rue Jean-Marie Poulmarch, quatre-vingt-quatorze mille deux cent quatre-vingt-dix Villeneuve-le-Roi
+Passage Henriette, quatre-vingt-quatorze, cent Saint-Maur-des-Fossés
+Rue Lacarrière, Sucy-en-Brie
+Rue Raymond Jeannot à Vitry-sur-Seine
+trois BIS rue Albert Larmé
+Chemin du Bois d'Auteuil au numéro vingt-deux
+vingt-neuf BIS rue Claude Cellier, quatre-vingt-quatorze mille deux cent trente Cachan
+vingt-sept BIS avenue Dunois, quatre-vingt-quatorze, deux cent quarante, L'Haÿ-les-Roses
+soixante-trois voie Greuze, quatre-vingt-quatorze, quatre cents à Vitry-sur-Seine
+Rue Antoine Marie Colin, quatre-vingt-quatorze mille quatre cents Vitry-sur-Seine
+Rue de l'Orme Sainte-Marie, quatre-vingt-quatorze, cent quatre-vingt-dix Villeneuve-Saint-Georges
+Boulevard de Vincennes, Fontenay-sous-Bois
+Avenue Charles Baudin à Champigny-sur-Marne
+six boulevard de Friedberg
+Villa du Moulin au numéro huit
+quatorze rue André Soladier, quatre-vingt-quatorze mille cent quarante Alfortville
+quarante-sept rue des Noriets, quatre-vingt-quatorze, quatre cents, Vitry-sur-Seine
+soixante-deux boulevard du vingt-cinq Août mille neuf cent quarante-quatre, quatre-vingt-quatorze, cent vingt à Fontenay-sous-Bois
+Avenue du Bois Guimier, quatre-vingt-quatorze mille cent Saint-Maur-des-Fossés
+Avenue de Vorges, quatre-vingt-quatorze, trois cents Vincennes
+Allée du Mélèze, Boissy-Saint-Léger
+Rue des Usines Périer à Bonneuil-sur-Marne
+douze avenue de Ceinture
+Rue Pelletan au numéro sept
+dix-huit rue Soddy, quatre-vingt-quatorze mille Créteil
+trois villa Magdeleine Rameau, quatre-vingt-quatorze, cent soixante-dix, Le Perreux-sur-Marne
+quatre BIS rue Reulos, quatre-vingt-quatorze, huit cents à Villejuif
+Avenue de Grosbois, quatre-vingt-quatorze mille quatre cent soixante-dix Boissy-Saint-Léger
+Rue Louise-Aglaë Cretté, quatre-vingt-quatorze, quatre cents Vitry-sur-Seine
+Rue Bourdignon, Saint-Maur-des-Fossés
+Rue Louise Adélaïde à Villiers-sur-Marne

--- a/server/data/fr/addresses-95.csv
+++ b/server/data/fr/addresses-95.csv
@@ -1,0 +1,70 @@
+cinq rue Lucien Royer, quatre-vingt-quinze mille trois cent quarante Persan
+vingt-trois allée de Pampelune, quatre-vingt-quinze, quatre cent dix, Groslay
+sept rue Jean Bouillot, quatre-vingt-quinze, cent trente à Franconville
+Ruelle des Vieilles Pierres, quatre-vingt-quinze mille quatre cent vingt Hodent
+Rue des Roulants, quatre-vingt-quinze, huit cents Cergy
+Rue Eugène Vallerand, Taverny
+Rue Charles Grimaud à Montmagny
+quatre clos des Quatre Feuilles
+Rue du Buisson Prunelle au numéro cinquante et un
+neuf rue Jeanne Robillon, quatre-vingt-quinze mille six cents Eaubonne
+six cour de Blémur, quatre-vingt-quinze, trois cent cinquante, Piscop
+vingt sentier des Grouettes, quatre-vingt-quinze, quatre cent quatre-vingts à Pierrelaye
+Ruelle Saint-Ladre, quatre-vingt-quinze mille deux cent soixante-dix Viarmes
+Chemin des Pilets, quatre-vingt-quinze, huit cents Cergy
+Rue Pierre Scheringa, Cergy
+Avenue des Millonnets à Vétheuil
+six rue Moulin Neuf
+Allée de Cormeilles au numéro cinquante-quatre
+quinze rue Victor Labarrière, quatre-vingt-quinze mille cent soixante-dix Deuil-la-Barre
+soixante-dix-sept rue de Passemay, quatre-vingt-quinze, cent, Argenteuil
+onze chemin des Avollées, quatre-vingt-quinze, trois cent vingt à Saint-Leu-la-Forêt
+RTE ROUEN, quatre-vingt-quinze mille quatre cent cinquante Théméricourt
+Rue de l'Asperge, quatre-vingt-quinze, cent Argenteuil
+Rue Georges Ribordy, Saint-Prix
+Rue Berthomme de Saint-André à Taverny
+trente boulevard de Boissy
+Rue de Gennete au numéro vingt-huit
+vingt-quatre villa du Chataignier, quatre-vingt-quinze mille cinq cents Gonesse
+six rue Claude Bigel, quatre-vingt-quinze, quatre cents, Arnouville
+trente-huit rue de Vauréal, quatre-vingt-quinze, zéro zéro zéro à Boisemont
+Rue du Mont de Veine, quatre-vingt-quinze mille trois cent cinquante Saint-Brice-sous-Forêt
+Allée Louis sept Le Jeune, quatre-vingt-quinze, cinq cents Gonesse
+Place des Chardonnerrettes, Sarcelles
+Rue de la Nonaise à Argenteuil
+dix-huit BIS rue Gaston Maurer
+Rue Béringier au numéro sept
+sept rue de la Heuse, quatre-vingt-quinze mille deux cent soixante Beaumont-sur-Oise
+vingt-deux rue de Jolival, quatre-vingt-quinze, cent, Argenteuil
+six rue Lucien Francia, quatre-vingt-quinze, zéro zéro zéro à Pontoise
+Rue Dame Alice, quatre-vingt-quinze mille cinq cents Le Thillay
+Rue Felix Rouget, quatre-vingt-quinze, quatre cent quatre-vingt-dix Vauréal
+Rue du Sergent Désolneux, Ermont
+Boulevard Raymond Lefevre à Goussainville
+seize BIS rue de la Luitte
+Ruelle des Petites Côtes au numéro trois
+trois clos de la Rive, quatre-vingt-quinze mille deux cent quatre-vingt-dix L'Isle-Adam
+trente-deux rue des Duchesnes, quatre-vingt-quinze, trois cent soixante-dix, Montigny-lès-Cormeilles
+vingt et un rue du Docteur Fourniols, quatre-vingt-quinze, quatre cent vingt à Magny-en-Vexin
+Rue Hadancourt, quatre-vingt-quinze mille trois cent quarante Persan
+Rue du Trou Nizeau, quatre-vingt-quinze, quatre cent soixante-dix Saint-Witz
+Route de Ménandon, Pontoise
+Chemin des Basses Bauves à Garges-lès-Gonesse
+vingt-trois rue Falande
+Sente de l'Orme Brulé au numéro vingt-deux BIS
+cent dix-neuf BIS rue de Morifosse, quatre-vingt-quinze mille cent Argenteuil
+vingt-trois rue du Champ de Chartres, quatre-vingt-quinze, deux cents, Sarcelles
+deux BIS rue de Barentin, quatre-vingt-quinze, cent à Argenteuil
+Rue Montmaur, quatre-vingt-quinze mille quatre cent trente Auvers-sur-Oise
+Rue du Docteur Rampont, quatre-vingt-quinze, quatre cents Villiers-le-Bel
+Villa des Merisiers, Saint-Prix
+Rue du Docteur Goldstein à Groslay
+onze rue Louis Albert Demangeon
+Rue des Meriens au numéro vingt-trois
+dix-sept rue Henri Vasseur, quatre-vingt-quinze mille cent Argenteuil
+un rue des Clairières Orange, quatre-vingt-quinze, zéro zéro zéro, Cergy
+cent quatorze allée du Bois de la Taillette, quatre-vingt-quinze, cent quatre-vingts à Menucourt
+Rue Roger Lemaître, quatre-vingt-quinze mille six cent soixante Champagne-sur-Oise
+Voie des Moulins Sud, quatre-vingt-quinze, deux cent quarante Cormeilles-en-Parisis
+Rue du Clos Lacroix, Le Plessis-Bouchard
+Avenue André Le Goas à Sannois

--- a/server/data/fr/addresses-971.csv
+++ b/server/data/fr/addresses-971.csv
@@ -1,0 +1,70 @@
+cent quatre-vingt-trois chemin de Petit Carbet, quatre-vingt-dix-sept mille cent quatorze Trois-Rivières
+quatre-vingt-sept ruelle Mancel, quatre-vingt-dix-sept, cent trente, Capesterre-Belle-Eau
+cent quarante-six rue Abel Racon, quatre-vingt-dix-sept, cent vingt-cinq à Bouillante
+Route de Rocroy, quatre-vingt-dix-sept mille cent dix-neuf Vieux-Habitants
+Route de Grand Croix, quatre-vingt-dix-sept, cent dix-neuf Vieux-Habitants
+Chemin des Pommes Acajou, Baillif
+Allée des Crabiers à Petit-Bourg
+cent dix-huit rue de Pont Pierre
+Chemin de la Caféière au numéro deux cent quatre-vingt-dix-huit
+sept cent cinquante-neuf A chemin des Galbas, quatre-vingt-dix-sept mille cent trente Capesterre-Belle-Eau
+quatorze rue Alexandre Isaac, quatre-vingt-dix-sept, cent, Basse-Terre
+trois cent douze rue Bruno Mercier, quatre-vingt-dix-sept, cent quarante et un à Vieux-Fort
+Rue du Gouverneur Houël, quatre-vingt-dix-sept mille cent trente-sept Terre-de-Haut
+Résidence Balisier, quatre-vingt-dix-sept, cent trente Capesterre-Belle-Eau
+Route de Matouba, Saint-Claude
+LOT LES RES DE BAIE ORIENTALE à Saint Martin
+soixante-dix rue des Hémérocalles
+Chemin des Pois Doux au numéro deux cent soixante-cinq
+trente rue Nozières, quatre-vingt-dix-sept mille cent dix Pointe-à-Pitre
+six cent cinquante avenue du Gouverneur Lyon, quatre-vingt-dix-sept, cent, Basse-Terre
+sept cent quarante-trois A chemin de Viard, quatre-vingt-dix-sept, cent soixante-dix à Petit-Bourg
+Chemin de la Regrettée, quatre-vingt-dix-sept mille cent quatorze Trois-Rivières
+Rue Martin Semiramoth, quatre-vingt-dix-sept, cent vingt Saint-Claude
+Avenue Paul Lacavé, Capesterre-Belle-Eau
+Rue Aristide Duvales à Saint-Claude
+quarante-trois lOT LES JARDINS D'ORIENT BAY
+Allée Alexer Alire au numéro cinquante-cinq
+trois cent soixante-deux route de Belfond, quatre-vingt-dix-sept mille cent vingt Saint-Claude
+deux cent quarante-huit chemin de Sarcelle, quatre-vingt-dix-sept, cent vingt-huit, Goyave
+onze rue Capitaine Emmanuel Gombaud-Saintonge, quatre-vingt-dix-sept, cent à Basse-Terre
+Ruelle Rechaud, quatre-vingt-dix-sept mille cent Basse-Terre
+Passage Victor Gaspard, quatre-vingt-dix-sept, cent Basse-Terre
+Chemin de Bois Raimbault, Baillif
+Rue Schoelcher à Pointe-à-Pitre
+mille six cent trente-cinq chemin Alfred Janvier
+Allée des Pommes Roses au numéro cent quinze
+cent trois rue Frebault, quatre-vingt-dix-sept mille cent dix Pointe-à-Pitre
+six mille deux cent sept rue Jean Ignace, quatre-vingt-dix-sept, cent seize, Pointe-Noire
+quatre cent quatre-vingt-cinq rue Absalon, quatre-vingt-dix-sept, cent vingt-cinq à Bouillante
+Rue Amédée Fengarol, quatre-vingt-dix-sept mille cent trente Capesterre-Belle-Eau
+Allée Emile le Dentu, quatre-vingt-dix-sept, cent Basse-Terre
+Chemin de Fontarabie, Petit-Bourg
+Chemin de Boynest à Petit-Bourg
+cinquante-sept chemin de Galbas
+LOT LES TERRES BASSES au numéro cent quatre-vingt-dix-neuf
+quatre cent trente-six rue Auguste Sainte-Luce, quatre-vingt-dix-sept mille cent trente Capesterre-Belle-Eau
+quarante-cinq lOT MONT VERNON deux, quatre-vingt-dix-sept, cent cinquante, Saint Martin
+six cent deux rue des Gommiers Blancs, quatre-vingt-dix-sept, cent vingt à Saint-Claude
+Rue Léon Mathis, quatre-vingt-dix-sept mille cent Basse-Terre
+Rue des Cattleyas, quatre-vingt-dix-sept, cent vingt Saint-Claude
+Boulevard de Bananier, Capesterre-Belle-Eau
+Route du Camp Jacob à Saint-Claude
+six cent neuf rue Raymonde Bouchaut
+Route de Moreau au numéro deux mille quatre cent vingt-trois
+cinq cent cinquante-quatre route de Haute Plaine, quatre-vingt-dix-sept mille cent trente Capesterre-Belle-Eau
+trois cent quarante-quatre rue Bernard Zébus, quatre-vingt-dix-sept, cent trente, Capesterre-Belle-Eau
+six cent soixante-dix B chemin Remy Roussas, quatre-vingt-dix-sept, cent soixante-dix à Petit-Bourg
+Chemin de Bovis, quatre-vingt-dix-sept mille cent vingt-trois Baillif
+RUE DE CONCORDIA, quatre-vingt-dix-sept, cent cinquante Saint Martin
+Impasse Barlet, Petit-Bourg
+Route de la Grippière à Petit-Bourg
+cinq cent dix-sept rue Maurice Selbonne
+Route de Dupré au numéro mille soixante et onze
+cinquante et un C faubourg Alexandre Isaac, quatre-vingt-dix-sept mille cent dix Pointe-à-Pitre
+cinq cent quatre-vingt-seize chemin de la Traversée, quatre-vingt-dix-sept, cent quatorze, Trois-Rivières
+deux mille six cent quarante-six chemin de Cousinière, quatre-vingt-dix-sept, cent dix-neuf à Vieux-Habitants
+RUE NANA CLARK, quatre-vingt-dix-sept mille cent cinquante Saint Martin
+BD BERTIN MAURICE LEONEL, quatre-vingt-dix-sept, cent cinquante Saint Martin
+Ruelle de l'Anse Mire, Terre-de-Haut
+Route Nationale N° un à Capesterre-Belle-Eau

--- a/server/data/fr/addresses-972.csv
+++ b/server/data/fr/addresses-972.csv
@@ -1,0 +1,70 @@
+six mille quatre cent soixante-six F chemin Sainville, quatre-vingt-dix-sept mille deux cent quinze Rivière-Salée
+vingt-sept rue du Balisier, quatre-vingt-dix-sept, deux cent vingt-neuf, Les Trois-Îlets
+cinquante-cinq route de Pointe Fort, quatre-vingt-dix-sept, deux cent trente et un au Robert
+Rue Herman Pérronnette, quatre-vingt-dix-sept mille deux cent trente-deux Le Lamentin
+Rue des Artisans-Za du Bac, quatre-vingt-dix-sept, deux cent vingt La Trinité
+Rue du Panier Caraïbe, Ducos
+Rue du Filao à Sainte-Marie
+vingt-quatre rue Joseph Souffleur
+Rue Sybosy au numéro deux
+vingt et un avenue des Balcons Montgéralde, quatre-vingt-dix-sept mille deux cents Fort-de-France
+quarante-quatre rue François Rustal, quatre-vingt-dix-sept, deux cents, Fort-de-France
+quatre-vingts rue Moreau de Jonnès, quatre-vingt-dix-sept, deux cents à Fort-de-France
+Route de Ravine Vilaine, quatre-vingt-dix-sept mille deux cents Fort-de-France
+Rue Paul Rano, quatre-vingt-dix-sept, deux cent quinze Rivière-Salée
+Rue Thine, Schœlcher
+Rue Stéphane Clémenté à Schœlcher
+trois mille deux chemin Birot
+Rue Daribo Leanise au numéro vingt-cinq
+soixante-six allée Kayali, quatre-vingt-dix-sept mille deux cent quarante Le François
+quatre-vingt-dix rue Joseph Lagrosilliere, quatre-vingt-dix-sept, deux cent vingt, La Trinité
+douze rue Paul Symphor, quatre-vingt-dix-sept, deux cent trente et un au Robert
+Résidence Grand Village, quatre-vingt-dix-sept mille deux cent trente-trois Schœlcher
+Rue A et T Duville, quatre-vingt-dix-sept, deux cent vingt-trois Le Diamant
+Rue du Versant Fleuri, Fort-de-France
+Route de l'Entraide à Fort-de-France
+quatre impasse des Hameaux
+Ancienne Route de Schoelcher au numéro vingt-six
+sept rue du Collier Chou, quatre-vingt-dix-sept mille deux cents Fort-de-France
+quarante BIS lotissement Pointe Hyacinthe, quatre-vingt-dix-sept, deux cent trente et un, Le Robert
+cent deux rue Leopold Bissol, quatre-vingt-dix-sept, deux cent trente-deux au Lamentin
+Passage Guéri Tout, quatre-vingt-dix-sept mille deux cents Fort-de-France
+Boulevard de la T.S.F., quatre-vingt-dix-sept, deux cents Fort-de-France
+Lotissement Pointe Savane Sud, Le Robert
+Rue Cité des Braves au Robert
+trente-trois route de la Batterie
+Avenue Georges Plissonneau au numéro vingt-cinq
+sept rue Albert Crétinoir, quatre-vingt-dix-sept mille deux cent trente-deux Le Lamentin
+soixante-trois route de Moutte, quatre-vingt-dix-sept, deux cents, Fort-de-France
+vingt-cinq impasse Roucouyer, quatre-vingt-dix-sept, deux cent dix-huit à Basse-Pointe
+Rue Ernest Dogue, quatre-vingt-dix-sept mille deux cents Fort-de-France
+Rue Faissal Vainduc, quatre-vingt-dix-sept, deux cents Fort-de-France
+Cité Saint-Georges Nord, Schœlcher
+Chemin Rural No sept de Zéphyr au Lamentin
+trois lotissement Campêche
+Avenue Léona Gabriel au numéro cent quatre-vingt-quinze
+trois cent vingt-quatre avenue Professeur Judes Turiaf, quatre-vingt-dix-sept mille deux cents Fort-de-France
+cent soixante-treize route des Religieuses, quatre-vingt-dix-sept, deux cents, Fort-de-France
+dix rue de la Fleuriste, quatre-vingt-dix-sept, deux cents à Fort-de-France
+Rue Monseigneur Lequin, quatre-vingt-dix-sept mille deux cents Fort-de-France
+Rue Joseph Del, quatre-vingt-dix-sept, deux cents Fort-de-France
+Chemin Jules Beaunes, Fort-de-France
+Avenue Ti-Émile Casérus à Fort-de-France
+deux cent quatre-vingts rue No vingt-deux Dillon
+Rue Yves Goussard au numéro douze
+cinquante-quatre avenue du Docteur Juvénal Linval, quatre-vingt-dix-sept mille deux cents Fort-de-France
+six passage du The Pays, quatre-vingt-dix-sept, deux cents, Fort-de-France
+soixante-treize rue Madinina, quatre-vingt-dix-sept, deux cents à Fort-de-France
+Rue Rodolphe et Agnès Maignan, quatre-vingt-dix-sept mille deux cent trente et un Le Robert
+Rue de la Valmenière, quatre-vingt-dix-sept, deux cents Fort-de-France
+Rue du Flamboyant, Fort-de-France
+Rue Carlos Finlay à Fort-de-France
+dix allée de l'Alamanda
+Rue Osman Nadeau au numéro dix
+deux allée Tire d'Aile, quatre-vingt-dix-sept mille deux cents Fort-de-France
+cinq rue de la Pointe des Pères, quatre-vingt-dix-sept, deux cent vingt-neuf, Les Trois-Îlets
+soixante-sept résidence La Carrière, quatre-vingt-dix-sept, deux cent quinze à Rivière-Salée
+Voie Communale de Poste Colon, quatre-vingt-dix-sept mille deux cents Fort-de-France
+Rue du Gros Mombin, quatre-vingt-dix-sept, deux cents Fort-de-France
+Rue de l'Effort Redoute, Fort-de-France
+Rue du Coq Créole à Fort-de-France

--- a/server/data/fr/addresses-973.csv
+++ b/server/data/fr/addresses-973.csv
@@ -1,0 +1,70 @@
+cent vingt-deux boulevard Emmanuel Bellony, quatre-vingt-dix-sept mille trois cent dix Kourou
+deux place Sylvano Antoinette, quatre-vingt-dix-sept, trois cent dix, Kourou
+neuf rue Auguste Boudinot, quatre-vingt-dix-sept, trois cent vingt à Saint-Laurent-du-Maroni
+Lotissement Les Jasmins un, quatre-vingt-dix-sept mille trois cents Cayenne
+Route de Baduel, quatre-vingt-dix-sept, trois cents Cayenne
+Rue des Caraibes, Matoury
+Rue Saut Caouenne à Sinnamary
+soixante-treize BIS rue Justin Catayée
+Rue Bois Jaboti au numéro trente-six
+trente avenue Jean Galmot, quatre-vingt-dix-sept mille trois cents Cayenne
+deux rue des Balourous, quatre-vingt-dix-sept, trois cent cinquante-quatre, Remire-Montjoly
+deux mille cinq cent quatre-vingt-quinze route d'Attila Cabassou, quatre-vingt-dix-sept, trois cent cinquante-quatre à Remire-Montjoly
+Rue Raymond Cresson, quatre-vingt-dix-sept mille trois cent dix Kourou
+Rue Henri Quintrie, quatre-vingt-dix-sept, trois cents Cayenne
+Rue Louise Orsini, Saint-Laurent-du-Maroni
+Faubourg l'Abri All B à Cayenne
+quarante-neuf chemin d'Armire
+Rue Lallouette au numéro soixante-quatre
+trente lotissement Morne Coco, quatre-vingt-dix-sept mille trois cent cinquante-quatre Remire-Montjoly
+vingt-deux rue Gonfolo, quatre-vingt-dix-sept, trois cent cinquante et un, Matoury
+trente-deux rue du Mahury, quatre-vingt-dix-sept, trois cent dix à Kourou
+Lotissement Aquavilla, quatre-vingt-dix-sept mille trois cent cinquante et un Matoury
+Lotissement Mortin, quatre-vingt-dix-sept, trois cent cinquante-quatre Remire-Montjoly
+Chemin de Troubiran, Cayenne
+Impasse des Œillets d'Inde à Matoury
+onze lotissement Toussaint
+Rue du Lieutenant-Colonel Chandon au numéro un BIS
+un chemin de la Montagne Carapa, quatre-vingt-dix-sept mille trois cent dix Kourou
+sept TER grand Brutus Allée deux, quatre-vingt-dix-sept, trois cents, Cayenne
+onze rue Kasse Ko, quatre-vingt-dix-sept, trois cent cinquante et un à Matoury
+Cite Chatenay quatre, quatre-vingt-dix-sept mille trois cents Cayenne
+Rue Vermont Polycarpe, quatre-vingt-dix-sept, trois cents Cayenne
+Rue de Cali, Kourou
+Rue des Calebasses à Kourou
+un impasse des Bons Eleves
+Avenue Doctoré Moges au numéro vingt et un
+trente-deux rue du Lieutenant Goinet, quatre-vingt-dix-sept mille trois cents Cayenne
+quatre résidence Perle Rose, quatre-vingt-dix-sept, trois cent cinquante-quatre, Remire-Montjoly
+vingt-trois avenue Wolfgang Amadéus Mozart, quatre-vingt-dix-sept, trois cent dix à Kourou
+Allée des Ébènes, quatre-vingt-dix-sept mille trois cent cinquante-cinq Macouria
+Rue du Mont Galbao, quatre-vingt-dix-sept, trois cent dix Kourou
+Lotissement Copaya un, Matoury
+Rue Jean-Baptiste Lieutenant à Mana
+sept allée des Balafons
+Rue Roland Lucile au numéro quarante-six
+huit lotissement Zi Collery Iii, quatre-vingt-dix-sept mille trois cents Cayenne
+douze rue Victor Ceide, quatre-vingt-dix-sept, trois cent cinquante-quatre, Remire-Montjoly
+trente-quatre rue Hippolyte Lètard, quatre-vingt-dix-sept, trois cent quinze à Sinnamary
+Avenue Louis Caristan, quatre-vingt-dix-sept mille trois cent cinquante-quatre Remire-Montjoly
+Lotissement Les Ames Claires, quatre-vingt-dix-sept, trois cent cinquante-quatre Remire-Montjoly
+Avenue de la Passoura, Kourou
+Rue des Frères Farlot à Remire-Montjoly
+trente-trois TER impasse des Flamboyants
+Lotissement Le Bois d'Opale deux au numéro quatre-vingt-onze A
+deux cent vingt-cinq avenue Jean Michotte, quatre-vingt-dix-sept mille trois cent cinquante-quatre Remire-Montjoly
+cinquante-quatre rue Bois Kobe, quatre-vingt-dix-sept, trois cent cinquante-quatre, Remire-Montjoly
+quatorze lotissement Les Olivettes, quatre-vingt-dix-sept, trois cent cinquante-quatre à Remire-Montjoly
+Route du Dégrad Saramaca, quatre-vingt-dix-sept mille trois cent dix Kourou
+Route de Rémire, quatre-vingt-dix-sept, trois cent cinquante-quatre Remire-Montjoly
+Rue René Barthélémi, Cayenne
+Rue Docteur Horth à Saint-Laurent-du-Maroni
+trente et un impasse Bois Jaboti
+Lotissement Sainte-Agathe au numéro quatre-vingt-cinq
+vingt-cinq avenue Auguste Boudinot, quatre-vingt-dix-sept mille trois cent dix Kourou
+huit route de Mango, quatre-vingt-dix-sept, trois cents, Cayenne
+cinq avenue de Préfontaine, quatre-vingt-dix-sept, trois cent dix à Kourou
+Rue de Règina, quatre-vingt-dix-sept mille trois cent dix Kourou
+Rue des Deux Criques, quatre-vingt-dix-sept, trois cent cinquante-quatre Remire-Montjoly
+Rue Paya, Kourou
+Allée des Glycerias à Saint-Laurent-du-Maroni

--- a/server/data/fr/addresses-974.csv
+++ b/server/data/fr/addresses-974.csv
@@ -1,0 +1,70 @@
+douze chemin Zaire, quatre-vingt-dix-sept mille quatre cent vingt-neuf Petite-Île
+quarante-cinq route de Cilaos, quatre-vingt-dix-sept, quatre cent vingt et un, Saint-Louis
+trente-huit rue Julius Hoarau, quatre-vingt-dix-sept, quatre cent quatorze à Entre-Deux
+Allèe De La Vierge, quatre-vingt-dix-sept mille quatre cent seize Saint-Leu
+Chemin Noun, quatre-vingt-dix-sept, quatre cent vingt-cinq Les Avirons
+Chemin du Cimetière H Delisle, Saint-Paul
+Sentier des Vetivers Bru à Saint-Denis
+quatre-vingt-neuf chemin du Cap
+Route du Moufia au numéro cent quatre-vingt-quatre
+quatre-vingt-onze chemin des Jamerosas, quatre-vingt-dix-sept mille quatre cent dix-huit Le Tampon
+douze avenue Monseigneur Roméro, quatre-vingt-dix-sept, quatre cent vingt, Le Port
+soixante-six rue du Camphrier, quatre-vingt-dix-sept, quatre cent onze à Saint-Paul
+Allée des Spinelles, quatre-vingt-dix-sept mille quatre cents Saint-Denis
+Lotissement le Pont, quatre-vingt-dix-sept, quatre cent vingt-neuf Petite-Île
+Rue Albert Lougnon, Saint-Joseph
+Chemin du Pere Raimbault à Saint-Denis
+deux impasse des mandarins
+Chemin Badamier au numéro dix
+douze rue Notre Dame des Rochers, quatre-vingt-dix-sept mille quatre cent trente-huit Sainte-Marie
+soixante-deux rue Hubert Delisle, quatre-vingt-dix-sept, quatre cent dix-huit, Le Tampon
+quarante-quatre rue du Géneral Ailleret, quatre-vingt-dix-sept, quatre cent dix-huit au Tampon
+Rue Auguste Técher, quatre-vingt-dix-sept mille quatre cent dix Saint-Pierre
+Chemin Stéphane Cdtrente-neuf, quatre-vingt-dix-sept, quatre cent dix Saint-Pierre
+Lotissement Chamby, Saint-Pierre
+Chemin Dumesgnil à Saint-Pierre
+deux avenue Raymond Barre
+Rue Adolphe Hoareau au numéro neuf A
+huit impasse des Caramboles, quatre-vingt-dix-sept mille quatre cent quarante et un Sainte-Suzanne
+cinquante-neuf rue Georges Moy de la Croix, quatre-vingt-dix-sept, quatre cent dix, Saint-Pierre
+quatre-vingt-dix-neuf BIS chemin Maniron, quatre-vingt-dix-sept, quatre cent vingt-sept à L'Étang-Salé
+Chemin Alfred Mazerieux, quatre-vingt-dix-sept mille quatre cents Saint-Denis
+Rue Oméga, quatre-vingt-dix-sept, quatre cent onze Saint-Paul
+Chemin Jean-Francois Revel, Le Tampon
+Chemin Nid Joli au Tampon
+dix chemin Berrichon
+Chemin Bassin Bleu (Ste Anne) au numéro un
+deux lotissement les Evis, quatre-vingt-dix-sept mille quatre cent douze Bras-Panon
+un A chemin de Ligne, quatre-vingt-dix-sept, quatre cent vingt-cinq, Les Avirons
+quatre-vingt-trois rue André Letoullec, quatre-vingt-dix-sept, quatre cent dix-neuf à La Possession
+Impasse Lefaguyès, quatre-vingt-dix-sept mille quatre cent quarante Saint-André
+Chemin Valcourt, quatre-vingt-dix-sept, quatre cent onze Saint-Paul
+Sentier Vetiver, Saint-Joseph
+Impasse Gaston Técher à Saint-Louis
+quarante-six TER rue Gervais Barret
+Rue des Pamplemousses au numéro six
+seize ruelle des Frères, quatre-vingt-dix-sept mille quatre cent dix Saint-Pierre
+soixante rue des Combavas, quatre-vingt-dix-sept, quatre cent quarante, Saint-André
+quatre-vingt-douze chemin Lefaguyes, quatre-vingt-dix-sept, quatre cent quarante à Saint-André
+Impasse Toolsy, quatre-vingt-dix-sept mille quatre cent dix Saint-Pierre
+Chemin René Payet, quatre-vingt-dix-sept, quatre cent trente-trois Salazie
+Chemin Bellier, Saint-Benoît
+Chemin du Piton Saint-Louis à Saint-Louis
+quatre cent douze chemin Boyer Desgranges
+Chemin Cour Renaud au numéro deux A
+deux cent vingt et un route du Tévelave, quatre-vingt-dix-sept mille quatre cent vingt-cinq Les Avirons
+quatorze A chemin Cachalot, quatre-vingt-dix-sept, quatre cent dix, Saint-Pierre
+cent quarante-quatre chemin La Chaîne, quatre-vingt-dix-sept, quatre cent dix à Saint-Pierre
+Route Jules Reydellet, quatre-vingt-dix-sept mille quatre cents Saint-Denis
+Chemin du Boeuf Mort, quatre-vingt-dix-sept, quatre cent dix-neuf La Possession
+Allée des Ecrins, Le Tampon
+Route des Bambous - Le Brule à Saint-Denis
+soixante-treize chemin Desruisseaux
+Rue Félix Guyon au numéro trente et un
+huit allée Manapany, quatre-vingt-dix-sept mille quatre cent dix Saint-Pierre
+trente-cinq rue Eugêne Dayot, quatre-vingt-dix-sept, quatre cent onze, Saint-Paul
+cent trente-quatre route du Bois de Nèfles, quatre-vingt-dix-sept, quatre cents à Saint-Denis
+Chemin Gramoune Bébé, quatre-vingt-dix-sept mille quatre cent vingt et un Saint-Louis
+Chemin Boissy, quatre-vingt-dix-sept, quatre cent dix-huit Le Tampon
+Chemin Lagourgue, Saint-André
+Sentier des Fleurs Jaunes à Saint-Leu

--- a/server/data/fr/addresses-976.csv
+++ b/server/data/fr/addresses-976.csv
@@ -1,0 +1,70 @@
+huit cHE ZIZA, quatre-vingt-dix-sept mille six cent cinquante M'Tsangamouji
+seize rue Chimo, quatre-vingt-dix-sept, six cent cinquante, M'Tsangamouji
+un cHE DJANFAR BACAR, quatre-vingt-dix-sept, six cent cinquante à M'Tsangamouji
+RUE IBRAHIM RAMADANI COCONI, quatre-vingt-dix-sept mille six cent soixante-dix Ouangani
+RUE DE L'AMITIE, quatre-vingt-dix-sept, six cent quinze Dzaoudzi
+LOT COTE PLAGE, Dembéni
+CHE MADI ABDOU HAMOURO à Bandrélé
+quatre cHE DE LA FONTAINE
+Rue de la Carrière Chembenyo au numéro seize
+seize rue M'Bouyoujou, quatre-vingt-dix-sept mille six cent quinze Dzaoudzi
+six mille neuf cent soixante-quatre rUE MADRASSE KAWENI, quatre-vingt-dix-sept, six cents, Mamoudzou
+quatre rue Riziki Foungoulie, quatre-vingt-dix-sept, six cent soixante-dix à Ouangani
+Rue Nahi Mkou, quatre-vingt-dix-sept mille six cent cinquante M'Tsangamouji
+Ruelle Haoibouchie, quatre-vingt-dix-sept, six cent soixante Bandrélé
+Rue Colo Fadila, M'Tsangamouji
+RUE DES douze VILLAS BARAKANI à Ouangani
+quatre-vingt-trois chemin Mosquée Cefe
+Rue de École Primaire au numéro six mille cent soixante-dix-huit
+six rue PPF, quatre-vingt-dix-sept mille six cent quinze Pamandzi
+trente rUE MSAIDIE SIAKA KAHANI, quatre-vingt-dix-sept, six cent soixante-dix, Ouangani
+vingt et un rue Antanambao, quatre-vingt-dix-sept, six cent cinquante à M'Tsangamouji
+CHE OUMARI BOINA, quatre-vingt-dix-sept mille six cent cinquante M'Tsangamouji
+Rue Mouzdalifa, quatre-vingt-dix-sept, six cent quinze Dzaoudzi
+RUE KONDROJOU, Bandrélé
+RUE DE LA MOSQUEE à Dzaoudzi
+vingt-trois rTE NATIONALE trois
+Rue Assani Houmadi au numéro six
+dix-sept rUE VITA LEMENGO, quatre-vingt-dix-sept mille six cent quinze Pamandzi
+douze rue Zevougnou, quatre-vingt-dix-sept, six cent cinquante, M'Tsangamouji
+quatre vILLAGE DE PAMANDZI, quatre-vingt-dix-sept, six cent quinze à Pamandzi
+Rue Assoumani Abdallah, quatre-vingt-dix-sept mille six cent cinquante M'Tsangamouji
+Rue Disma, quatre-vingt-dix-sept, six cent soixante Bandrélé
+CHE DADY HAMIDA, M'Tsangamouji
+RUE DE MLIHA - MLIHA à M'Tsangamouji
+cinq rue Moussa Sakalava
+Rue Abdallah Djoumoi au numéro dix-neuf
+deux rLE DES VACANCIERS BARAKANI, quatre-vingt-dix-sept mille six cent soixante-dix Ouangani
+onze rUE DE LA BALANCE, quatre-vingt-dix-sept, six cent cinquante, M'Tsangamouji
+six rLE SOUMAILA KANDZOU BARAKAN, quatre-vingt-dix-sept, six cent soixante-dix à Ouangani
+RLE ZAINA MSOILI, quatre-vingt-dix-sept mille six cent soixante-dix Ouangani
+IMP TROPINA - MIRERENI, quatre-vingt-dix-sept, six cent quatre-vingts Tsingoni
+Rue M'Dogo Oili, Dzaoudzi
+RUE MZE MATTOIR MBOUANATSA à Bouéni
+deux rue Magnassini
+RLE BA MOUSSILIMOU BARAKANI au numéro un
+six eSC ANLI HELI, quatre-vingt-dix-sept mille six cent cinquante M'Tsangamouji
+trois cHE WAILI, quatre-vingt-dix-sept, six cent cinquante, M'Tsangamouji
+dix-neuf rue Cecile Bleue, quatre-vingt-dix-sept, six cent quinze à Dzaoudzi
+ESC MABANDRANI BARAKANI, quatre-vingt-dix-sept mille six cent soixante-dix Ouangani
+RLE BOBOKA - BARAKANI, quatre-vingt-dix-sept, six cent soixante-dix Ouangani
+Rue Antanibazaha, M'Tsangamouji
+Chemin de la SNIE à Bandrélé
+un rUE DE LA CTAM
+RUE SACO au numéro trente et un
+vingt-trois rUE AMIR RIDJALI, quatre-vingt-dix-sept mille six cent cinquante M'Tsangamouji
+vingt rUE DU CINEMA, quatre-vingt-dix-sept, six cents, Mamoudzou
+vingt-cinq rUE CONVALESCENCE BARAKANI, quatre-vingt-dix-sept, six cent soixante-dix à Ouangani
+RUE VETIVER, quatre-vingt-dix-sept mille six cents Mamoudzou
+RUE DE LA CENTRALE EDM KAWEN, quatre-vingt-dix-sept, six cents Mamoudzou
+RUE CHEF BE - BARAKANI, Ouangani
+RUE DU BARRAGE MIRERENI à Tsingoni
+vingt lOT DARINE MONJOLY ILONI
+RUE BOUVET - COCONI au numéro un
+quatre passage Bacar Bourzane, quatre-vingt-dix-sept mille six cent quinze Dzaoudzi
+deux rue Koudjouni, quatre-vingt-dix-sept, six cent cinquante, M'Tsangamouji
+neuf rue du Jardin Moya, quatre-vingt-dix-sept, six cent quinze à Dzaoudzi
+Rue Sirf, quatre-vingt-dix-sept mille six cent quinze Dzaoudzi
+Rue Boubouni, quatre-vingt-dix-sept, six cents Mamoudzou
+RUE DE MAHABOU, Mamoudzou
+RUE MANGA M'KAKASSI à Mamoudzou


### PR DESCRIPTION
Add ~7000 new french sentences generated from [source: BANO](https://www.data.gouv.fr/fr/datasets/base-d-adresses-nationale-ouverte-bano/) (Licence: ODbL) using https://github.com/lissyx/commonvoice-fr/blob/master/bano.py script.

To regenerate this dataset with more or less data, use `cd path/to/commonvoice-fr/data/addresses && find *  | xargs   -l bash -c 'head -n <ADJUST_PER_FILE_SIZE_HERE> $0 > path/to/voice-web/server/data/fr/$0'` 

NB: 
 - custom templating is used to create some variability. Examples:
   - zipcode 75001 is sometimes translated to "soixante-quinze mille un" and sometime "soixante-quinze, zéro zéro un"
   - sometimes we ask the entire address (number + street + city + zicode), sometimes just the ask the street and the city, etc. See https://github.com/lissyx/commonvoice-fr/blob/master/bano.py#L12 for more info
 - Per subregion split aims to represent local specificities (ex: Alsatian addresses are very different from corsicans)

