### PR TITLE
Add a welcome modal for the Open Voice Challenge

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -48,6 +48,7 @@
     "preload-webpack-plugin": "^3.0.0-beta.3",
     "promise-decode-audio-data": "^0.4.1",
     "react": "^16.8.6",
+    "react-balance-text": "^2.0.1",
     "react-content-loader": "^4.2.1",
     "react-dom": "^16.8.6",
     "react-intersection-observer": "^8.23.0",

--- a/web/src/components/layout/layout.tsx
+++ b/web/src/components/layout/layout.tsx
@@ -32,6 +32,7 @@ import Nav from './nav';
 import UserMenu from './user-menu';
 import * as cx from 'classnames';
 import { isStaging } from '../../utility';
+import WelcomeModal from '../welcome-modal/welcome-modal';
 
 const LOCALES_WITH_NAMES = LOCALES.map(code => [
   code,
@@ -57,6 +58,7 @@ interface LayoutState {
   hasScrolled: boolean;
   hasScrolledDown: boolean;
   showStagingBanner: boolean;
+  showWelcomeModal: boolean;
 }
 
 class Layout extends React.PureComponent<LayoutProps, LayoutState> {
@@ -69,6 +71,7 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
     hasScrolled: false,
     hasScrolledDown: false,
     showStagingBanner: isStaging(),
+    showWelcomeModal: this.props.location.search.includes('ovchall=1'),
   };
 
   componentDidMount() {
@@ -152,6 +155,7 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
       hasScrolledDown,
       isMenuVisible,
       showStagingBanner,
+      showWelcomeModal,
     } = this.state;
     const isBuildingProfile = location.pathname.includes(URLS.PROFILE_INFO);
 
@@ -162,6 +166,17 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
 
     return (
       <div id="main" className={className}>
+        {showWelcomeModal && (
+          <WelcomeModal
+            onRequestClose={() => {
+              this.setState({ showWelcomeModal: false });
+            }}
+            onClick={() => {
+              window.location.pathname = '/login';
+            }}
+            team="SAP"
+          />
+        )}
         {isIOS() && !isNativeIOS() && !isSafari() && (
           <div
             id="install-app"

--- a/web/src/components/layout/layout.tsx
+++ b/web/src/components/layout/layout.tsx
@@ -12,7 +12,9 @@ import {
   getItunesURL,
   isIOS,
   isNativeIOS,
+  isProduction,
   isSafari,
+  isStaging,
   replacePathLocale,
 } from '../../utility';
 import { LocaleLink, LocaleNavLink } from '../locale-helpers';
@@ -31,7 +33,6 @@ import Logo from './logo';
 import Nav from './nav';
 import UserMenu from './user-menu';
 import * as cx from 'classnames';
-import { isStaging } from '../../utility';
 import WelcomeModal from '../welcome-modal/welcome-modal';
 
 const LOCALES_WITH_NAMES = LOCALES.map(code => [
@@ -71,7 +72,8 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
     hasScrolled: false,
     hasScrolledDown: false,
     showStagingBanner: isStaging(),
-    showWelcomeModal: this.props.location.search.includes('ovchall=1'),
+    showWelcomeModal:
+      !isProduction() && this.props.location.search.includes('ovchall=1'),
   };
 
   componentDidMount() {

--- a/web/src/components/welcome-modal/wave-grey.svg
+++ b/web/src/components/welcome-modal/wave-grey.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="259" height="137" viewBox="0 0 259 137">
+    <defs>
+        <linearGradient id="a" x1="49.29%" x2="49.29%" y1="32.29%" y2="95.57%">
+            <stop offset="0%" stop-color="#E7E5E2"/>
+            <stop offset="100%" stop-color="#F3F2F1" stop-opacity="0"/>
+        </linearGradient>
+    </defs>
+    <path fill="url(#a)" fill-rule="evenodd" d="M559.574 192.182c-469.719 2.114-739.243 2.114-808.574 0C-37.735 183.17-98.677 49-10.487 49c38.276 0 57.294 48.663 64.806 64.205 7.513 15.543 38.984 53.058 60.026 24.574 34.467-46.662 88.8 27.936 127.943 9.82 28.61-13.241 21.76-57.642 66.017-57.642 39.487 0 48.313 54.683 58.277 72.24 24.14 42.534 132.269 28.91 192.992 29.985z" opacity=".4" style="mix-blend-mode:multiply" transform="translate(0 -50)"/>
+</svg>

--- a/web/src/components/welcome-modal/wave-grey.svg
+++ b/web/src/components/welcome-modal/wave-grey.svg
@@ -1,9 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="259" height="137" viewBox="0 0 259 137">
-    <defs>
-        <linearGradient id="a" x1="49.29%" x2="49.29%" y1="32.29%" y2="95.57%">
-            <stop offset="0%" stop-color="#E7E5E2"/>
-            <stop offset="100%" stop-color="#F3F2F1" stop-opacity="0"/>
-        </linearGradient>
-    </defs>
-    <path fill="url(#a)" fill-rule="evenodd" d="M559.574 192.182c-469.719 2.114-739.243 2.114-808.574 0C-37.735 183.17-98.677 49-10.487 49c38.276 0 57.294 48.663 64.806 64.205 7.513 15.543 38.984 53.058 60.026 24.574 34.467-46.662 88.8 27.936 127.943 9.82 28.61-13.241 21.76-57.642 66.017-57.642 39.487 0 48.313 54.683 58.277 72.24 24.14 42.534 132.269 28.91 192.992 29.985z" opacity=".4" style="mix-blend-mode:multiply" transform="translate(0 -50)"/>
-</svg>

--- a/web/src/components/welcome-modal/welcome-modal.css
+++ b/web/src/components/welcome-modal/welcome-modal.css
@@ -1,0 +1,70 @@
+@import url('../vars.css');
+
+.welcome-modal {
+    max-height: 100vh;
+    overflow: auto;
+
+    @media (--md-up) {
+        padding: 60px 130px !important;
+        max-width: 775px !important;
+    }
+
+    h1 {
+        font-size: var(--font-size-xxl);
+        font-weight: normal;
+    }
+
+    .subheading {
+        max-width: 450px;
+        margin: 30px auto;
+        font-family: var(--base-font-family);
+        font-size: 18px;
+        font-weight: 300;
+        letter-spacing: 0.75px;
+    }
+
+    .checkbox-row {
+        text-align: start;
+
+        label {
+            display: flex;
+            justify-content: center;
+        }
+
+        .terms-agree {
+            line-height: 1.5;
+            color: var(--near-black);
+        }
+    }
+
+    .button {
+        border-color: transparent;
+        margin: 30px auto 0;
+        padding: 0 55px;
+        min-width: auto;
+        height: 57px;
+        font-size: 14px;
+        font-weight: 600;
+        letter-spacing: 0.8px;
+        text-transform: uppercase;
+        background: var(--valid-green);
+
+        &:disabled {
+            background: var(--near-black);
+        }
+
+        &:hover,
+        &:focus {
+            border-color: var(--black);
+        }
+
+        & svg {
+            margin-left: 12px;
+            transform: rotateZ(90deg);
+        }
+
+        & path {
+            fill: var(--white);
+        }
+    }
+}

--- a/web/src/components/welcome-modal/welcome-modal.tsx
+++ b/web/src/components/welcome-modal/welcome-modal.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { useState } from 'react';
+import BalanceText from 'react-balance-text';
+import Modal, { ModalProps } from '../modal/modal';
+import { ArrowLeft } from '../ui/icons';
+import { Button, Checkbox } from '../ui/ui';
+
+import './welcome-modal.css';
+
+export interface WelcomeModalProps extends ModalProps {
+  onClick(): void;
+  team: string;
+}
+
+export default ({ onClick, team, ...props }: WelcomeModalProps) => {
+  const [hasAgreed, setHasAgreed] = useState<boolean>(false);
+
+  return (
+    <Modal {...props} innerClassName="welcome-modal">
+      <h1>
+        <BalanceText>Welcome to the Open Voice Challenge</BalanceText>
+      </h1>
+      <BalanceText className="subheading">
+        Ready to join the {team} challenge team? Read and agree to the challenge
+        terms and you're set to go!
+      </BalanceText>
+
+      <div className="checkbox-row">
+        <label>
+          <Checkbox onChange={(e: any) => setHasAgreed(e.target.checked)} />
+          <BalanceText className="terms-agree">
+            I've read and agree to the Open Voice Challenge Terms & Conditions
+          </BalanceText>
+        </label>
+      </div>
+
+      <Button rounded disabled={!hasAgreed} onClick={onClick}>
+        Join the {team} team
+        <ArrowLeft />
+      </Button>
+    </Modal>
+  );
+};

--- a/web/src/react-balance-text.d.ts
+++ b/web/src/react-balance-text.d.ts
@@ -1,0 +1,12 @@
+declare module 'react-balance-text' {
+  export default class BalanceText extends React.Component<
+    BalanceTextProps & any,
+    any
+  > {}
+
+  interface BalanceTextProps {
+    style?: any;
+    className?: string;
+    resize?: boolean;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2002,6 +2002,11 @@ babel-runtime@^6.26.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
+balance-text@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/balance-text/-/balance-text-3.3.0.tgz#8af2bc65a3e396b8f55f41b216327c33500544b7"
+  integrity sha512-UqP+MT0lQhMAdFGyHwRXrtfto6ndzelPe1Az94ZOcFsui7+RIwM9aNcQPRsIGOwHptm7h7OqeYX57CCLgWNXQA==
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -8469,6 +8474,13 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-balance-text@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-balance-text/-/react-balance-text-2.0.1.tgz#0da811d37190c2ea0d4b10cbeb4ff5c1f86ab1b0"
+  integrity sha512-AyhX0GchhK6xcPEzvsLPAgbM8dcUA6xkrWEYJtyg3voDRYW/QLPlCFgHU3r3sdTaZu0UztsOdJa8BemScd8llQ==
+  dependencies:
+    balance-text "^3.2.0"
 
 react-content-loader@^4.2.1:
   version "4.2.2"


### PR DESCRIPTION
This commit adds a skeleton welcome modal for the upcoming partner challenge. Because the Open Voice Challenge is not yet underway, the modal is gated behind an `!isProduction()` check.

<img width="890" alt="Screen Shot 2019-10-15 at 12 24 22 PM" src="https://user-images.githubusercontent.com/1840854/66862912-c302ca80-ef46-11e9-8c3f-b7f8faae8fe6.png">

NOTE: The modal still needs to be:

- linked to an updated T&C, and
- hooked up to a working signup endpoint.

Test plan:

- Navigate to localhost:9000/?ovchall=1

Modal should pop up. Button should be disabled.

- Check the T&C box.

Button should be enabled.

- Click the button.

Page should redirect to /login.