### PR TITLE
Clarify format of Auth0 credentials

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ You can then access the website at [http://localhost:9000](http://localhost:9000
 
 You can find configurable options, like the port CommonVoice is running on, in `/server/src/config-helper.ts`. Just create a `/config.json` with the config you want to override.
 
-If you want to work with login-related features (Profile, Dashboard, Goals, ...) you'll need to create an [Auth0](https://auth0.com/) account and put the data you get from it into the config (the keys are `AUTH0: { DOMAIN, CLIENT_ID, SECRET }`).
+If you want to work with login-related features (Profile, Dashboard, Goals, ...) you'll need to create an [Auth0](https://auth0.com/) account and put the data you get from it into the config.json file (the keys are `"AUTH0": { "DOMAIN": "<domain_here>", "CLIENT_ID": "<client_id_here>", "CLIENT_SECRET": "<client_secret_here>" }`).
 
 #### Setting up Amazon S3 for development
 


### PR DESCRIPTION
The keys for use with Auth0 had a slight mismatch between the keyname given (SECRET) and that in the code (CLIENT_SECRET) so simply clarifying that here in this minor update