### PR TITLE
2 minor corrections for German

### DIFF
--- a/server/data/de/countries-and-cities.txt
+++ b/server/data/de/countries-and-cities.txt
@@ -164,7 +164,7 @@ Madrid ist die Hauptstadt von Spanien.
 Sri Jayewardenepura ist die Hauptstadt von Sri Lanka.
 Basseterre ist die Hauptstadt von St. Kitts und Nevis.
 Castries ist die Hauptstadt von St. Lucia.
-Kingstown ist die Hauptstadt von St. Vincent und die Grenadinen.
+Kingstown ist die Hauptstadt von St. Vincent und den Grenadinen.
 Pretoria ist die Hauptstadt von Südafrika.
 Kapstadt ist der Parlamentssitz von Südafrika.
 Juba ist die Hauptstadt vom Südsudan.

--- a/server/data/de/est31.txt
+++ b/server/data/de/est31.txt
@@ -81,7 +81,7 @@ Das letzte Level ist einfach.
 Füller ohne Tinte schreiben nicht.
 Zudem werden die nächsten zwei Tage nicht benötigt.
 Der Schaden am Stoff kann zügig repariert werden.
-Kurz, nachdem die Räuber die Bank verlassen haben, wurde die Polizei verständigt.
+Kurz nachdem die Räuber die Bank verlassen hatten, wurde die Polizei verständigt.
 Zuerst Lecks stopfen, danach Wasser auspumpen.
 Mit einem warmen Getränk im Bauch lässt sich die Kälte besser aushalten.
 Seit der Reparatur des Autos tritt das Problem nicht mehr auf.


### PR DESCRIPTION
A wrong article, a comma and wrong tense.