### PR TITLE
Create one role per environment

### DIFF
--- a/nubis/terraform/metrics.tf
+++ b/nubis/terraform/metrics.tf
@@ -1,7 +1,7 @@
 # Allows mozilla-itsre account to consume Cloudwatch metrics
 
 resource "aws_iam_role" "cloudwatch_fetch_metrics" {
-  name               = "cloudwatch_fetch_metrics"
+  name               = "cloudwatch_fetch_metrics-${var.environment}"
   path               = "/itsre/"
   assume_role_policy = "${data.aws_iam_policy_document.allow_assume_role.json}"
 }
@@ -19,7 +19,7 @@ data "aws_iam_policy_document" "allow_assume_role" {
 }
 
 resource "aws_iam_role_policy" "allow_fetch_cloudwatch_metrics" {
-  name   = "allow_fetch_cloudwatch_metrics"
+  name   = "allow_fetch_cloudwatch_metrics-${var.environment}"
   role   = "${aws_iam_role.cloudwatch_fetch_metrics.id}"
   policy = "${data.aws_iam_policy_document.allow_fetch_cloudwatch_metrics.json}"
 }


### PR DESCRIPTION
Actually only one global IAM role is needed in order to get the metrics. However having only one, would make Jenkins prod fail trying to create that role and finding that it already exists.

One option could have been manually importing the role into the Terraform state, but in case we want to start from scratch with the same Terraform code, it will fail. That's why I went for creating 2.