### PR TITLE
Add HTTP referer string to challenge enrollments

### DIFF
--- a/server/src/auth-router.ts
+++ b/server/src/auth-router.ts
@@ -97,11 +97,16 @@ if (DOMAIN) {
 router.get(
   CALLBACK_URL,
   passport.authenticate('auth0', { failureRedirect: '/login' }),
-  async ({ user, query: { state }, session }: Request, response: Response) => {
+  async (request: Request, response: Response) => {
+    const {
+      user,
+      query: { state },
+      session,
+    } = request;
     const { locale, old_user, old_email, redirect, enrollment } = JSON.parse(
       AES.decrypt(state, SECRET).toString(enc.Utf8)
     );
-    const basePath = locale ? '/' + locale + '/' : '/';
+    const basePath = locale ? `/${locale}/` : '/';
     if (!user) {
       response.redirect(basePath + 'login-failure');
     } else if (old_user) {
@@ -119,7 +124,8 @@ router.get(
           user.emails[0].value,
           enrollment.challenge,
           enrollment.team,
-          enrollment.invite
+          enrollment.invite,
+          request.header('Referer')
         ))
       ) {
         // if the user is unregistered, pass enrollment to frontend

--- a/server/src/lib/api.ts
+++ b/server/src/lib/api.ts
@@ -180,11 +180,18 @@ export default class API {
     response.json(userClients);
   };
 
-  saveAccount = async ({ body, user }: Request, response: Response) => {
+  saveAccount = async (request: Request, response: Response) => {
+    const { body, user } = request;
     if (!user) {
       throw new ClientParameterError();
     }
-    response.json(await UserClient.saveAccount(user.emails[0].value, body));
+    response.json(
+      await UserClient.saveAccount(
+        user.emails[0].value,
+        body,
+        request.header('Referer')
+      )
+    );
   };
 
   getAccount = async ({ user }: Request, response: Response) => {

--- a/server/src/lib/model/db/migrations/20191107232609-add-referer-to-challenge-enrollment.ts
+++ b/server/src/lib/model/db/migrations/20191107232609-add-referer-to-challenge-enrollment.ts
@@ -1,0 +1,7 @@
+export const up = async function(db: any): Promise<any> {
+  return db.runSql(`ALTER TABLE enroll ADD COLUMN referer VARCHAR(255);`);
+};
+
+export const down = function(): Promise<any> {
+  return null;
+};


### PR DESCRIPTION
When we analyze our signup data, we might want to know where users came
from when they initially signed up. Tracking the HTTP `referer` header
on `enroll` entries is a lightweight way to do so.