### PR TITLE
Add unique row key to ChallengeList render to get rid of warning

### DIFF
--- a/web/src/components/pages/dashboard/challenge/challenge-list.tsx
+++ b/web/src/components/pages/dashboard/challenge/challenge-list.tsx
@@ -154,7 +154,7 @@ class ChallengeList extends React.Component<Props, State> {
         row.name ===
         (team ? user.account.enrollment.team : user.account.username);
       return (
-        <>
+        <div key={i}>
           {!!prevPosition && prevPosition + 1 < row.position && (
             <FetchRow
               key={row.position + 'prev'}
@@ -262,7 +262,7 @@ class ChallengeList extends React.Component<Props, State> {
                 }
               />
             )}
-        </>
+        </div>
       );
     });
     // [TODO]: This should be a <table>.


### PR DESCRIPTION
Was getting a warning on duplicate list keys on challenge-list.tsx, presumably because the mapped items/row positions are not unique across all FetchRows. This is just a super quick fix - I'm not familiar with this part of the codebase, lemme know if there's another way you'd prefer to handle it @catherine917 