### PR TITLE
more corrections in German

### DIFF
--- a/server/data/de/countries-and-cities.txt
+++ b/server/data/de/countries-and-cities.txt
@@ -217,9 +217,9 @@ Von achtzehn-hundert-fünfundsechzig bis achtzehn-hundert-einundsiebzig war Flor
 Das Königreich Neapel existierte von dreizehn-hundert-zwei bis achtzehn-hundert-sechtzehn.
 Istanbul war schon die Hauptstadt des Osmanischen Reiches.
 Auch Posen und Krakau waren mal Hauptstädte von Polen.
-Bratislava war die Hauptstadt des Königreich Ungarn.
+Bratislava war die Hauptstadt des Königreichs Ungarn.
 Belgrad war die Hauptstadt von Jugoslawien.
-Von siebzehn-hundert-zwölf bis neunzehn-hundert-achtzenh war Sankt Petersburg die Hauptstadt des Russischen Reichs.
+Von siebzehn-hundert-zwölf bis neunzehn-hundert-achtzehn war Sankt Petersburg die Hauptstadt des Russischen Reichs.
 Moskau war die Hauptstadt der Sowjetunion.
 Rio de Janeiro war kurze Zeit sogar die Hauptstadt von Portugal.
 Konstantinopel war die Hauptstadt des Byzantinischen Reichs.
@@ -294,7 +294,7 @@ Der Pazifische Ozean grenzt an alle anderen Weltmeere.
 Das Südpolarmeer umschließt den Kontinent Antarktika.
 Ein Flug zwischen Amerika und Europa ist ein Transatlantikflug.
 In Hongkong wird nicht Mandarin sondern Kantonesisch gesprochen.
-Neben englisch ist Hindi die Amtssprache in Indien.
+Neben Englisch ist Hindi die Amtssprache in Indien.
 Urdu ist in Pakistan und einigen indischen Bundesstaaten Amtssprache.
 In vielen afrikanischen Staaten ist französisch Amtssprache.
 Auch in vielen nordafrikanischen Ländern wird arabisch gesprochen.

--- a/server/data/de/countries-and-cities.txt
+++ b/server/data/de/countries-and-cities.txt
@@ -200,7 +200,7 @@ Washington, D.C. ist die Hauptstadt der Vereinigten Staaten von Amerika.
 Hanoi ist die Hauptstadt von Vietnam.
 Minsk ist die Hauptstadt von Weißrussland.
 Bangui ist die Hauptstadt der Zentralafrikanischen Republik.
-Nikosia ist die Hauptstadt von Republik Zypern.
+Nikosia ist die Hauptstadt der Republik Zypern.
 Pristina ist die Hauptstadt vom Kosovo.
 Ramallah ist die Hauptstadt von Palästina.
 Hargeysa ist die Hauptstadt von Somaliland.
@@ -262,7 +262,7 @@ Der Nil gilt traditionell als der längste Fluss der Welt.
 Die Donau durchfließt zehn Länder.
 Die Wolga ist der längste Fluss Europas.
 Der Rhein ist eine der verkehrsreichsten Wasserstraßen der Welt.
-Der Amazonas ist der Wasserreichste Fluss der Erde.
+Der Amazonas ist der wasserreichste Fluss der Erde.
 Australien ist keine Insel sondern ein Kontinent.
 Die Sahara ist die größte Wüste der Welt.
 Antarktika ist der südlichste Kontinent der Erde.

--- a/server/data/de/countries-and-cities.txt
+++ b/server/data/de/countries-and-cities.txt
@@ -208,18 +208,18 @@ Die Hauptstadt von Taiwan ist Taipeh.
 El Aaiún ist die Hauptstadt der Westsahara.
 Nord-Nikosia ist die Hauptstadt der Türkischen Republik Nord-Zypern.
 Die Hauptstadt der Cookinseln ist Avarua.
-Von neunzehn-hundert-zweiundzwanzig bis neunzehn-hundert-vierzig war Kaunas die Hauptstadt von Litauen.
+Von neunzehnhundertzweiundzwanzig bis neunzehnhundertvierzig war Kaunas die Hauptstadt von Litauen.
 Kalkutta war die Hauptstadt von Britisch-Indien.
 Mehrfach in der Geschichte Chinas war Nanjing die Hauptstadt des Landes.
-Von neunzehn-hundert-siebundvierzig bis neunzehn-hundert-neunundfünfzig war Karatschi die Hauptstadt von Pakistan.
+Von neunzehnhundertsiebenundvierzig bis neunzehnhundertneunundfünfzig war Karatschi die Hauptstadt von Pakistan.
 Vor der Wiedervereinigung des Landes war Saigon die Hauptstadt von Südvietnam.
-Von achtzehn-hundert-fünfundsechzig bis achtzehn-hundert-einundsiebzig war Florenz die Hauptstadt von Italien.
-Das Königreich Neapel existierte von dreizehn-hundert-zwei bis achtzehn-hundert-sechtzehn.
+Von achtzehnhundertfünfundsechzig bis achtzehnhunderteinundsiebzig war Florenz die Hauptstadt von Italien.
+Das Königreich Neapel existierte von dreizehnhundertzwei bis achtzehnhundertsechtzehn.
 Istanbul war schon die Hauptstadt des Osmanischen Reiches.
 Auch Posen und Krakau waren mal Hauptstädte von Polen.
 Bratislava war die Hauptstadt des Königreichs Ungarn.
 Belgrad war die Hauptstadt von Jugoslawien.
-Von siebzehn-hundert-zwölf bis neunzehn-hundert-achtzehn war Sankt Petersburg die Hauptstadt des Russischen Reichs.
+Von siebzehnhundertzwölf bis neunzehnhundertachtzehn war Sankt Petersburg die Hauptstadt des Russischen Reichs.
 Moskau war die Hauptstadt der Sowjetunion.
 Rio de Janeiro war kurze Zeit sogar die Hauptstadt von Portugal.
 Konstantinopel war die Hauptstadt des Byzantinischen Reichs.
@@ -300,7 +300,7 @@ In vielen afrikanischen Staaten ist französisch Amtssprache.
 Auch in vielen nordafrikanischen Ländern wird arabisch gesprochen.
 Auch Spanisch ist eine Weltsprache.
 Russisch schreibt man mit dem kyrillischen Alphabet.
-Für zweihundert-fünfzehn Millionen Sprecher ist Bengalisch die Muttersprache.
+Für zweihundertfünfzehn Millionen Sprecher ist Bengalisch die Muttersprache.
 Die Amtssprache im Iran ist Persisch.
 Das koreanische Alphabet wurde erst im fünfzehnten Jahrhundert erfunden.
 Alaska ist die größte Exklave der Erde.

--- a/server/data/de/german-cities.txt
+++ b/server/data/de/german-cities.txt
@@ -70,7 +70,7 @@ Von Flensburg bis nach Delmenhorst ist es eine lange Strecke
 Zu Fuß ist man von Gera bis Fürth lange unterwegs
 Man kann mit dem Fahrrad bis Oldenburg fahren
 Der Zug hält heute nicht in Waiblingen
-Muss ich in Bochum Umsteigen?
+Muss ich in Bochum umsteigen?
 Der Bus fährt nach Heidelberg
 Du kannst mit dem Bus nach Frankfurt an der Oder fahren.
 Ist es weit bis Nordhorn?
@@ -199,7 +199,7 @@ Von Weimar bis nach Neustadt an der Weinstraße ist es eine lange Strecke
 Zu Fuß ist man von Offenburg bis Leipzig lange unterwegs
 Man kann mit dem Fahrrad bis Wilhelmshaven fahren
 Der Zug hält heute nicht in Schweinfurt
-Muss ich in Gelsenkirchen Umsteigen?
+Muss ich in Gelsenkirchen umsteigen?
 Der Bus fährt nach Heilbronn
 Du kannst mit dem Bus nach Würzburg fahren
 Ist es weit bis Wolfsburg?

--- a/server/data/de/german-cities.txt
+++ b/server/data/de/german-cities.txt
@@ -121,7 +121,7 @@ Ich bin gerade erst in Aachen angekommen
 Möchte heute noch jemand nach Bergheim fahren?
 Ich könnte eine Mitfahrgelegenheit nach München anbieten
 Der nächste Zug nach Neustadt an der Weinstraße geht um zwölf Uhr dreißig
-Der Zug nach Wolfsburg ist schon um Dreiviertel drei abgefahren
+Der Zug nach Wolfsburg ist schon um dreiviertel drei abgefahren.
 Wenn du dich beeilst bekommst du noch den Zug um viertel nach fünf nach Mainz
 Der nächste Zug nach Frankfurt geht in einer Stunde und dreißig Minuten
 Können wir stattdessen mit dem Fernbus nach Berlin fahren?
@@ -250,7 +250,7 @@ Ich bin gerade erst in Göttingen angekommen
 Möchte heute noch jemand nach Neumünster fahren?
 Ich könnte eine Mitfahrgelegenheit nach Schweinfurt anbieten
 Der nächste Zug nach Görlitz geht um zwölf Uhr dreißig
-Der Zug nach Frankfurt am Main ist schon um Dreiviertel drei abgefahren
+Der Zug nach Frankfurt am Main ist schon um dreiviertel drei abgefahren.
 Wenn du dich beeilst bekommst du noch den Zug um viertel nach fünf nach München
 Der nächste Zug nach Wetzlar geht in einer Stunde und dreißig Minuten
 Können wir stattdessen mit dem Fernbus nach Nürnberg fahren?

--- a/server/data/de/jf99.txt
+++ b/server/data/de/jf99.txt
@@ -394,7 +394,7 @@ Wir sind weltweit führend in unserer Branche.
 Mit solchen Argumenten kannst du ihn nicht überzeugen.
 Widerstand ist zwecklos.
 So wie Richard es sagt, klingt es total unglaubwürdig.
-Die Geschichte hast du uns schon mindestens zehn mal erzählt.
+Die Geschichte hast du uns schon mindestens zehnmal erzählt.
 Thomas hat eine Realschulempfehlung bekommen.
 Um diese Hecke müsste sich auch mal jemand kümmern.
 Kann ich meine Sachen hier irgendwo einschließen?
@@ -584,7 +584,7 @@ Die Polizei konnte den Anrufer dingfest machen.
 Wo sehen Sie sich in fünf Jahren?
 Beeindrucken Sie mich.
 Was war Ihre größte Jugendsünde?
-Christiane ist jetzt bereits zwei mal durch die Matheprüfung gefallen.
+Christiane ist jetzt bereits zweimal durch die Matheprüfung gefallen.
 Bei diesem Feuerlöscher handelt es sich um einen Pulverlöscher.
 Martina geht tatsächlich jeden Sonntag in die Kirche.
 Ist sie Messdiener?
@@ -1207,7 +1207,7 @@ Keine Widerrede, das wird sofort erledigt!
 Das war ein Befehl und keine Diskussionsgrundlage.
 Inzwischen sind ja auch die meisten Frauen erwerbstätig.
 Sieht aus wie eine Zuhälterkarre.
-Diese Verhaltensmuster erinnert mich an jemanden.
+Dieses Verhaltensmuster erinnert mich an jemanden.
 Die Polizei ist weder gewillt, noch dazu in der Lage, mit meinen Daten vernünftig umzugehen.
 Filterblasen gab es schon immer, nur dass früher alle in derselben steckten.
 Ein Kumpel von mir kommt morgen aus dem Gefängnis frei.

--- a/server/data/de/jf99.txt
+++ b/server/data/de/jf99.txt
@@ -172,7 +172,7 @@ Stell dir vor es geht, aber keiner kriegt's hin.
 Das ist doch kein Problem.
 Gern geschehen!
 Es war mir eine Freude.
-Schön Sie kennen zu lernen, Herr Professor.
+Schön Sie kennenzulernen, Herr Professor.
 Du kannst mich duzen.
 Für dich immer noch Sie!
 Dürfte ich um Ihre Aufmerksamkeit bitten?
@@ -3791,7 +3791,7 @@ Teil der Ausstellung ist ein mittelalterliches Katapult.
 Auch sonst ist die Vorstellung sehr eindrucksvoll gewesen.
 Verzeiht mir meine Obszönitäten.
 Womit hast du die Ravioli gefüllt?
-Mit Rinderfleisch!
+Mit Rindfleisch!
 Egal, es ist echt lecker.
 Jetzt wirst du aber unsachlich.
 Frau Hoppe fühlt sich ausgelaugt und lässt sich daher eine Massage geben.


### PR DESCRIPTION
Not so sure about the year numbers. In other files, they are written without hyphens.
neunzehn-hundert-achtzehn vs. neunzehnhundertachtzehn

Sure, it's easier to read with hyphens, but I think without them is the formerly correct way. Also, we should probably have a consistent way to write such year numbers.

Shall I remove the hyphens?