### PR TITLE
[German data] punctuation fix

### DIFF
--- a/server/data/de/jf99.txt
+++ b/server/data/de/jf99.txt
@@ -2780,7 +2780,7 @@ Das musst du aushalten.
 Nach zwei Wochen ist es vorbei, versprach Christoph.
 Alexandra hört das Lied seit zwei Stunden in Dauerschleife.
 Hast du schon dein Seepferdchen gemacht, Alex?
-Wenn auf Bilderkennung trainierte, neuronale Netze träumen, erzeugen sie kunstvolle Bilder.
+Wenn auf Bilderkennung trainierte neuronale Netze träumen, erzeugen sie kunstvolle Bilder.
 Ich frage mich, ob neuronale Netze zur Spracherkennung beim Träumen anfangen zu sprechen.
 Wahrscheinlich wäre es eher unverständliches Gebrabbel.
 Aber man könnte wohl noch erkennen, um welche Sprache es sich handelt.


### PR DESCRIPTION
Das Adjektiv „trainiert“ darf nicht mit einem Komma von seinem Bezugswort getrennt werden. Deutlicher wird dies, wenn man schreibt: *Wenn trainierte neuronale Netze träumen, …*
Wenn man das als eingeschobenen Nachtrag (siehe [§ 77(7)](https://grammis.ids-mannheim.de/rechtschreibung/6201#par77)) auffassen würde, müsste man zwei Kommas setzen und den Satz wahrscheinlich umstellen: *Wenn neuronale Netze, auf Bilderkennung trainiert, träumen, …*