### PR TITLE
add Hong Kong to zh-tw accents

### DIFF
--- a/web/src/stores/demographics.ts
+++ b/web/src/stores/demographics.ts
@@ -183,6 +183,7 @@ export const ACCENTS: any = {
     penghu_county: '出生地：澎湖縣',
     kinmen_county: '出生地：金門縣',
     lienchiang_county: '出生地：連江縣',
+    hong_kong: '香港',
   },
 };
 


### PR DESCRIPTION
Chinese is Hong Kong's official language, and traditional characters are their de facto writing standard. (Hong Kong are the second large zh-tw Firefox usage place besides Taiwan.) 
They plan to promote Common Voice soon.