### PR TITLE
Add better support for localhost dev without setting up an s3 account

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,9 @@ services:
       - voice-web
     environment:
       - S3PROXY_AUTHORIZATION=none
+      - S3PROXY_CORS_ALLOW_ALL=true
+    ports:
+      - 80:80
   web:
     build:
       context: .

--- a/docs/HOWTO_S3.md
+++ b/docs/HOWTO_S3.md
@@ -1,3 +1,7 @@
+# S3Proxy
+
+If you want to avoid setting up an s3 account, set up a hosts file entry for s3proxy: `127.0.0.1    s3proxy`. This will redirect s3proxy requests to localhost, to be served by the s3proxy docker container.
+
 # Setting up S3 Storage
 
 If you don't already have one you will need a configured S3 account, and a bucket

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -29,11 +29,11 @@ const CSP_HEADER = [
   `default-src 'none'`,
   `style-src 'self' https://fonts.googleapis.com https://optimize.google.com 'unsafe-inline'`,
   `img-src 'self' www.google-analytics.com www.gstatic.com https://optimize.google.com https://www.gstatic.com https://gravatar.com data:`,
-  `media-src data: blob: https://*.amazonaws.com https://*.amazon.com`,
+  `media-src data: blob: https://*.amazonaws.com https://*.amazon.com http://s3proxy/`,
   // Note: we allow unsafe-eval locally for certain webpack functionality.
   `script-src 'self' 'unsafe-eval' 'sha256-yybRmIqa26xg7KGtrMnt72G0dH8BpYXt7P52opMh3pY=' 'sha256-jfhv8tvvalNCnKthfpd8uT4imR5CXYkGdysNzQ5599Q=' https://www.google-analytics.com https://pontoon.mozilla.org https://optimize.google.com https://sentry.io`,
   `font-src 'self' https://fonts.gstatic.com`,
-  `connect-src 'self' https://pontoon.mozilla.org/graphql https://*.amazonaws.com https://*.amazon.com https://www.gstatic.com https://www.google-analytics.com https://sentry.io https://basket.mozilla.org https://basket-dev.allizom.org`,
+  `connect-src 'self' https://pontoon.mozilla.org/graphql https://*.amazonaws.com http://s3proxy/ https://*.amazon.com https://www.gstatic.com https://www.google-analytics.com https://sentry.io https://basket.mozilla.org https://basket-dev.allizom.org`,
   `frame-src https://optimize.google.com`,
 ].join(';');
 


### PR DESCRIPTION
This works for me, though I’m not sure if it’s the best solution long term, since it adds s3proxy to the CSP and requires a host file change. The host file change is still far easier than setting up an s3 bucket and creds though. It seems that the puppet config overwrites the CSP anyway, so that part might not be a problem?