### PR TITLE
Use dualstack for S3

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^10.3.0",
     "@types/passport": "^0.4.3",
     "@types/request-promise-native": "^1.0.14",
-    "aws-sdk": "^2.67.0",
+    "aws-sdk": "^2.362.0",
     "body-parser": "^1.18.2",
     "common": "*",
     "commonmark": "^0.28.1",

--- a/server/src/config-helper.ts
+++ b/server/src/config-helper.ts
@@ -47,6 +47,7 @@ const DEFAULTS: CommonVoiceConfig = {
   ADMIN_EMAILS: '[]', // array of admin emails, as JSON
   S3_CONFIG: {
     signatureVersion: 'v4',
+    useDualstack: true,
   },
   AUTH0: {
     DOMAIN: '',


### PR DESCRIPTION
Currently non-dualstack S3 endpoints are used, meaning that requests are made only over IPv4, even if the user's browser would prefer IPv6.