### PR TITLE
Support for Universal Links in iOS app

### DIFF
--- a/ios/voicebank-ios-wrapper.xcodeproj/project.pbxproj
+++ b/ios/voicebank-ios-wrapper.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		3E42BC781ECA43B8002E3CDA /* Recorder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Recorder.swift; sourceTree = "<group>"; };
 		3EC11D901EF45B6D00589896 /* BrowserViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserViewController.swift; sourceTree = "<group>"; };
 		3EE991BB1ED8B81800432FC5 /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
+		FCC0561721B60DDE00C44C75 /* voicebank-ios-wrapper.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "voicebank-ios-wrapper.entitlements"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -103,6 +104,7 @@
 		3E0027CC1EC3C7860050B4AC /* voicebank-ios-wrapper */ = {
 			isa = PBXGroup;
 			children = (
+				FCC0561721B60DDE00C44C75 /* voicebank-ios-wrapper.entitlements */,
 				3E0027CD1EC3C7860050B4AC /* AppDelegate.swift */,
 				3E0027CF1EC3C7860050B4AC /* ViewController.swift */,
 				3E0027D11EC3C7870050B4AC /* Main.storyboard */,
@@ -428,6 +430,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = EL6XVK58NU;
+				CODE_SIGN_ENTITLEMENTS = "voicebank-ios-wrapper/voicebank-ios-wrapper.entitlements";
 				INFOPLIST_FILE = "voicebank-ios-wrapper/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -443,6 +446,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = EL6XVK58NU;
+				CODE_SIGN_ENTITLEMENTS = "voicebank-ios-wrapper/voicebank-ios-wrapper.entitlements";
 				INFOPLIST_FILE = "voicebank-ios-wrapper/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/ios/voicebank-ios-wrapper/AppDelegate.swift
+++ b/ios/voicebank-ios-wrapper/AppDelegate.swift
@@ -37,6 +37,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 
-
+	func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
+		// Respond to user tapping authorization URL in their email
+		if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
+			let viewController = UIApplication.shared.keyWindow!.rootViewController as! ViewController
+			let url = userActivity.webpageURL
+			let request = URLRequest(url: url!)
+			viewController.webView?.load(request)
+		}
+		
+		return true
+	}
 }
 

--- a/ios/voicebank-ios-wrapper/voicebank-ios-wrapper.entitlements
+++ b/ios/voicebank-ios-wrapper/voicebank-ios-wrapper.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:voice.mozilla.org</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
This adds support for clicking a link in the user's web browser or mail app and having it launch the Common Voice app and navigate to the URL.

However, it needs the following server-side changes in order to be fully functional:

1. Edit the app ID at developer.apple.com and enable Associated Domains.

2. The authorization URL currently starts with https://auth.mozilla.auth0.com. Because Mozilla doesn't own auth0.com, there's no way to make it work with Universal Links. So the URL in the email needs to be changed to start with voice.mozilla.org and then redirect to the auth0 URL.