### PR TITLE
Fix #1295: Contribute more button rerendering

### DIFF
--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -552,9 +552,9 @@ class SpeakPage extends React.Component<Props, State> {
           isFirstSubmit={user.recordTally === 0}
           isPlaying={this.isRecording}
           isSubmitted={isSubmitted}
-          onReset={() => this.resetState()}
+          onReset={this.resetState}
           onSkip={this.handleSkip}
-          onSubmit={() => this.upload()}
+          onSubmit={this.upload}
           primaryButtons={
             <RecordButton
               status={recordingStatus}

--- a/web/src/components/pages/contribution/success.tsx
+++ b/web/src/components/pages/contribution/success.tsx
@@ -31,6 +31,26 @@ const GoalPercentage = ({
   </span>
 );
 
+const ContributeMoreButton = (props: {
+  hasAccount: boolean;
+  children: React.ReactNode;
+  onClick: () => any;
+}) =>
+  props.hasAccount ? (
+    <Button
+      className="contribute-more-button"
+      rounded
+      onClick={props.onClick}
+      children={props.children}
+    />
+  ) : (
+    <TextButton
+      className="contribute-more-button secondary"
+      onClick={props.onClick}
+      children={props.children}
+    />
+  );
+
 function Success({
   getString,
   onReset,
@@ -90,22 +110,6 @@ function Success({
   const finalPercentage = Math.ceil(
     (100 * (contributionCount || 0)) / goalValue
   );
-
-  const ContributeMoreButton = (props: { children: React.ReactNode }) =>
-    hasAccount ? (
-      <Button
-        className="contribute-more-button"
-        rounded
-        onClick={onReset}
-        {...props}
-      />
-    ) : (
-      <TextButton
-        className="contribute-more-button secondary"
-        onClick={onReset}
-        {...props}
-      />
-    );
 
   const goalPercentage = (
     <GoalPercentage
@@ -169,7 +173,7 @@ function Success({
         </div>
       )}
 
-      <ContributeMoreButton>
+      <ContributeMoreButton hasAccount={hasAccount} onClick={onReset}>
         {type === 'speak' ? <MicIcon /> : <PlayOutlineIcon />}
         <Localized id="contribute-more" $count={SET_COUNT}>
           <span />


### PR DESCRIPTION
This addresses [the rerendering issue](https://github.com/mozilla/voice-web/issues/1295) affecting the "Ready to do 5 more" button on the success page.

I approached this by narrowing down the cause of the render, which is the result of several functions being re-declared on every render. So, by passing direct references to the properties ".resetState" and ".upload" in speak.tsx and also moving the component's creation outside of the `Success` component's render cycle, we are helping React reconcile the component properly.

This strategy might surface several other opportunities for improving performance of these components (by unnesting component functions) if that has ever been an issue.

`/en/speak`
![image](https://user-images.githubusercontent.com/2925395/65351585-78479a00-dbb6-11e9-9621-0a0ef39fc783.png)
