### PR TITLE
Remove placeholder content from the welcome Modal

### DIFF
--- a/web/src/components/layout/layout.tsx
+++ b/web/src/components/layout/layout.tsx
@@ -34,6 +34,12 @@ import Nav from './nav';
 import UserMenu from './user-menu';
 import * as cx from 'classnames';
 import WelcomeModal from '../welcome-modal/welcome-modal';
+import {
+  ChallengeTeamToken,
+  challengeTeamTokens,
+  ChallengeToken,
+  challengeTokens,
+} from 'common/challenge';
 
 const LOCALES_WITH_NAMES = LOCALES.map(code => [
   code,
@@ -55,6 +61,8 @@ interface LayoutProps
     RouteComponentProps<any> {}
 
 interface LayoutState {
+  challengeTeamToken: ChallengeTeamToken;
+  challengeToken: ChallengeToken;
   isMenuVisible: boolean;
   hasScrolled: boolean;
   hasScrolledDown: boolean;
@@ -68,12 +76,21 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
   private installApp: HTMLElement;
 
   state: LayoutState = {
+    challengeTeamToken: isProduction()
+      ? null
+      : challengeTeamTokens.find(challengeTeamToken =>
+          this.props.location.search.includes(`team=${challengeTeamToken}`)
+        ),
+    challengeToken: isProduction()
+      ? null
+      : challengeTokens.find(challengeToken =>
+          this.props.location.search.includes(`challenge=${challengeToken}`)
+        ),
     isMenuVisible: false,
     hasScrolled: false,
     hasScrolledDown: false,
     showStagingBanner: isStaging(),
-    showWelcomeModal:
-      !isProduction() && this.props.location.search.includes('challenge=pilot'),
+    showWelcomeModal: true,
   };
 
   componentDidMount() {
@@ -153,6 +170,8 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
   render() {
     const { locale, location, user } = this.props;
     const {
+      challengeTeamToken,
+      challengeToken,
       hasScrolled,
       hasScrolledDown,
       isMenuVisible,
@@ -168,15 +187,13 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
 
     return (
       <div id="main" className={className}>
-        {showWelcomeModal && (
+        {showWelcomeModal && challengeTeamToken && challengeToken && (
           <WelcomeModal
             onRequestClose={() => {
               this.setState({ showWelcomeModal: false });
             }}
-            onClick={() => {
-              window.location.pathname = '/login';
-            }}
-            team="SAP"
+            challengeToken={challengeToken}
+            teamToken={challengeTeamToken}
           />
         )}
         {isIOS() && !isNativeIOS() && !isSafari() && (

--- a/web/src/components/welcome-modal/welcome-modal.tsx
+++ b/web/src/components/welcome-modal/welcome-modal.tsx
@@ -5,15 +5,21 @@ import Modal, { ModalProps } from '../modal/modal';
 import { ArrowLeft } from '../ui/icons';
 import { Button, Checkbox } from '../ui/ui';
 import { trackChallenge } from '../../services/tracker';
+import {
+  ChallengeTeamToken,
+  challengeTeams,
+  ChallengeToken,
+} from 'common/challenge';
 
 import './welcome-modal.css';
 
 export interface WelcomeModalProps extends ModalProps {
-  onClick(): void;
-  team: string;
+  challengeToken: ChallengeToken;
+  teamToken: ChallengeTeamToken;
 }
 
-export default ({ onClick, team, ...props }: WelcomeModalProps) => {
+export default ({ challengeToken, teamToken, ...props }: WelcomeModalProps) => {
+  const readableTeamName = challengeTeams[teamToken].readableName;
   const [hasAgreed, setHasAgreed] = useState<boolean>(false);
   useEffect(() => trackChallenge('modal-welcome'), []);
 
@@ -23,8 +29,8 @@ export default ({ onClick, team, ...props }: WelcomeModalProps) => {
         <BalanceText>Welcome to the Open Voice Challenge</BalanceText>
       </h1>
       <BalanceText className="subheading">
-        Ready to join the {team} challenge team? Read and agree to the challenge
-        terms and you're set to go!
+        Ready to join the {readableTeamName} challenge team? Read and agree to
+        the challenge terms and you're set to go!
       </BalanceText>
 
       <div className="checkbox-row">
@@ -36,8 +42,13 @@ export default ({ onClick, team, ...props }: WelcomeModalProps) => {
         </label>
       </div>
 
-      <Button rounded disabled={!hasAgreed} onClick={onClick}>
-        Join the {team} team
+      <Button
+        rounded
+        disabled={!hasAgreed}
+        onClick={() => {
+          window.location.pathname = `/login`;
+        }}>
+        Join the {readableTeamName} team
         <ArrowLeft />
       </Button>
     </Modal>


### PR DESCRIPTION
This commit lets the Open Voice Challenge's welcome modal accept dynamic values
from query strings, disregard invalid params, and handle valid params.

Test plan:

- `yarn test`
- `yarn prettier`

And...

- Navigate to http://localhost:9000/en?challenge=oiyu

Modal should not open.

- Navigate to http://localhost:9000/en?challenge=pilot

Modal should not open.

- Navigate to http://localhost:9000/en?challenge=pilot&team=ibm

Modal should open. All mentions of the team should be capitalized properly ("IBM").

- Click the "I agree..." checkbox.
- Click the "Join..." button.

Page should redirect to `/login?challenge=pilot&team=ibm`.