### PR TITLE
Bring back normalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "postcss-loader": "^2.0.7",
     "prettier": "^1.7.0",
     "prom-client": "^10.1.1",
+    "promise-decode-audio-data": "^0.4.1",
     "proxy-agent": "^2.0.0",
     "random-js": "^1.0.8",
     "react": "^16.3.0",

--- a/web/src/components/normalized-player.tsx
+++ b/web/src/components/normalized-player.tsx
@@ -3,6 +3,8 @@
 
 // TODO: human perception based loudness filtering (IIR filters)
 
+require('promise-decode-audio-data');
+
 export interface NormalizedPlayerInterface {
   play(clipUrl: string): Promise<void>;
   stop(): void;

--- a/web/src/components/normalized-player.tsx
+++ b/web/src/components/normalized-player.tsx
@@ -1,0 +1,80 @@
+// Audio normalization. Based on ReplayGain.
+// http://wiki.hydrogenaud.io/index.php?title=ReplayGain_specification
+
+// TODO: human perception based loudness filtering (IIR filters)
+
+export interface NormalizedPlayerInterface {
+  play(clipUrl: string): Promise<void>;
+  stop(): void;
+  onended?: (event: Event) => void;
+}
+export default class NormalizedPlayer implements NormalizedPlayerInterface {
+  private audioCtx: AudioContext;
+  private gainNode: GainNode;
+  private bufSource?: AudioBufferSourceNode;
+  onended?: (event: Event) => void;
+  constructor() {
+    const AudioContext = window.AudioContext || window.webkitAudioContext;
+    this.audioCtx = new AudioContext();
+    this.gainNode = this.audioCtx.createGain();
+    this.gainNode.gain.value = 1.0;
+    this.gainNode.connect(this.audioCtx.destination);
+  }
+  async play(clipUrl: string) {
+    const res = await fetch(clipUrl);
+    const encodedBuf = await res.arrayBuffer();
+    const decodedData = await this.audioCtx.decodeAudioData(encodedBuf);
+    // The decoded audio samples live in decodedBuffer
+    const decodedBuffer = decodedData.getChannelData(0);
+
+    // Obtain one Root Mean Square (RMS) value for
+    // each slice of 50ms length
+    var sliceLen = Math.floor(decodedData.sampleRate * 0.05);
+    var averages = [];
+    var sum = 0.0;
+    for (var i = 0; i < decodedBuffer.length; i++) {
+      sum += decodedBuffer[i] ** 2;
+      if (i % sliceLen === 0) {
+        sum = Math.sqrt(sum / sliceLen);
+        averages.push(sum);
+        sum = 0;
+      }
+    }
+
+    // Ascending sort of the averages array
+    averages.sort(function(a, b) {
+      return a - b;
+    });
+
+    // Take the average at the 95th percentile
+    var a = averages[Math.floor(averages.length * 0.95)];
+
+    var gain = 1.0 / a;
+
+    // Perform some clamping
+    gain = Math.max(gain, 0.02);
+    gain = Math.min(gain, 100.0);
+
+    // ReplayGain uses pink noise for this one one but we just take
+    // some arbitrary value... we're no standard
+    // Important is only that we don't output on levels
+    // too different from other websites
+    gain = gain / 10.0;
+
+    this.gainNode.gain.value = gain;
+    this.playBuf(decodedData);
+  }
+  private playBuf(buf: AudioBuffer) {
+    if (this.bufSource) {
+      this.bufSource.stop();
+    }
+    this.bufSource = this.audioCtx.createBufferSource();
+    this.bufSource.buffer = buf;
+    this.bufSource.connect(this.gainNode);
+    this.bufSource.onended = this.onended;
+    this.bufSource.start();
+  }
+  stop() {
+    this.bufSource.stop();
+  }
+}

--- a/web/src/components/pages/contribution/listen/listen.tsx
+++ b/web/src/components/pages/contribution/listen/listen.tsx
@@ -6,6 +6,7 @@ import { Clips } from '../../../../stores/clips';
 import { Locale } from '../../../../stores/locale';
 import StateTree from '../../../../stores/tree';
 import URLS from '../../../../urls';
+import NormalizedPlayer from '../../../normalized-player';
 import {
   CheckIcon,
   CrossIcon,
@@ -70,7 +71,7 @@ const initialState: State = {
 };
 
 class ListenPage extends React.Component<Props, State> {
-  audioRef = React.createRef<HTMLAudioElement>();
+  audioPlayer = new NormalizedPlayer();
   playedSomeInterval: any;
 
   state: State = initialState;
@@ -97,13 +98,14 @@ class ListenPage extends React.Component<Props, State> {
     return this.state.clips.findIndex(clip => clip.isValid === null);
   }
 
-  private play = () => {
+  private play = async () => {
     if (this.state.isPlaying) {
       this.stop();
       return;
     }
 
-    this.audioRef.current.play();
+    this.audioPlayer.onended = this.hasPlayed;
+    await this.audioPlayer.play(this.state.clips[this.getClipIndex()].audioSrc);
     this.setState({ isPlaying: true });
     clearInterval(this.playedSomeInterval);
     this.playedSomeInterval = setInterval(
@@ -113,9 +115,7 @@ class ListenPage extends React.Component<Props, State> {
   };
 
   private stop = () => {
-    const audio = this.audioRef.current;
-    audio.pause();
-    audio.currentTime = 0;
+    this.audioPlayer.stop();
     clearInterval(this.playedSomeInterval);
     this.setState({ isPlaying: false });
   };
@@ -188,12 +188,6 @@ class ListenPage extends React.Component<Props, State> {
     const activeClip = clips[clipIndex];
     return (
       <React.Fragment>
-        <audio
-          {...activeClip && { src: activeClip.audioSrc }}
-          preload="auto"
-          onEnded={this.hasPlayed}
-          ref={this.audioRef}
-        />
         <ContributionPage
           activeIndex={clipIndex}
           errorContent={

--- a/yarn.lock
+++ b/yarn.lock
@@ -954,6 +954,10 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+base-audio-context@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/base-audio-context/-/base-audio-context-1.1.1.tgz#d75a5b6cbbfda6728722b8590095b5136d8b8d28"
+
 base64-js@^1.0.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.3.tgz#fb13668233d9614cf5fb4bce95a9ba4096cdf801"
@@ -6771,6 +6775,12 @@ prom-client@^10.1.1:
   resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-10.2.2.tgz#76b39720710ec10796d7ce60135b5d5dafbff615"
   dependencies:
     tdigest "^0.1.1"
+
+promise-decode-audio-data@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/promise-decode-audio-data/-/promise-decode-audio-data-0.4.1.tgz#d29b0e716197c71543ad696c1f730ee6a30c25a2"
+  dependencies:
+    base-audio-context "^1.1.1"
 
 promise-inflight@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Fixes #1498.

Should have safari support now by using the promise-decode-audio-data package the way its author described in [this gist](https://gist.github.com/mohayonao/89fd55526cef5a60364e860695a4bf75). But please test it because I don't have any safari lying around to test it. I've tested it on Firefox though and here normalization works again!