### PR TITLE
Visual feedback for shortcuts (Fixes #1275)

### DIFF
--- a/docker/local-docker-config.json
+++ b/docker/local-docker-config.json
@@ -6,5 +6,6 @@
     "accessKeyId": "local-identity",
     "secretAccessKey": "local-credential",
     "s3ForcePathStyle": true
-  }
+  },
+  "AUTH0": { "DOMAIN": "dev-r03xtm-t.auth0.com", "CLIENT_ID": "7hFT8qVkuSqJWihZfrttItJ7RUS33ulZ", "CLIENT_SECRET": "OAJwXCBchSWGanMw07qPXmCzos6-2NN7pq-FwJEDa9vDrL8C17hsu9jKNQQMF_6B" }
 }

--- a/docker/local-docker-config.json
+++ b/docker/local-docker-config.json
@@ -6,6 +6,5 @@
     "accessKeyId": "local-identity",
     "secretAccessKey": "local-credential",
     "s3ForcePathStyle": true
-  },
-  "AUTH0": { "DOMAIN": "dev-r03xtm-t.auth0.com", "CLIENT_ID": "7hFT8qVkuSqJWihZfrttItJ7RUS33ulZ", "CLIENT_SECRET": "OAJwXCBchSWGanMw07qPXmCzos6-2NN7pq-FwJEDa9vDrL8C17hsu9jKNQQMF_6B" }
+  }
 }

--- a/web/src/components/pages/contribution/contribution.css
+++ b/web/src/components/pages/contribution/contribution.css
@@ -372,8 +372,6 @@
 
         & .skip {
             display: inline-flex;
-            animation-duration: .2s;
-            animation-iteration-count: 3;
 
             & svg {
                 margin-inline-start: 13px;
@@ -383,6 +381,9 @@
                 }
             }
 
+            animation-duration: .2s;
+            animation-iteration-count: 3;
+            animation-timing-function: cubic-bezier(1, 0, 0, 1);
             &.triggered {
                 animation-name: emphasize;
             }

--- a/web/src/components/pages/contribution/contribution.css
+++ b/web/src/components/pages/contribution/contribution.css
@@ -372,6 +372,8 @@
 
         & .skip {
             display: inline-flex;
+            animation-duration: .2s;
+            animation-iteration-count: 3;
 
             & svg {
                 margin-inline-start: 13px;
@@ -379,6 +381,10 @@
                 [dir='rtl'] & {
                     transform: rotateY(180deg);
                 }
+            }
+
+            &.triggered {
+                animation-name: emphasize;
             }
         }
 

--- a/web/src/components/pages/contribution/contribution.tsx
+++ b/web/src/components/pages/contribution/contribution.tsx
@@ -105,7 +105,7 @@ interface Props extends LocalizationProps, PropsFromState {
   shortcuts: {
     key: string;
     label: string;
-    action: () => any;
+    action: (e: KeyboardEvent) => any;
   }[];
   type: 'speak' | 'listen';
   skipTriggered?: boolean;
@@ -268,7 +268,7 @@ class ContributionPage extends React.Component<Props, State> {
     );
     if (!shortcut) return;
 
-    shortcut.action();
+    shortcut.action(event);
     ((type === 'listen' ? trackListening : trackRecording) as any)(
       'shortcut',
       locale

--- a/web/src/components/pages/contribution/contribution.tsx
+++ b/web/src/components/pages/contribution/contribution.tsx
@@ -108,6 +108,7 @@ interface Props extends LocalizationProps, PropsFromState {
     action: () => any;
   }[];
   type: 'speak' | 'listen';
+  skipTriggered?: boolean;
 }
 
 interface State {
@@ -242,11 +243,11 @@ class ContributionPage extends React.Component<Props, State> {
       onSubmit,
       type,
     } = this.props;
-
     if (
       event.ctrlKey ||
       event.altKey ||
       event.shiftKey ||
+      event.metaKey ||
       this.state.showReportModal
     ) {
       return;
@@ -285,6 +286,7 @@ class ContributionPage extends React.Component<Props, State> {
       reportModalProps,
       type,
       user,
+      skipTriggered,
     } = this.props;
     const {
       showAccountModal,
@@ -399,6 +401,7 @@ class ContributionPage extends React.Component<Props, State> {
       primaryButtons,
       sentences,
       type,
+      skipTriggered
     } = this.props;
     const { selectedPill } = this.state;
 
@@ -521,7 +524,7 @@ class ContributionPage extends React.Component<Props, State> {
                 <Button
                   rounded
                   outline
-                  className="skip"
+                  className={skipTriggered ? "skip triggered" : "skip"}
                   disabled={!this.isLoaded}
                   onClick={onSkip}>
                   <Localized id="skip">

--- a/web/src/components/pages/contribution/contribution.tsx
+++ b/web/src/components/pages/contribution/contribution.tsx
@@ -108,7 +108,6 @@ interface Props extends LocalizationProps, PropsFromState {
     action: (e: KeyboardEvent) => any;
   }[];
   type: 'speak' | 'listen';
-  skipTriggered?: boolean;
 }
 
 interface State {
@@ -117,6 +116,7 @@ interface State {
   showReportModal: boolean;
   showShareModal: boolean;
   showShortcutsModal: boolean;
+  skipTriggered: boolean;
 }
 
 class ContributionPage extends React.Component<Props, State> {
@@ -130,6 +130,7 @@ class ContributionPage extends React.Component<Props, State> {
     showReportModal: false,
     showShareModal: false,
     showShortcutsModal: false,
+    skipTriggered: false
   };
 
   private canvasRef: { current: HTMLCanvasElement | null } = React.createRef();
@@ -191,12 +192,23 @@ class ContributionPage extends React.Component<Props, State> {
   }
 
   private get shortcuts() {
-    const { onSkip, shortcuts } = this.props;
+    const { shortcuts } = this.props;
     return shortcuts.concat({
       key: 'shortcut-skip',
       label: 'skip',
-      action: onSkip,
+      action: this.handleSkip,
     });
+  }
+
+  private handleSkip = (event?: React.MouseEvent<any, MouseEvent> | KeyboardEvent) => {
+    if (event instanceof KeyboardEvent) {
+      this.setState({ skipTriggered: true });
+    }
+    this.props.onSkip();
+  }
+
+  private endSkipTriggered = () => {
+    this.setState({ skipTriggered: false });
   }
 
   private startWaving = () => {
@@ -282,11 +294,9 @@ class ContributionPage extends React.Component<Props, State> {
       flags,
       getString,
       isSubmitted,
-      onSkip,
       reportModalProps,
       type,
-      user,
-      skipTriggered,
+      user
     } = this.props;
     const {
       showAccountModal,
@@ -322,7 +332,7 @@ class ContributionPage extends React.Component<Props, State> {
         {showReportModal && (
           <ReportModal
             onRequestClose={() => this.setState({ showReportModal: false })}
-            onSubmitted={onSkip}
+            onSubmitted={this.handleSkip}
             {...reportModalProps}
           />
         )}
@@ -395,15 +405,13 @@ class ContributionPage extends React.Component<Props, State> {
       isFirstSubmit,
       isSubmitted,
       onReset,
-      onSkip,
       onSubmit,
       pills,
       primaryButtons,
       sentences,
-      type,
-      skipTriggered
+      type
     } = this.props;
-    const { selectedPill } = this.state;
+    const { selectedPill, skipTriggered } = this.state;
 
     return isSubmitted ? (
       <Success onReset={onReset} type={type} />
@@ -524,9 +532,10 @@ class ContributionPage extends React.Component<Props, State> {
                 <Button
                   rounded
                   outline
-                  className={skipTriggered ? "skip triggered" : "skip"}
+                  className={['skip', skipTriggered ? 'triggered' : ''].join(' ')}
                   disabled={!this.isLoaded}
-                  onClick={onSkip}>
+                  onAnimationEnd={this.endSkipTriggered}
+                  onClick={this.handleSkip}>
                   <Localized id="skip">
                     <span />
                   </Localized>{' '}

--- a/web/src/components/pages/contribution/listen/listen.css
+++ b/web/src/components/pages/contribution/listen/listen.css
@@ -54,6 +54,7 @@
     & .vote-button {
         border: none;
         border-radius: 30px;
+        color: var(--near-black);
 
         display: flex;
         justify-content: center;
@@ -75,6 +76,7 @@
 
         &,
         & path {
+            fill: var(--near-black);
             transition: all var(--transition-duration) linear;
         }
 
@@ -107,11 +109,25 @@
             background: var(--white);
             box-shadow: var(--vote-button-box-shadow)
                 color-mod(var(--grey) alpha(80%));
+            color: var(--disabled-grey);
 
-            cursor: not-allowed;
+            pointer-events: none;
+
+            & path {
+                fill: var(--disabled-grey);
+            }
 
             & path {
                 fill: var(--near-black);
+            }
+        }
+
+        &:hover,
+        &:active {
+            color: var(--white);
+
+            & path {
+                fill: var(--white);
             }
         }
 

--- a/web/src/components/pages/contribution/listen/listen.css
+++ b/web/src/components/pages/contribution/listen/listen.css
@@ -66,6 +66,13 @@
         z-index: var(--top-z-index);
         background: var(--white);
 
+        animation-duration: .2s;
+        animation-iteration-count: 3;
+        animation-timing-function: cubic-bezier(1, 0, 0, 1);
+        &.triggered {
+            animation-name: emphasize;
+        }
+
         &,
         & path {
             transition: all var(--transition-duration) linear;
@@ -95,21 +102,13 @@
             }
         }
 
-        &:hover,
-        &:active {
-            color: var(--white);
-
-            & path {
-                fill: var(--white);
-            }
-        }
-
         &.yes:disabled,
         &.no:disabled {
-            color: var(--near-black);
             background: var(--white);
             box-shadow: var(--vote-button-box-shadow)
                 color-mod(var(--grey) alpha(80%));
+
+            cursor: not-allowed;
 
             & path {
                 fill: var(--near-black);

--- a/web/src/components/pages/contribution/listen/listen.tsx
+++ b/web/src/components/pages/contribution/listen/listen.tsx
@@ -24,7 +24,6 @@ import { PlayButton } from '../../../primary-buttons/primary-buttons';
 import Pill from '../pill';
 
 import './listen.css';
-import { instanceOf } from 'prop-types';
 
 const VOTE_NO_PLAY_MS = 3000; // Threshold when to allow voting no
 
@@ -156,7 +155,6 @@ class ListenPage extends React.Component<Props, State> {
   }
 
   private voteYes = (event: React.MouseEvent<any, MouseEvent> | KeyboardEvent) => {
-    console.log('EVENT', event);
     if (!this.state.hasPlayed) {
       return;
     }

--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -111,6 +111,7 @@ interface State {
   rerecordIndex?: number;
   showPrivacyModal: boolean;
   showDiscardModal: boolean;
+  skipTriggered: boolean;
 }
 
 const initialState: State = {
@@ -121,6 +122,7 @@ const initialState: State = {
   rerecordIndex: null,
   showPrivacyModal: false,
   showDiscardModal: false,
+  skipTriggered: false
 };
 
 class SpeakPage extends React.Component<Props, State> {
@@ -351,6 +353,11 @@ class SpeakPage extends React.Component<Props, State> {
     const { id } = clips[current].sentence;
     removeSentences([id]);
     this.setState({
+      skipTriggered: true
+    });
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    this.setState({
+      skipTriggered: false,
       clips: clips.map((clip, i) =>
         current === i ? { recording: null, sentence: null } : clip
       ),
@@ -462,6 +469,7 @@ class SpeakPage extends React.Component<Props, State> {
       rerecordIndex,
       showPrivacyModal,
       showDiscardModal,
+      skipTriggered
     } = this.state;
     const recordingIndex = this.getRecordingIndex();
     return (
@@ -554,6 +562,7 @@ class SpeakPage extends React.Component<Props, State> {
           isSubmitted={isSubmitted}
           onReset={() => this.resetState()}
           onSkip={this.handleSkip}
+          skipTriggered={skipTriggered}
           onSubmit={() => this.upload()}
           primaryButtons={
             <RecordButton

--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -111,7 +111,6 @@ interface State {
   rerecordIndex?: number;
   showPrivacyModal: boolean;
   showDiscardModal: boolean;
-  skipTriggered: boolean;
 }
 
 const initialState: State = {
@@ -121,8 +120,7 @@ const initialState: State = {
   recordingStatus: null,
   rerecordIndex: null,
   showPrivacyModal: false,
-  showDiscardModal: false,
-  skipTriggered: false
+  showDiscardModal: false
 };
 
 class SpeakPage extends React.Component<Props, State> {
@@ -353,11 +351,6 @@ class SpeakPage extends React.Component<Props, State> {
     const { id } = clips[current].sentence;
     removeSentences([id]);
     this.setState({
-      skipTriggered: true
-    });
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    this.setState({
-      skipTriggered: false,
       clips: clips.map((clip, i) =>
         current === i ? { recording: null, sentence: null } : clip
       ),
@@ -468,8 +461,7 @@ class SpeakPage extends React.Component<Props, State> {
       recordingStatus,
       rerecordIndex,
       showPrivacyModal,
-      showDiscardModal,
-      skipTriggered
+      showDiscardModal
     } = this.state;
     const recordingIndex = this.getRecordingIndex();
     return (
@@ -562,7 +554,6 @@ class SpeakPage extends React.Component<Props, State> {
           isSubmitted={isSubmitted}
           onReset={() => this.resetState()}
           onSkip={this.handleSkip}
-          skipTriggered={skipTriggered}
           onSubmit={() => this.upload()}
           primaryButtons={
             <RecordButton

--- a/web/src/components/vars.css
+++ b/web/src/components/vars.css
@@ -8,6 +8,7 @@
     --near-black: #4a4a4a;
     --grey: #e7e5e2;
     --darker-grey: #e6e5e3;
+    --disabled-grey: #cacaca;
     --light-grey: #f3f2f0;
     --lighter-grey: #f9f9f9;
     --desert-storm: #f3f2f1;

--- a/web/src/components/vars.css
+++ b/web/src/components/vars.css
@@ -86,6 +86,15 @@
     }
 }
 
+@keyframes emphasize {
+    0% {
+        box-shadow: 0 0 8px var(--blue);
+    }
+    100% {
+        box-shadow: none;
+    }
+}
+
 .md-block {
     display: none;
 


### PR DESCRIPTION
Add a visual indicator for buttons triggered with keyboard shortcuts.

Yes/No/Skip

Yes/No:

![shortcut-feedback](https://user-images.githubusercontent.com/833911/65003249-b0549180-d8c5-11e9-8fda-9ef386057007.gif)

Skip (Listen and Speak):

![shortcut-feedback-2](https://user-images.githubusercontent.com/833911/65003250-b0549180-d8c5-11e9-970e-3821cc83f55a.gif)

I also fixed some broken styling around the disabled states of the yes/no buttons. I have not yet added anything to address the comment on the thread about attempting to click/trigger Yes before the clip is ended. That might need some more design thought.