### PR TITLE
Add Turkish German to list of accents

### DIFF
--- a/web/src/stores/demographics.ts
+++ b/web/src/stores/demographics.ts
@@ -38,6 +38,7 @@ export const ACCENTS: any = {
     romania: 'Rumänisch Deutsch',
     liechtenstein: 'liechtensteinisches Deutscher',
     namibia: 'Namibisch Deutsch',
+    turkey: 'Türkisch Deutsch',
   },
   en: {
     us: 'United States English',


### PR DESCRIPTION
Originally received the report here: https://www.meetup.com/Berlin-Mozilla-Meetup/events/257383300/

Currently the accents do not list "Turkish German", but they list some others. Given the amount of Turkish people living in German speaking countries, I agree with Mehmet that adding this would make sense.