### PR TITLE
Fixed typos and poorly translated expressions

### DIFF
--- a/web/locales/es/cross-locale.ftl
+++ b/web/locales/es/cross-locale.ftl
@@ -1,16 +1,15 @@
 ## Languages
-
 contribute = Colaborar
 get-involved-button = Participa
 get-involved-title = Contribuir en { $lang }
-get-involved-text = Gracias por tu interés en contribuir en { $lang }. Trabajamos duro para tener todos los idiomas listos para el lanzamiento y mantener a los equipos actualizados por correo. Si quieres contribuir, por favor entréganos tu correo a continuación.
+get-involved-text = Gracias por tu interés en contribuir en { $lang }. Trabajamos duro para tener todos los idiomas listos para el lanzamiento y mantener a los equipos actualizados por correo. Si quieres contribuir, por favor indícanos tu correo a continuación.
 get-involved-form-title = Suscribirse a las actualizaciones para { $lang }:
 get-involved-email =
     .label = Correo
-get-involved-opt-in = Sí, envíenme correos. Me gustaría mantenerme informado acerca del progreso de este idioma en Common Voice.
+get-involved-opt-in = Sí, enviadme correos. Me gustaría mantenerme informado sobre el progreso de este idioma en Common Voice.
 get-involved-submit = Enviar
-get-involved-stayintouch = Nosotros en Mozilla estamos construyendo una comunidad en torno a la tecnología de voz. Nos gustaría mantenernos al tanto con las actualizaciones, nuevas fuentes de datos y escuchar más sobre como ocupas estos datos.
-get-involved-privacy-info = Prometemos manejar tu información con cuidado. Lee más en nuestra <privacyLink>política de privacidad</privacyLink>.
-get-involved-success-title = Te has registrado corréctamente para contribuir en { $language }. Gracias.
+get-involved-stayintouch = En Mozilla estamos construyendo una comunidad en torno a la tecnología de voz. Nos gustaría mantenerte al tanto de las actualizaciones, nuevas fuentes de datos y saber más sobre cómo tú usas esos datos.
+get-involved-privacy-info = Prometemos tratar tu información con cuidado. Lee más en nuestra <privacyLink>política de privacidad</privacyLink>.
+get-involved-success-title = Te has registrado correctamente para contribuir en { $language }. Gracias.
 get-involved-success-text = Estaremos en contacto con más información cuando esté disponible.
 get-involved-return-to-languages = Regresar a Idiomas


### PR DESCRIPTION
Also made the spacing consistent with the English version and the information messages match the ones in 'messages.ftl'.