### PR TITLE
Add GA tracking events to the Open Voice Challenge

### DIFF
--- a/web/src/components/invite-modal/invite-modal.tsx
+++ b/web/src/components/invite-modal/invite-modal.tsx
@@ -4,6 +4,7 @@ import BalanceText from 'react-balance-text';
 import Modal, { ModalProps } from '../modal/modal';
 import { FontIcon } from '../ui/icons';
 import { Button } from '../ui/ui';
+import { trackChallenge } from '../../services/tracker';
 
 import './invite-modal.css';
 
@@ -24,6 +25,7 @@ export default ({ inviteId, teamId, ...props }: InviteModalProps) => {
       return () => clearTimeout(timer);
     }
   }, [copiedRecently]);
+  useEffect(() => trackChallenge('modal-invite'), []);
 
   return (
     <Modal {...props} innerClassName="invite-modal">

--- a/web/src/components/onboarding-modal/onboarding-modal.tsx
+++ b/web/src/components/onboarding-modal/onboarding-modal.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '../ui/ui';
 import { PlayOutlineGreenIcon, MicIcon, SkipIcon } from '../ui/icons';
 import Modal from '../modal/modal';
 import URLS from '../../urls';
 import { LocaleLink } from '../locale-helpers';
+import { trackChallenge } from '../../services/tracker';
 import './onboarding-modal.css';
 
 interface Step {
@@ -61,6 +62,8 @@ const OnboardingModal = ({ onRequestClose }: Props) => {
   let [step, setStep] = useState<number>(0);
   const stepData = STEPS[step];
   const isLastStep = step === STEPS.length - 1;
+  useEffect(() => trackChallenge('modal-onboarding'), []);
+
   return (
     <Modal innerClassName="onboarding-modal" onRequestClose={onRequestClose}>
       <div className="step-container">

--- a/web/src/components/pages/dashboard/challenge/challenge.tsx
+++ b/web/src/components/pages/dashboard/challenge/challenge.tsx
@@ -9,6 +9,7 @@ import { useAccount, useAction } from '../../../../hooks/store-hooks';
 import { User } from '../../../../stores/user';
 import { CrossIcon, InfoIcon } from '../../../ui/icons';
 import { LabeledCheckbox } from '../../../ui/ui';
+import { trackChallenge } from '../../../../services/tracker';
 import './challenge.css';
 
 const Overlay = ({ hideOverlay }: { hideOverlay?: () => void }) => {
@@ -97,6 +98,8 @@ export default function ChallengePage() {
       window.removeEventListener('resize', checkSize);
     };
   }, []);
+  useEffect(() => trackChallenge('dashboard-view'), []);
+
   return (
     <div className="challenge challenge-container">
       <WeeklyChallenge isNarrow={isNarrow} />

--- a/web/src/components/welcome-modal/welcome-modal.tsx
+++ b/web/src/components/welcome-modal/welcome-modal.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import BalanceText from 'react-balance-text';
 import Modal, { ModalProps } from '../modal/modal';
 import { ArrowLeft } from '../ui/icons';
 import { Button, Checkbox } from '../ui/ui';
+import { trackChallenge } from '../../services/tracker';
 
 import './welcome-modal.css';
 
@@ -14,6 +15,7 @@ export interface WelcomeModalProps extends ModalProps {
 
 export default ({ onClick, team, ...props }: WelcomeModalProps) => {
   const [hasAgreed, setHasAgreed] = useState<boolean>(false);
+  useEffect(() => trackChallenge('modal-welcome'), []);
 
   return (
     <Modal {...props} innerClassName="welcome-modal">


### PR DESCRIPTION
Test plan:

- `yarn prettier`
- `yarn test`
- Navigate to localhost:9000?challenge=pilot

An analytics event with:
`{action: "modal-welcome", category: "Challenge", locale: undefined}`
should be logged.

- etc.