### PR TITLE
Please remove apostrophes

### DIFF
--- a/server/data/eo/proverbaro.txt
+++ b/server/data/eo/proverbaro.txt
@@ -22,12 +22,12 @@ Al ĉiu sinjoro estu lia honoro.
 Al Dio plaĉu, sed sur diablon ne kraĉu.
 Al Dio servu, diablon rezervu.
 Al du sinjoroj samtempe oni servi ne povas.
-Al farun' malbonspeca ne helpos la spico.
+Al faruno malbonspeca ne helpos la spico.
 Al feliĉulo eĉ koko donas ovojn.
-Al fiŝ' kuirita jam akvo ne helpos.
+Al fiŝo kuirita jam akvo ne helpos.
 Al glacio printempa kaj al amiko tro nova ne fidu.
 Al grandaj sinjoroj grandaj honoroj.
-Al hundo bastono — al hom' leciono.
+Al hundo bastono — al homo leciono.
 Al kavo senfunda ŝtopado ne helpas.
 Al kokino la ovo lecionojn ne donu.
 Al koro penetro per okula fenestro.
@@ -35,7 +35,7 @@ Al kuko kaj kaso ĉiam venas amaso.
 Al la afero!
 Al la buŝo de "oni" neniu povas ordoni.
 Al la fiŝo ne instruu naĝarton.
-Al la malamik' en kuro faru ponton kun plezuro.
+Al la malamiko en kuro faru ponton kun plezuro.
 Al la papero ne mankas tolero.
 Al li ne mankas defendo kontraŭ ofendo.
 Al loko dolora ni manon etendas, al loko ĉarma okulojn ni sendas.
@@ -43,12 +43,12 @@ Al malriĉulo infanoj ne mankas.
 Al malriĉulo ovo kiel al riĉulo bovo.
 Al malsaĝulo ne helpas admono, nur bastono.
 Al mono kaj forto humiliĝas la sorto.
-Al pec' pecon algluas, kiu neston konstruas.
+Al peco pecon algluas, kiu neston konstruas.
 Al porko Dio kornojn ne donas.
 Al posedanto de metio mankas nenio.
 Al promeso oni ne kredas — kredu, kiu posedas.
 Al protekto kaj forto helpas la sorto.
-Al sklavo mon' ne estas savo, li ĉiam restas sklavo.
+Al sklavo mono ne estas savo, li ĉiam restas sklavo.
 Al tiu ĉio cedas, kiu monon posedas.
 Al venko rajto venas, se ĝin forto subtenas.
 Al vi ne plaĉis sitelo, laboru per martelo.
@@ -138,7 +138,7 @@ Aŭskulti kiel ĥinan predikon.
 Avarulo avaras, heredantoj malŝparas.
 Avarulo kaj porko estas bonaj post la morto.
 Avarulo pagas duoble.
-Azen' al azeno riproĉas malsaĝon.
+Azeno al azeno riproĉas malsaĝon.
 Azenon komunan oni batas plej multe.
 Babilas, muelas, kion lango elpelas.
 Balaaĵon el korto eksteren ne elportu.
@@ -205,7 +205,7 @@ Buĉas la lupo, oni ankaŭ ĝin buĉos.
 Butonumi iun malvaste.
 Ĉasaĵo ĉasanton ne atendas.
 Ĉe botisto la ŝuo estas ĉiam kun truo.
-Ĉe l' freŝa faro.
+Ĉe la freŝa faro.
 Ĉe la tagiĝo.
 Ĉe mastro ŝtelisto la servantoj ne ŝtelas.
 Ĉe plej granda fido memoru pri perfido.
@@ -250,7 +250,7 @@ Cindrulino.
 Ĉiu havas sian propran guston.
 Ĉiu havas sian ŝarĝon.
 Ĉiu havas sian vermon.
-Ĉiu iras, kiel saĝ' al li diras.
+Ĉiu iras, kiel saĝo al li diras.
 Ĉiu klopodu nur en sia metio, tiam al la urbo mankos nenio.
 Ĉiu komenco estas malfacila.
 Ĉiu kreas sian forton, ĉiu forĝas sian sorton.
@@ -261,11 +261,11 @@ Cindrulino.
 Ĉiu morgaŭ havas sian zorgon.
 Ĉiu persono kun sia bezono.
 Ĉiu por si mem estas la plej kara.
-Ĉiu por si, por ĉiuj Di'.
+Ĉiu por si, por ĉiuj Dio.
 Ĉiu propran saĝon posedas.
 Ĉiu provas, kion li povas.
 Ĉiu sezono kun sia bono.
-Ĉiu sin direktas, kiel la kap' al li diktas.
+Ĉiu sin direktas, kiel la kapo al li diktas.
 Ĉiu sin gvidas, kiel li vidas.
 Ĉiu tajloro havas sian tranĉmanieron.
 Ĉiu vivas laŭ sia prudento kaj sento.
@@ -289,9 +289,9 @@ De fremda groŝo ŝiriĝas la poŝo.
 De guto post guto disfalas granito.
 De kantado senpaga doloras la gorĝo.
 De kiu la kulpo, por tiu la puno.
-De l' koro spegulo estas la okulo.
+De la koro spegulo estas la okulo.
 De la buŝo ĝis la manoj estas granda interspaco.
-De la manoj ĝis lipoj la sup' elverŝiĝis.
+De la manoj ĝis lipoj la supo elverŝiĝis.
 De la volo la ordono pli efikas ol bastono.
 De legado sen atento ne riĉiĝas la prudento.
 De lia vivo aranĝo estas trinko kaj manĝo.
@@ -323,13 +323,13 @@ Demando ne kostas, demando ne devigas.
 Demeti de si la antikvan Adamon.
 Dentoj mordas la langon, tamen ambaŭ sin amas.
 Depost tempo nememorebla.
-Detruita ĝis la fundo de l' fundamento.
+Detruita ĝis la fundo de la fundamento.
 Deziri al iu amason da mono kaj titolon de barono.
 Deziri al iu ĉion bonan.
 Deziro kaj inklino ordonon ne obeas.
 Deziro tre granda, sed mankas la forto.
 Deziru sincere, vi atingos libere.
-Deziru, ne deziru — ordon' estas, iru!
+Deziru, ne deziru — ordono estas, iru!
 Diablo ne ĉiam unu pordon sieĝas.
 Diablo ŝercon ne komprenas, vokite li venas.
 Difekton de naturo ne kovros veluro.
@@ -428,7 +428,7 @@ Edziĝo najbara garantias de eraro.
 Edziĝo pro amo flamanta al la sako sonanta.
 Edziĝo tro momenta estas longapenta.
 Edzigu filon, kiam vi volas — edzinigu filinon, kiam vi povas.
-Edzin' admirata — edzo malsata.
+Edzino admirata — edzo malsata.
 Edzino pli elverŝas per funelo, ol edzo enverŝas per sitelo.
 Edzo edzinon laŭdas, edzino edzon aplaŭdas.
 Edzo kaj edzino — ĉiela difino.
@@ -449,7 +449,7 @@ El fremda ledo oni tranĉas larĝe.
 El fremda poŝo oni pagas facile.
 El kanto oni vortojn ne elĵetas.
 El klara ĉielo tondro ekbatis.
-El la buŝ' multaj vortoj eliras, sed ne ĉiuj ion diras.
+El la buŝo multaj vortoj eliras, sed ne ĉiuj ion diras.
 El la faraĉo fariĝis kaĉo.
 El la mizero oni devas fari virton.
 El la neceseco oni devas fari virton.
@@ -479,7 +479,7 @@ En arbaro sidis kaj arbojn ne vidis.
 En bona horo!
 En bona ordo tra la pordo!
 En buŝo Biblio, en koro malpio.
-En ĉeesto amata, en forest' insultata.
+En ĉeesto amata, en foresto insultata.
 En ĉiu aĝo devas kreski la saĝo.
 En ĉiu angulo alia postulo.
 En ĉiu brusto estas sia gusto.
@@ -488,7 +488,7 @@ En ĉiu kranio regas aparta opinio.
 En ĉiu malbono estas iom da bono.
 En ĉiu objekto troviĝas difekto.
 En ĉiu transloĝiĝo estas parto de ruiniĝo.
-En dom' de pendigito pri ŝnuro ne parolu.
+En domo de pendigito pri ŝnuro ne parolu.
 En feliĉo ne fieru, en malfeliĉo esperu.
 En fremda okulo ni vidas ligneron, en nia ni trabon ne vidas.
 En fremda tegmento li flikas truon kaj en propra ne vidas la fluon.
@@ -504,10 +504,10 @@ En la tago de la sankta Neniamo.
 En la triĵaŭda semajno.
 En landoj transmaraj estas oraj arbaroj.
 En luma tago.
-En malfacila horo eĉ groŝ' estas valoro.
+En malfacila horo eĉ groŝo estas valoro.
 En malsata familio mankas harmonio.
 En mizero eĉ saĝulo estas malsaĝa.
-En nomo de l' ĉielo, sed pro bono de l' felo.
+En nomo de la ĉielo, sed pro bono de la felo.
 En plej alta mizero al Dio esperu.
 En propra angulo ĉiu estas fortulo.
 En puton ne kraĉu, ĉar vi trinki bezonos.
@@ -515,7 +515,7 @@ En ŝerco kaj ludo ofte sidas aludo.
 En sia afero ĉiu juĝu libere.
 En sia angulo li estas bravulo.
 En sia dometo li estas atleto.
-En sia korto ĉiu kok' estas forta.
+En sia korto ĉiu koko estas forta.
 En trankvila vetero ĉiu remas sen danĝero.
 En unu sako du katoj, ĉiam mordoj kaj gratoj.
 En via malica regalo vin atendas ankaŭ pokalo.
@@ -544,7 +544,7 @@ Esti inter martelo kaj amboso.
 Esti sub la ŝuo de sia edzino.
 Estinta amiko estas plej danĝera malamiko.
 Estintaj amikoj plej kruele malpacas.
-Estis la tempo, ni ne komprenis — pasis la tempo, la saĝ' al ni venis.
+Estis la tempo, ni ne komprenis — pasis la tempo, la saĝo al ni venis.
 Estro ne malsatas.
 Estu ĉapo laŭ la kapo.
 Estu saĝa homo en via propra domo.
@@ -586,7 +586,7 @@ Festeno kaj ĉaso kaj da ŝuldoj amaso.
 Festotaga laboro estas sen valoro.
 Fianĉiĝis — por ĉiam ligiĝis.
 Fianĉiĝo ne estas edziĝo.
-Fianĉon de l' sorto difinitan forpelos nenia malhelpo.
+Fianĉon de la sorto difinitan forpelos nenia malhelpo.
 Fidanta al vorto atendas ĝis morto.
 Fiera mieno — kapo malplena.
 Fiereco venas antaŭ la falo.
@@ -606,7 +606,7 @@ Fleksu arbon dum ĝia juneco.
 Flugema kiel vento.
 Fluidaĵo sen difino, nek vinagro nek vino.
 Fluis sur lipoj, sed en buŝon ne trafis.
-For de l' okuloj, for de la koro.
+For de la okuloj, for de la koro.
 For el la manoj — for el kalkulo.
 For konscienco, venos potenco.
 For!
@@ -648,7 +648,7 @@ Gardatan ŝafon eĉ lupo timas.
 Gardu kandelon por la nokto.
 Gardu min Dio kontraŭ amikoj, kontraŭ malamikoj mi gardos min mem.
 Gardu vin du baroj: lipoj kaj dentaroj.
-Gast' en tempo malĝusta estas ŝtono sur brusto.
+Gasto en tempo malĝusta estas ŝtono sur brusto.
 Gasto havas akrajn okulojn.
 Gasto kiel fiŝo baldaŭ fariĝas malfreŝa.
 Gasto sen avizo estas agrabla surprizo.
@@ -676,7 +676,7 @@ Geedzoj en paco vivas en reĝa palaco.
 Ĝi fariĝis por mi osto en la gorĝo.
 Ĝi glitas de li kiel pizo de muro.
 Ĝi havas ankoraŭ signon de demando.
-Ĝi helpos kiel hirud' al mortinto.
+Ĝi helpos kiel hirudo al mortinto.
 Ĝi iris al li preter la buŝon.
 Ĝi jam staras al mi en la gorĝo.
 Ĝi ne eliris ankoraŭ el malproksima nebulo.
@@ -728,7 +728,7 @@ Hodiaŭ forto, morgaŭ morto.
 Hodiaŭ pagi vi devas, morgaŭ kredite ricevos.
 Hodiaŭ supre, morgaŭ malsupre.
 Hoko elsaltis, afero haltis.
-Hom' malesperas, Dio aperas.
+Homo malesperas, Dio aperas.
 Homo bagatelema.
 Homo esperas, morto aperas.
 Homo fidas, feliĉo decidas.
@@ -769,7 +769,7 @@ Inter pokalo kaj lipoj povas multe okazi.
 Interkonsento estas pli bona ol mono.
 Iom da malvero ne estas danĝero.
 Iras ĉiu kruro laŭ sia plezuro.
-Iri for en bona hor'.
+Iri for en bona horo.
 Jen havu!
 Jen kiaj ni estas!
 Jen staras la bovoj antaŭ la monto!
@@ -803,7 +803,7 @@ Juku la haŭto, sed ne sur mia korpo.
 Juneco ne scias, maljuneco ne povas.
 Juneco petolis, maljuneco malsatos.
 Ĵuri kaj reĵuri.
-Ĵuri per la barbo de l' profeto.
+Ĵuri per la barbo de la profeto.
 Kaldrono ridas pri poto kaj mem estas kota.
 Kalkuli muŝojn.
 Kalumniante konstante, oni eĉ anĝelon nigrigas.
@@ -823,10 +823,10 @@ Karaktero olea.
 Karakteron al kanto donas la tono.
 Karesi al iu la barbon.
 Karesi kontraŭ la haroj.
-Kastel' en aero — malsato sur tero.
+Kastelo en aero — malsato sur tero.
 Kaŝu kiom vi povos, mensogo sin elŝovos.
 Kaŝu malbenon kaj faru bonan mienon.
-Ke la lup' estu sata, kaj la ŝaf' ne tuŝata.
+Ke la lupo estu sata, kaj la ŝafo ne tuŝata.
 Kelktempa ĉeso ne estas forgeso.
 Kia ago, tia pago.
 Kia demando, tia respondo.
@@ -885,7 +885,7 @@ Kie pano estas, tie musoj ne mankas.
 Kie regas konkordo, regas ordo.
 Kie regas la forto, tie rajto silentas.
 Kie regas virino, malbona estas la fino.
-Kie sklav' regadon havas, tie mastro baldaŭ sklavas.
+Kie sklavo regadon havas, tie mastro baldaŭ sklavas.
 Kie timo, tie honto.
 Kiel akirite, tiel perdite.
 Kiel li meritis, tiel li profitis.
@@ -924,7 +924,7 @@ Kio pasis, nin forlasis.
 Kio post la montoj kuŝas, tio nin neniom tuŝas.
 Kio servas por ĉio, taŭgas por nenio.
 Kio taŭgas por somero, ne taŭgas por vintro.
-Kio tra l' dentoj travenis, tion la lipoj ne retenos.
+Kio tra la dentoj travenis, tion la lipoj ne retenos.
 Kio vendiĝas kaŝite, vendiĝas plej profite.
 Kiom ajn oni penas, per forto plaĉo ne venas.
 Kiom ajn vi penos, nenio elvenos.
@@ -974,7 +974,7 @@ Kiu bone agas, timi ne bezonas.
 Kiu bone sidas, tiu lokon ne ŝanĝu.
 Kiu bone ŝmiras, bone veturas.
 Kiu ĉasas du leporojn, kaptas neniun.
-Kiu ĉe l' vojo konstruas, tiun ĉiu instruas.
+Kiu ĉe la vojo konstruas, tiun ĉiu instruas.
 Kiu cedas al sia infano, ĝin pereigas per propra mano.
 Kiu ĉion formanĝis en tago, malsatos vespere.
 Kiu ĉion senpripense parolas, aŭdos tion, kion li ne volas.
@@ -1020,7 +1020,7 @@ Kiu koleras, tiu ne prosperas.
 Kiu koleras, tiu perdas.
 Kiu komencas juĝon, iras sub jugon.
 Kiu komencas tro frue, finas malfrue.
-Kiu komencis kuiri, ne forkuru de l' fajro.
+Kiu komencis kuiri, ne forkuru de la fajro.
 Kiu konsilas kaj rezonas, tiu helpon ne donas.
 Kiu konstante lokon ŝanĝas, neniam sin aranĝas.
 Kiu kritikas kuraĝe, mem agas malsaĝe.
@@ -1157,7 +1157,7 @@ Konkordo malgrandaĵon kreskigas, malkonkordo grandaĵon ruinigas.
 Konscienco senmakula estas kuseno plej mola.
 Konscienco trankvila estas bona dormilo.
 Konsento konstruas, malpaco detruas.
-Konservas eĉ karbo la strukturon de l' arbo.
+Konservas eĉ karbo la strukturon de la arbo.
 Konsilojn ĉiu donas, sed ne kiam oni bezonas.
 Konsilu kiu povas.
 Konsoliĝas mizerulo, se li estas ne sola.
@@ -1223,7 +1223,7 @@ Kuraĝe li staras, kiam muro lin baras.
 Kuraĝo ĉion atingas.
 Kurba estas la ligno, sed rekte ĝi brulas.
 Kurbiĝadi kiel diablo en akvo benita.
-Kurbiĝu hoko laŭ postuloj de l' loko.
+Kurbiĝu hoko laŭ postuloj de la loko.
 Kuri de sia propra korpo.
 Kutimo estas dua naturo.
 Kvalito bona ne bezonas admonon.
@@ -1238,7 +1238,7 @@ La afero ne brulas.
 La afero ne iras glate.
 La afero ne staras sur pinto de ponto.
 La afero ne urĝas.
-La dorm' estas bona, se mankas la mono.
+La dormo estas bona, se mankas la mono.
 La enigmo simple solviĝas.
 La felo tanadon ne valoras.
 La fino kronas la verkon.
@@ -1260,7 +1260,7 @@ La morto ne distingas, ĉiujn egale atingas.
 La morto ŝercon ne komprenas: oni ĝin vokas, ĝi venas.
 La muro havas orelojn.
 La parto plej vasta venos la lasta.
-La plej danĝera homo — malbona in' en domo.
+La plej danĝera homo — malbona ino en domo.
 La sama afero, sed kun la kapo al tero.
 La sigelo ankoraŭ ne estas metita.
 La tempo ĉiam malkaŝas la veron.
@@ -1276,7 +1276,7 @@ Laboro kaj pacienco kondukas al potenco.
 Laboro kondukas al honoro kaj oro.
 Laboro lacigas, sed akiro ĝojigas.
 Laboro ne estas leporo — ĝi haltos, ne forsaltos.
-Lang' estas mola kaj laŭvole petola.
+Lango estas mola kaj laŭvole petola.
 Langa vundo plej profunda.
 Lango miela, sed koro kruela.
 Lango nenion atingas, se ĝin saĝo ne svingas.
@@ -1285,9 +1285,9 @@ Larmoj pravecon ne pruvas.
 Larmoj ŝuldon ne pagas.
 Lasi fali la manojn.
 Laŭ ĉiuj leĝoj de la arto.
-Laŭ la agoj de l' homo estas lia nomo.
+Laŭ la agoj de la homo estas lia nomo.
 Laŭ la frukto oni arbon ekkonas.
-Laŭdu belecon de l' maro, sed ĉe rando de arbaro.
+Laŭdu belecon de la maro, sed ĉe rando de arbaro.
 Laŭdu la maron, sed restu sur tero.
 Laŭdu tagon nur vespere.
 Lavu tutan jaron, negro ne blankiĝos.
@@ -1317,7 +1317,7 @@ Li ekscitiĝas kiel bolanta lakto.
 Li esploris iom la fundon de la glaso.
 Li estas bravulo en sia angulo.
 Li estas en acida humoro.
-Li estas en klopodoj de l' kapo ĝis piedoj.
+Li estas en klopodoj de la kapo ĝis piedoj.
 Li estas flamiĝema kiel rezina ligno.
 Li estas frotita kaj polurita.
 Li estas homo sperta kaj lerta.
@@ -1477,7 +1477,7 @@ Malsaĝulo ne griziĝas nek senhariĝas.
 Malsaĝulo ofte estas profeto.
 Malsaĝulo ŝtonon ĵetis, dek saĝuloj ĝin ne atingos.
 Malsaĝulo venas, komercisto festenas.
-Malsaĝuloj kreskas mem, sen plugo kaj sem'.
+Malsaĝuloj kreskas mem, sen plugo kaj semo.
 Malsaĝulon favoras feliĉo.
 Malsaĝulon oni batas eĉ en la preĝejo.
 Malsanan demandu, al sana donu.
@@ -1594,7 +1594,7 @@ Ne atendis, ne esperis — malfeliĉo aperis.
 Ne atendita, ne esperita ofte venas subite.
 Ne atingos krio ĝis la trono de Dio.
 Ne aŭskultinte, ne kondamnu.
-Ne batalu pot' el tero kontraŭ kaldrono el fero.
+Ne batalu poto el tero kontraŭ kaldrono el fero.
 Ne batas bastono sen persono.
 Ne bedaŭru hieraŭan, ne atendu morgaŭan, ne forlasu hodiaŭan.
 Ne bela estas amata, sed amata estas bela.
@@ -1647,7 +1647,7 @@ Ne en unu tago elkreskis Kartago.
 Ne esperite, ne sonĝite.
 Ne estas piediranto kolego al rajdanto.
 Ne estingu la fajron, kiu vin ne bruligas.
-Ne falas frukto malproksime de l' arbo.
+Ne falas frukto malproksime de la arbo.
 Ne fanfaronu irante, fanfaronu revenante.
 Ne faru kalkulon sen la mastro.
 Ne fidu amikon, kiu havas jam flikon.
@@ -1694,7 +1694,7 @@ Ne pekas drinkulo, pekas ebriulo.
 Ne pelu tiun, kiu mem forkuras.
 Ne pentru diablon sur la muro.
 Ne por lupo estas supo.
-Ne povas ĉiu homo esti pap' en Romo.
+Ne povas ĉiu homo esti papo en Romo.
 Ne prediku knabino al via patrino.
 Ne prenis pastro la donon — rekaŝu sako la monon.
 Ne prokrastu ĝis morgaŭ, kion vi povas fari hodiaŭ.
@@ -1724,17 +1724,17 @@ Ne unu fajron li pasis, ne unu hundo lin ĉasis.
 Ne unu hundo lin mordis, ne unu vento lin tordis.
 Ne valoranto plaĉas, sed plaĉanto valoras.
 Ne valoras bofilo, kiam mortis filino.
-Ne valoras la akiro eĉ la penon de l' deziro.
-Ne valoras la faro la koston de l' preparo.
+Ne valoras la akiro eĉ la penon de la deziro.
+Ne valoras la faro la koston de la preparo.
 Ne veku malfeliĉon, kiam ĝi dormas.
 Ne venas honoro sen laboro.
-Ne venas mont' al monto, sed homo homon renkontas.
+Ne venas monto al monto, sed homo homon renkontas.
 Ne venas rato mem al kato.
 Ne venos rato mem al kato.
 Ne venos rato mem al la kato.
 Ne vivu kiel vi volas, vivu kiel vi povas.
 Ne voku diablon, ĉar li povas aperi.
-Ne volas kokin' al festeno, sed oni ĝin trenas perforte.
+Ne volas kokino al festeno, sed oni ĝin trenas perforte.
 Ne volis rajdi sur ĉevalo, ekrajdis sur azeno.
 Ne zorgu pri tio, kio estas ekster via scio.
 Nebuligi al iu la okulojn.
@@ -1806,7 +1806,7 @@ Ofte saĝulo vivas malriĉe kaj malsaĝulo feliĉe.
 Okaza komplimento ne iras al testamento.
 Okazo faras ŝteliston.
 Okazo kreas ŝteliston.
-Okazon kaptu ĉe l' kapo, ĉar la vosto estas glita.
+Okazon kaptu ĉe la kapo, ĉar la vosto estas glita.
 Okulo avidas ĉion kion vidas.
 Okulo de mastro pli ol beno de pastro.
 Okulo ne atentas, dorso eksentas.
@@ -1863,7 +1863,7 @@ Palpi al iu la pulson.
 Pano buŝon ne serĉas.
 Pano estas alportita, korbo estu forĵetita.
 Pardonemeco superas justecon.
-Parenc' al parenco ne malhelpas intence.
+Parenco al parenco ne malhelpas intence.
 Parenco per Adamo.
 Parolanto semas, aŭdanto rikoltas.
 Paroli dolĉe en la orelon.
@@ -1883,12 +1883,12 @@ Pecon detranĉitan al la pano ne regluu.
 Pekas junuloj kaj pekas maljunuloj.
 Peke akirita ne estas profita.
 Pekinto pentas, kolero silentas.
-Peko kaj eraro estas ecoj de l' homaro.
+Peko kaj eraro estas ecoj de la homaro.
 Peko malnova perdas pekecon.
 Pekon serĉi oni ne bezonas.
 Peli tagojn sen afero de mateno al vespero.
 Pelis pavon, falis kavon.
-Pelu mizeron tra l' pordo, ĝi revenos tra l' fenestro.
+Pelu mizeron tra la pordo, ĝi revenos tra la fenestro.
 Pendonto ne dronos.
 Pensoj iras trans limo sen pago kaj timo.
 Per bezono venas mono.
@@ -1917,7 +1917,7 @@ Perdinta la kapon pri haroj ne ploras.
 Pereis ŝafino, pereu ankaŭ la ŝafido.
 Perforta amo estas plej forta malamo.
 Peto de barono estas ordono.
-Peto kaj demando kondukas tra l' tuta lando.
+Peto kaj demando kondukas tra la tuta lando.
 Petolado sen mezuro ne kondukas al plezuro.
 Petolu, diboĉu, sed poste sorton ne riproĉu.
 Petro kornojn tenas, Paŭlo lakton prenas.
@@ -1996,7 +1996,7 @@ Pli feliĉa estas donanto ol prenanto.
 Pli feliĉa estas martelo insultata, ol amboso kompatata.
 Pli feliĉa sinjoro sen havo, ol riĉulo sed sklavo.
 Pli helpas guto da feliĉo, ol barelo da saĝo.
-Pli kara estas kap' al ĉapo.
+Pli kara estas kapo al ĉapo.
 Pli kara estas kapo ol ĉapo.
 Pli kara kapo ol ĉapo.
 Pli kostas la sako, ol la tuta pako.
@@ -2028,12 +2028,12 @@ Por ebriulo ne ekzistas danĝero.
 Por fremda koro ne ekzistas esploro.
 Por gasto ne petita mankas kulero.
 Por glate mensogi, oni spriton bezonas.
-Por honoro ni dankas, se manĝ' al ni mankas.
+Por honoro ni dankas, se manĝo al ni mankas.
 Por hundon dronigi, oni nomas ĝin rabia.
 Por kapti ezokon, bongustigu la hokon.
-Por la mono pastra preĝo, por la mono romp' de leĝo.
+Por la mono pastra preĝo, por la mono rompo de leĝo.
 Por li eĉ la muso ne estas sen felo.
-Por longa malsano kurac' estas vana.
+Por longa malsano kuraco estas vana.
 Por malfrua gasto restas nur osto.
 Por malsaĝulo bastono — por saĝulo leciono.
 Por malsanulo forto, por kokido la morto.
@@ -2046,7 +2046,7 @@ Por patrino ne ekzistas infano malbela.
 Por Paŭlo sperto, por Petro averto.
 Por peko senkonscia puno nenia.
 Por pendigi ŝteliston, antaŭe lin kaptu.
-Por pot' argila poto fera estas najbaro danĝera.
+Por poto argila poto fera estas najbaro danĝera.
 Por regna speso ne ekzistas forgeso.
 Por riĉulo fasto — por malriĉulo festo.
 Por ŝafo tondita Dio venton moderigas.
@@ -2068,7 +2068,7 @@ Post konfeso venas forgeso.
 Post la batalo preĝo ne helpas.
 Post la falo oni fariĝas singarda.
 Post la fasto venas festo.
-Post la fino de l' batalo estas multe da kuraĝuloj.
+Post la fino de la batalo estas multe da kuraĝuloj.
 Post mia malapero renversiĝu la tero.
 Post morto kuracilo jam estas sen utilo.
 Post nokta ripozo helpas la muzo.
@@ -2129,7 +2129,7 @@ Prunto amikon forpelas.
 Puno pekon svingas, favorkoreco ĝin estingas.
 Pura ĉielo fulmon ne timas.
 Pura konscienco estas plej granda potenco.
-Putrado de fiŝo komenciĝas de l' kapo.
+Putrado de fiŝo komenciĝas de la kapo.
 Rado malbona knaras plej multe.
 Rajdi sur ĉevalo oni ne lernas sen falo.
 Rakonti ĉion faritan kaj kaŝitan.
@@ -2174,7 +2174,7 @@ Rigardu per ambaŭ okuloj!
 Ripetado estas plej bona lernado.
 Ripetata parolo pri la sama titolo.
 Riveretoj fluas al riveroj.
-Rol' de virino — bona mastrino.
+Rola de virino — bona mastrino.
 Romo estas tie, kie estas la papo.
 Rostita kolombeto ne flugas al buŝeto.
 Rusto manĝas feron, ĉagreno la koron.
@@ -2182,8 +2182,8 @@ Rusto manĝas la feron, kaj zorgo la homon.
 Ŝafaro harmonia lupon ne timas.
 Ŝafo donas sian lanon, por ke mastro havu panon.
 Ŝafo kalkulita ne estas savita.
-Saĝa estas la frato post ricevo de l' bato.
-Saĝa estas la hundo post ricevo de l' vundo.
+Saĝa estas la frato post ricevo de la bato.
+Saĝa estas la hundo post ricevo de la vundo.
 Saĝa hundo post la vundo.
 Saĝa kapo duonvorton komprenas.
 Saĝa scias, kion li diras — malsaĝa diras, kion li scias.
@@ -2229,14 +2229,14 @@ Se decidos la sorto, helpos nenia forto.
 Se devigas neceso, faru kun kareso.
 Se Dio ne aranĝos, lupo vin ne manĝos.
 Se Dio ne volas, sanktulo ne helpos.
-Se Dio ordonos, eĉ ŝton' lakton donos.
+Se Dio ordonos, eĉ ŝtono lakton donos.
 Se edzino ordonas, domo ordon ne konas.
 Se elsaltas la okazo, ĝi rompiĝas kiel vazo.
-Se en kor' io sidas, vizaĝo perfidas.
+Se en koro io sidas, vizaĝo perfidas.
 Se ezoko piiĝis, gobio ne dormu.
 Se forestas la suno, sufiĉas la luno.
 Se geedzoj sin batas, fremdulo restu flanke.
-Se gut' al guto aliĝas, maro fariĝas.
+Se guto al guto aliĝas, maro fariĝas.
 Se haroj ne mankus, oni kalvon ne havus.
 Se homoj mankas, infano ankaŭ estas homo.
 Se io venas al buŝo, buŝon ne fermu.
@@ -2364,7 +2364,7 @@ Sperto saĝon akrigas.
 Spesmilo superflua poŝon ne ŝiras.
 Spesmilo vojon trabatas.
 Spiko malplena plej alte sin tenas.
-Sprit' en tempo ne ĝusta estas tre malbongusta.
+Sprito en tempo ne ĝusta estas tre malbongusta.
 Sprita vorto tentas, nenion atentas.
 Staras la morto jam en la korto.
 Stari per unu piedo en la tombo.
@@ -2398,7 +2398,7 @@ Sukcesa venkanto de pordoj malfermitaj.
 Ŝuldon tempo ne kuracas.
 Superpinte — nur tuŝinte.
 Sur arbon kliniĝintan saltas la kaproj.
-Sur ĉeval' de najbaro la ŝarĝo ne pezas.
+Sur ĉevalo de najbaro la ŝarĝo ne pezas.
 Sur ĉiu flanko nur manko kaj manko.
 Sur la ŝtelisto brulas la ĉapo.
 Sur la ventro veluro, en la ventro murmuro.
@@ -2418,8 +2418,8 @@ Tajloro krimis, botisto pendas.
 Taksi la sanon ni lernas en malsano.
 Tani al iu la haŭton.
 Tapiŝon ne deziris, maton akiris.
-Temp' estas mono.
-Temp' estas valoro simile al oro.
+Tempo estas mono.
+Tempo estas valoro simile al oro.
 Tempo flatas, tempo batas.
 Tempo kaj cirkonstancoj saĝon alportas.
 Tempo prenas, tempo pagas.
@@ -2474,7 +2474,7 @@ Tro elektema ricevas nenion.
 Tro forta ĵuro — la afero ne pura.
 Tro grandaj kalkuloj kondukas al nuloj.
 Tro kara aranĝo por malkara tagmanĝo.
-Tro longa atendo ĝis fino de l' vendo.
+Tro longa atendo ĝis fino de la vendo.
 Tro longa sufero — malgranda espero.
 Tro multe da salo malbonigas la manĝon.
 Tro nutrata kapro fariĝas kiel apro.
@@ -2490,7 +2490,7 @@ Troa petolo danĝera al kolo.
 Troa petolo estas danĝera por la kolo.
 Troviĝas bonaj homoj en la mondo.
 Trovis malbonulo malbonulon pli grandan.
-Truon de l' honoro flikos neniu tajloro.
+Truon de la honoro flikos neniu tajloro.
 Turniĝadi kiel serpento.
 Tuso kaj amo ne estas kaŝeblaj.
 Tuta jam sata, sed okulo malsatas.
@@ -2516,7 +2516,7 @@ Unu sola guto la glason plenigas.
 Unu soldato militon ne faras.
 Unu vido taŭgas pli ol dek aŭdoj.
 Unu vundo alian kuracas.
-Unu, du, tri, kvar, kaj finita la far'.
+Unu, du, tri, kvar, kaj finita la faro.
 Unua atesto estas la vesto.
 Unua paŝo iron direktas.
 Unua venis, unua prenis.
@@ -2562,7 +2562,7 @@ Vi amas preni, amu redoni.
 Vi min manĝigos, mi vin trinkigos.
 Vi ne kredas, ne aŭskultu, sed min ne insultu.
 Vi povas eĉ haki lignon sur lia kapo.
-Vi sekrete vorton diros, ĝi tra l' tuta mondo iros.
+Vi sekrete vorton diros, ĝi tra la tuta mondo iros.
 Vi sekretos al edzino, ŝi sekretos al fratino, kaj tiel la sekreto promenados sen fino.
 Vi varmigos serpenton, ĝi al vi enpikos la denton.
 Via dekstra mano ne sciu, kion faras la maldekstra.
@@ -2604,9 +2604,9 @@ Vivo glate ne fluas, ĉiam batas kaj skuas.
 Vivo modera estas vivo sendanĝera.
 Vivo sen modero kondukas al mizero.
 Vivon privatan kaŝu la muroj.
-Vivon travivi estas art' malfacila.
+Vivon travivi estas arto malfacila.
 Vivu mizere, sed vivu libere!
-Vivu stomako laŭ stato de l' sako.
+Vivu stomako laŭ stato de la sako.
 Vivu, progresu, sed lerni ne ĉesu.
 Vizaĝo agrabla kaj ungo diabla.
 Vizaĝo de Katono, sed virto de fripono.
@@ -2619,7 +2619,7 @@ Volo kaj deziro leĝojn ne konas.
 Volo kaj sento faras pli ol prudento.
 Volu-ne-volu — elekto ne ekzistas.
 Volus kato fiŝojn, sed la akvon ĝi timas.
-Vort' en ĝusta momento faras pli ol arĝento.
+Vorto en ĝusta momento faras pli ol arĝento.
 Vorto dirita al la mondo apartenas kaj neniam revenas.
 Vorto donita estas kiel leĝo.
 Vorto sona estas plej admona.


### PR DESCRIPTION
In Esperanto apostrophes are used as ellision marks mainly in literature and songs, for metrical reasons[1][2]. Only one normal usage of the ellision is in widespread use, in the idiomatic sentence "dank'al".

Because the Common Voice database is a tool to help voice recognition, and since in normal conversations speakers do not use the ellisions, this pull request changes all the apostrophized words to the actually spoken forms.

[1] https://en.wikipedia.org/wiki/Apostrophe#As_a_mark_of_elision
[2] https://bertilow.com/pmeg/gramatiko/apostrofo/normala_uzo.html