### PR TITLE
Revert fill to near-black for visibility in Chrome & Safari

### DIFF
--- a/web/src/components/ui/ui.css
+++ b/web/src/components/ui/ui.css
@@ -167,7 +167,7 @@ button.card-action:focus.focus-visible path {
         top: -6px;
 
         & path {
-            fill: var(--black);
+            fill: var(--near-black);
         }
     }
 


### PR DESCRIPTION
* Closes #2025 

The color had to be changed from `--black` to `--near-black` because:

1. Both `Safari & Chrome` fail to show the **checkmark**. 
2. Using `-webkit-fill: var(--near-black)` to create a specialized case for *WebKit* browsers and retaining style for others did **NOT** work. 

This essentially undoes 3271508c .