### PR TITLE
Fixed: Clicking Yes/No control doesn't stop the playing audio

### DIFF
--- a/web/src/components/pages/contribution/listen/listen.tsx
+++ b/web/src/components/pages/contribution/listen/listen.tsx
@@ -130,7 +130,7 @@ class ListenPage extends React.Component<Props, State> {
     const { clips } = this.state;
     const clipIndex = this.getClipIndex();
 
-    clearInterval(this.playedSomeInterval);
+    this.stop();
     this.props.vote(isValid, this.state.clips[this.getClipIndex()].id);
     this.setState({
       hasPlayed: false,


### PR DESCRIPTION
Fixed: #1217 

I think this quick fix should solve this bug.