### PR TITLE
Please remove apostrophes

### DIFF
--- a/server/data/eo/chu-li.txt
+++ b/server/data/eo/chu-li.txt
@@ -11,7 +11,7 @@ Akceptante, vi faros profitan por vi aferon.
 Akcepti vian komplezon estus ĝin trouzi.
 Akceptu min; mi igos vin tre feliĉa.
 Akompanite de la juna virino, li eniris en la salonon.
-Akra kaj malbonodora fumo subite plenigis la koridoron de l' hotelo.
+Akra kaj malbonodora fumo subite plenigis la koridoron de la hotelo.
 Al kia mono vi aludas do?
 Al kiu do?
 Al la Maziera hotelo; kaj rapidu.
@@ -411,7 +411,7 @@ Dum la doktoro alpaŝis, li sentis sin malkvieta.
 Dum la nokto la bankiero revenis Parizon.
 Dum la tuta tago kaj la tuta nokto ni restis alkroĉitaj sur la pirogo.
 Dum okazis tiu mistera dramo, Fernando revenis piede Parizon.
-Dum sinjorino Herbeno monologis, ŝi malfermis la pordon de l' salono.
+Dum sinjorino Herbeno monologis, ŝi malfermis la pordon de la salono.
 Dum tiu tempo, Petro kaj lia edzino revenis hejmen.
 Dume Beatrico mortmalsaniĝis pro kortuŝeco kaj maltrankvileco.
 Dume ĉiuj ĉeestantoj iom post iom forlasis sian miregan sintenadon.
@@ -486,7 +486,7 @@ En la pasinta tempo li sen ia skrupulo min faris sia amatino.
 En la proceso okazis nenio rimarkinda.
 En la subetaĝo, farante lesivon.
 En la tempo pasinta li min amis.
-En la unua parto de l' enketo okazis nenia rakontinda fariĝo.
+En la unua parto de la enketo okazis nenia rakontinda fariĝo.
 En Parizo.
 En praktikado?
 En romanoj, eble; sed en realeco, tio estas tute ne efektivigebla.
@@ -605,7 +605,7 @@ Fernando ŝajnis embarasita.
 Fernando sin estis perfidinta.
 Fernando staris antaŭ li.
 Fernando, ekkriis Fradeko entuziasme, vi estas bonkora kaj grandanima.
-Fervoja oficisto malfermis la pordojn de l' atendejo.
+Fervoja oficisto malfermis la pordojn de la atendejo.
 Fidante al la dia justeco, ŝi atendis.
 Filipo jesis per klino de kapo.
 Filipo klinis la kapon.
@@ -615,7 +615,7 @@ Fine ĉiu tuja danĝero ŝajnis provizore malaperinta.
 Fine la aferoj troviĝis en tiu stato, kiam Petro naskiĝis.
 Fine la devo superis.
 Fine mi do povos vivi se ne feliĉa, almenaŭ trankvila.
-Fine mi havos la ŝlosilon de l' mistero, li diris.
+Fine mi havos la ŝlosilon de la mistero, li diris.
 Fine okazis fariĝo, kiu igis tute neutilaj ĉiujn iliajn antaŭzorgojn.
 Fine ŝia edzo konfesis, ke li estas Fernando.
 Fine tio, kio estas farita, estas farita: ni ne parolu plu pri ĝi.
@@ -658,7 +658,7 @@ Fraŭlino, permesu, ke mi prezentu al vi la kapitanon Herbeno.
 Gesinjoroj Herbeno!
 Ĝi estas ĉio.
 Ĝi estas li!
-Ĝi estas monografio pri la atrofio de l' umbilika ŝnuro.
+Ĝi estas monografio pri la atrofio de la umbilika ŝnuro.
 Ĝi estas necesega.
 Ĝi estas ŝi!
 Ĝi estis la kera damo.
@@ -670,7 +670,7 @@ Gesinjoroj Herbeno!
 Ĝi estis malnova skatolo por sardeloj.
 Ĝi estis Maziero.
 Ĝi estis mortiga ago: ĝi sukcesis.
-Ĝi estis Petro, kiu revenis, rapide avertite de l' pordisto.
+Ĝi estis Petro, kiu revenis, rapide avertite de la pordisto.
 Ĝi estis por mi ĉiela revo, kiun mi neniam forgesos, sed nur revo.
 Ĝi estis sango de Sedilo.
 Ĝi estis tro sincera por esti ludita.
@@ -751,7 +751,7 @@ Izolite tiuj du fotografaĵoj estas absolute similaj.
 Jam la vojaĝo, en kiu ŝi veturis sola kun Petro, estis severe juĝita.
 Je Dio; mi tion vidas, respondis Malo.
 Je kiu epoko?
-Je l' nomo de Maŭrico kaj je la mia, lasu min vin danki.
+Je la nomo de Maŭrico kaj je la mia, lasu min vin danki.
 Je la deka, Beatrico sin levis por eliri.
 Je la sepa, Maziero alvenis sola.
 Jen estas ankoraŭ la plej bona rimedo, por ke ĝi ne min premegu.
@@ -790,7 +790,7 @@ Jes, muĝis Reĝino per siblanta apenaŭ distingebla voĉo.
 Jes, panjo.
 Jes, respondis unu el ĉeestantoj.
 Jes, ŝi estos rajtigita al tio, li daŭrigis.
-Jes, sinjorino, se la fendego komunikiĝas kun la kuŝujo de l' torento.
+Jes, sinjorino, se la fendego komunikiĝas kun la kuŝujo de la torento.
 Jes, sinjorino.
 Jes, sinjoro, tuje.
 Jes, sinjoro.
@@ -820,7 +820,7 @@ Kaj li ĉesigis la operacion, feliĉe por Maziero.
 Kaj li daŭrigis sian interrompitan paŝadon.
 Kaj li refalis en sian mutecon.
 Kaj li ŝin enirigis en sian laborĉambron.
-Kaj mi en la profundaĵoj de l' glaciejo?
+Kaj mi en la profundaĵoj de la glaciejo?
 Kaj mi estas certa, ke li min gratulis fundkore pro mia diskreteco.
 Kaj mi foriras, kurante kiel eble plej rapide.
 Kaj mi lin suspektis!
@@ -940,7 +940,7 @@ Kio ĝi estas?
 Kio li fariĝis?
 Kio malhelpis, ke li restu fraŭlo?
 Kio okazas?
-Kio okazis en la interno de l' glaciejo?
+Kio okazis en la interno de la glaciejo?
 Kio okazis?
 Kio ŝi fariĝos?
 Kio tio povas esti?
@@ -1076,15 +1076,15 @@ La fajro de ŝia rigardo subite sekigis ŝiajn plorojn.
 La fajro estis metita vole.
 La fariĝoj estas ankoraŭ tro novaj; kaj ŝi ne bezonas emociojn.
 La fiakristo vipbatis sian ĉevalaĉon, kiu ekgalopis.
-La fiziologia sentemo de l' agoniantino jam estis malviva.
-La fizionomio de l' doktoro estis malgaja.
+La fiziologia sentemo de la agoniantino jam estis malviva.
+La fizionomio de la doktoro estis malgaja.
 La Fradeko, kiun ni konas, estas la sama homo kiel Fernando.
 La geamantoj trovis en Filipo altvaloran helpanton.
 La geedziĝo okazis.
 La gejunuloj daŭrigis sian promenadon momente interrompitan.
 La gejunuloj eliris.
 La ĝemadoj plifortiĝis.
-La grandegeco de l' malespero enhavas tiajn kvietecojn.
+La grandegeco de la malespero enhavas tiajn kvietecojn.
 La gravega momento alproksimiĝis.
 La gvidisto ĵetis rigardon ĉirkaŭ si.
 La homo ne respondis.
@@ -1105,7 +1105,7 @@ La juna bankiero rapidis al sia amiko, prezentante siajn manojn.
 La juna oficiro havis tikon.
 La juna virino aŭskultis, muta pro miro.
 La juna virino daŭrigis sian laboron.
-La juna virino englutis la enhavon de l' glaso per unu trinko.
+La juna virino englutis la enhavon de la glaso per unu trinko.
 La juna virino ne ŝanceliĝis eĉ unu sekundon.
 La juna virino obstine rifuzis enlitiĝi.
 La junulino lasis ŝin paroli, sed ne ŝin aŭskultis.
@@ -1172,7 +1172,7 @@ La morgaŭon, la agoniantino vivis ankoraŭ.
 La morgaŭon, la junulo estis tute resanigita.
 La morto estis subita.
 La nescianta mortiginto sin metis en angulon, dirante neniun vorton.
-La okuloj de l' juna kuracisto restis sekaj.
+La okuloj de la juna kuracisto restis sekaj.
 La operacio komencis.
 La opinioj ne venis al sama konsento.
 La perdo de lia havaĵo malordigis lian cerbon.
@@ -1180,14 +1180,14 @@ La pliboniĝo akceliĝis.
 La pordisto staris tie, proponante siajn servojn.
 La pordisto, okupita en la precipa ŝtuparo, ne vidas min enirantan.
 La postan matenon oni havis ankoraŭ neniun novaĵon pri la du alpistoj.
-La prepara studado de l' proceso ne povis senfine daŭri.
+La prepara studado de la proceso ne povis senfine daŭri.
 La profesia sekreto malpermesas, ke Taburio parolu.
 La randoj estas neegale malhelaj.
 La raporto estis finita.
 La reveno estis silentoplena.
 La salono pleniĝis.
 La scienco konfesis sian malpotencon.
-La serĉadoj de l' magistrato ne estis longaj.
+La serĉadoj de la magistrato ne estis longaj.
 La servistino eliris.
 La servistino eniris, alportante la unuan manĝopladon.
 La servistino faris la komision.
@@ -1202,7 +1202,7 @@ La sola Fernando ĝin uzis.
 La sorto vin montris.
 La studento ne estis ankoraŭ doktoro.
 La svenado ĉesis, sed estis anstataŭita de deliro.
-La tago de l' geedziĝo alvenis.
+La tago de la geedziĝo alvenis.
 La tempo marŝis; la geinfanoj kreskis; la knabinoj fariĝis junulinoj.
 La tento estis tro forta.
 La tiko de Fernando!
@@ -1865,7 +1865,7 @@ Nu, neutile ilin serĉi pli longatempe.
 Nu, pensis la bankiero, tiu malfeliĉa Petro estis prava.
 Nu, petis ĉiuj, ĉu via malsanulo estis grave vundita?
 Nu, Petro, prezentu al mi vian brakon, diris gaje Beatrico.
-Nu, ŝi pensis, mi estas ankoraŭ venkita de l' fatalo.
+Nu, ŝi pensis, mi estas ankoraŭ venkita de la fatalo.
 Nu, sinjorino, ĉu vi trovis?
 Nu, sinjoro, decidu vin, ekkriis la ĥirurgiisto.
 Nu, sinjoro, silentu, mi vin petegas.
@@ -1949,7 +1949,7 @@ Parolu; mi vin aŭskultas.
 Pedelo, alvoku nun Ragelon kaj la edzinon Ragelo.
 Penu vin senkulpigi, se tion fari vi povos.
 Per angulo de sia antaŭtuko la malfeliĉa patrino viŝis larmon.
-Per bona higieno la farto de l' estaĵeto rapide resaniĝos.
+Per bona higieno la farto de la estaĵeto rapide resaniĝos.
 Per du vortoj Maziero ilin sciigis pri la okazantaĵo.
 Per ia ajn rimedo oni devis alidirekti la interparoladon.
 Per iom da maltimo eble ĉio povas esti savita.
@@ -1985,7 +1985,7 @@ Petro rigardis horon en horloĝo.
 Petro ŝajnis miregita de tia konfeso.
 Petro ŝanceliĝis, sed ne moviĝis.
 Petro tremetis kaj sin starigis, havante en okuloj flamon de kolero.
-Petu la revizion de l' proceso.
+Petu la revizion de la proceso.
 Peza silento regis.
 Piede de la pontego li piedfrapis la korpon de viro kuŝanta sur tero.
 Pikite de scivoleco, Fradeko obeis.
@@ -2216,7 +2216,7 @@ Sed dum dek jaroj mi zorge studis la bankajn aferojn.
 Sed dum tiu tempo la jaroj fluas.
 Sed dum tiu tempo ni ne devos resti neagemaj.
 Sed ekzistas en Francujo tridekses mil komunumoj.
-Sed en la korto, ili estis haltigitaj de l' administranto.
+Sed en la korto, ili estis haltigitaj de la administranto.
 Sed en tiu momento iliaj rigardoj falis sur Beatricon.
 Sed en tiu momento la doktoro sin intermetis.
 Sed estas afero, kiun vi devas koni: neniam mi edziĝos.
@@ -2249,7 +2249,7 @@ Sed la bankiero havis ankoraŭ junulan fortikecon.
 Sed la bankiero ne insistis.
 Sed la bankiero tre priokupata ne aŭdis tiun lastan frazon.
 Sed la bankiero, kiu ne ankoraŭ plene rekonsciiĝis, ne tion rimarkis.
-Sed la ĵaluzeco detruas la rektecon de l' juĝeco.
+Sed la ĵaluzeco detruas la rektecon de la juĝeco.
 Sed la juna virino sin turnis al alia temo.
 Sed la kompatema koro de Maziero estis emociita.
 Sed la mallumaĵoj ne ebligis, ke oni distingu ĝian realan formon.
@@ -2541,7 +2541,7 @@ Tia agmaniero ĉion simpligus.
 Tia animforteco estas ŝtoniga.
 Tia animforteco ŝajnis al li pli ŝajna ol reala.
 Tia estas la konsekvenco, kiun Taburio kaj mi konkludis.
-Tia estas la ordono de l' kuracisto.
+Tia estas la ordono de la kuracisto.
 Tia estis efektive mia unua intenco.
 Tia estis la kazo de Beatrico.
 Tia estis mia penso, respondis Maziero.
@@ -2561,7 +2561,7 @@ Tial ke vi estas malsaneta, ripozu: vi finos morgaŭ.
 Tiam Beatrico estos avertita pri tio, kio okazas.
 Tiam ĉiuj ĉeestantoj sidiĝis.
 Tiam ĉu restas ankoraŭ iom da espero?
-Tiam ĝi veturas kun la masego mem de l' glaciejo.
+Tiam ĝi veturas kun la masego mem de la glaciejo.
 Tiam kiamaniere vi scias, ke li estas malviva?
 Tiam kio ĝi estis?
 Tiam kio okazos?
@@ -2724,7 +2724,7 @@ Tiu nomo Herbeno estas vera Sizifa ŝtonego.
 Tiu pasio estis partoprenita.
 Tiu pordo malrapide malfermiĝis: en la kadro aperis homo.
 Tiu prokrasto sufiĉis por nin savi.
-Tiu punkto de l' proceso estas pruvita.
+Tiu punkto de la proceso estas pruvita.
 Tiu rakonto okazis antaŭ la servistino, kiu preparis la teon.
 Tiu renkonto incitis mian scivolon.
 Tiu rimarko mirigis ĉiujn ĉeestantojn.


### PR DESCRIPTION
In Esperanto apostrophes are used as ellision marks mainly in literature and songs, for metrical reasons[1][2]. Only one normal usage of the ellision is in widespread use, in the idiomatic sentence "dank'al". Those occurrences were not modified in the file.

Because the Common Voice database is a tool to help voice recognition, and since in normal conversations speakers do not use the ellisions, this pull request changes all the apostrophized words to the actually spoken forms.

[1] https://en.wikipedia.org/wiki/Apostrophe#As_a_mark_of_elision
[2] https://bertilow.com/pmeg/gramatiko/apostrofo/normala_uzo.html