### PR TITLE
Jz/challenge/add challenge date query params

### DIFF
--- a/docker/local-docker-config.json
+++ b/docker/local-docker-config.json
@@ -6,5 +6,11 @@
     "accessKeyId": "local-identity",
     "secretAccessKey": "local-credential",
     "s3ForcePathStyle": true
-  }
+  },
+  "AUTH0": {
+    "DOMAIN": "phire.auth0.com",
+    "CLIENT_ID": "qbAdutLVRV0rgvghVkYDrr55CRWR4saD",
+    "CLIENT_SECRET": "dCs7ESt1NZuCvWH6zkGfaQICEmKxjcRFs1fwUMDxj1NP9dLRAQSIux8iaGGzrs1O"
+  },
+  "IMPORT_SENTENCES": false
 }

--- a/docker/local-docker-config.json
+++ b/docker/local-docker-config.json
@@ -6,11 +6,5 @@
     "accessKeyId": "local-identity",
     "secretAccessKey": "local-credential",
     "s3ForcePathStyle": true
-  },
-  "AUTH0": {
-    "DOMAIN": "phire.auth0.com",
-    "CLIENT_ID": "qbAdutLVRV0rgvghVkYDrr55CRWR4saD",
-    "CLIENT_SECRET": "dCs7ESt1NZuCvWH6zkGfaQICEmKxjcRFs1fwUMDxj1NP9dLRAQSIux8iaGGzrs1O"
-  },
-  "IMPORT_SENTENCES": false
+  }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -49,6 +49,7 @@
     "postcss-preset-env": "^6.7.0",
     "preload-webpack-plugin": "^3.0.0-beta.3",
     "promise-decode-audio-data": "^0.4.1",
+    "query-string": "^6.8.3",
     "react": "^16.8.6",
     "react-balance-text": "^2.0.1",
     "react-content-loader": "^4.2.1",

--- a/web/src/components/pages/dashboard/challenge/constants.ts
+++ b/web/src/components/pages/dashboard/challenge/constants.ts
@@ -1,4 +1,5 @@
 import { ChallengeDuration, ChallengeTeamToken } from 'common/challenge';
+const queryString = require('query-string');
 
 export const challengeLogos: {
   [key in ChallengeTeamToken]: {
@@ -26,7 +27,31 @@ export const isBeforeChallenge = (challenge: ChallengeDuration) => {
   return now < challenge.start;
 };
 
-export const pilotDates: ChallengeDuration = {
-  start: new Date('2019-11-18'),
-  end: new Date('2019-12-18'),
+const isValidDate = (dateObj: any) => {
+  return dateObj instanceof Date && !isNaN(dateObj.getTime());
 };
+
+const getChallengeDates = (): ChallengeDuration => {
+  const params = queryString.parse(location.search);
+
+  let defaultDates: ChallengeDuration = {
+    start: new Date('2019-11-18'),
+    end: new Date('2019-12-18'),
+  };
+
+  let challengeDates: ChallengeDuration = defaultDates;
+
+  if (params.challenge_start && isValidDate(new Date(params.challenge_start))) {
+    challengeDates.start = new Date(params.challenge_start);
+  }
+
+  if (params.challenge_end && isValidDate(new Date(params.challenge_end))) {
+    challengeDates.end = new Date(params.challenge_end);
+  }
+
+  return challengeDates.end > challengeDates.start
+    ? challengeDates
+    : defaultDates;
+};
+
+export const pilotDates: ChallengeDuration = getChallengeDates();

--- a/yarn.lock
+++ b/yarn.lock
@@ -8268,6 +8268,15 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.8.3:
+  version "6.8.3"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.8.3.tgz#fd9fb7ffb068b79062b43383685611ee47777d4b"
+  integrity sha512-llcxWccnyaWlODe7A9hRjkvdCKamEKTh+wH8ITdTc3OhchaqUZteiSCX/2ablWHVrkVIe04dntnaZJ7BdyW0lQ==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -9285,6 +9294,11 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -9438,6 +9452,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-argv@^0.1.1:
   version "0.1.2"


### PR DESCRIPTION
Adds URL query parameter processing so that testers can manually specify `challenge_start` and `challenge_end` dates for the sake of testing empty states. 

* Default dates are Nov 18 to Dec 18 midnight UTC time
* If you specify a start date but no end date, the challenge should run from the custom start date to Dec 18
* If you specify an end date but no start date, the challenge should run from Nov 18 to the custom end date
* If an invalid date is provided (e.g. `challenge_start=test`), it will be disregarded and treated as though the parameter did not exist
* If either of the values supplied create a scenario where the end is not after the start, the default dates will be used

This code does no auth checking for, e.g. making sure the person logged in is a Mozillian or anything like that, and should be removed before launch.