### PR TITLE
Fix "checked" property of checkboxes

### DIFF
--- a/web/src/components/pages/datasets/dataset-info.tsx
+++ b/web/src/components/pages/datasets/dataset-info.tsx
@@ -217,7 +217,10 @@ class DatasetInfo extends React.Component<Props, State> {
                   splits: Object.entries(localeStats.splits)
                     .filter(([, values]) => Object.keys(values).length > 1)
                     .map(([category, values]) => (
-                      <Splits {...{ category, values, locale }} />
+                      <Splits
+                        key={category}
+                        {...{ category, values, locale }}
+                      />
                     )),
                 }).map(([id, value], i) => (
                   <li key={id}>

--- a/web/src/components/pages/datasets/dataset-info.tsx
+++ b/web/src/components/pages/datasets/dataset-info.tsx
@@ -260,6 +260,7 @@ class DatasetInfo extends React.Component<Props, State> {
                       </Localized>
                     }
                     name="confirmSize"
+                    checked={confirmSize}
                     onChange={this.handleInputChange}
                     style={{ marginBottom: 40 }}
                   />
@@ -270,6 +271,7 @@ class DatasetInfo extends React.Component<Props, State> {
                       </Localized>
                     }
                     name="confirmNoIdentify"
+                    checked={confirmNoIdentify}
                     onChange={this.handleInputChange}
                     style={{ marginBottom: 20 }}
                   />


### PR DESCRIPTION
I clicked checkboxes below, but check marks don't appear.

I found `"checked"` property was not passed to the checkbox components, so I fixed it.

![スクリーンショット 2019-05-18 22 11 52](https://user-images.githubusercontent.com/16313897/57970243-fc480600-79b9-11e9-8b36-c860e7d49528.png)

(In addition, I fixed react "key" warning of list)
