### PR TITLE
Jz/challenge/redirect enrolled users

### DIFF
--- a/server/src/auth-router.ts
+++ b/server/src/auth-router.ts
@@ -150,7 +150,7 @@ router.get(
       // [BUG] try refresh the challenge board, toast will show again, even though DB won't give it the same achievement again
       response.redirect(
         redirect ||
-          `${basePath}login-success?challenge=${enrollment.challenge}&first=1&achievement=1`
+          `${basePath}dashboard/challenge?challenge=${enrollment.challenge}&first=1&achievement=1`
       );
     } else {
       response.redirect(redirect || basePath + 'login-success');

--- a/web/src/components/layout/content.tsx
+++ b/web/src/components/layout/content.tsx
@@ -76,7 +76,7 @@ export default function Content() {
             path={toLocaleRoute(URLS.DASHBOARD)}
             component={DashboardPage}
           />
-          {[URLS.STATS, URLS.GOALS, URLS.AWARDS].map(path => (
+          {[URLS.STATS, URLS.GOALS, URLS.AWARDS, URLS.CHALLENGE].map(path => (
             <Route
               key={path}
               exact

--- a/web/src/components/layout/layout.tsx
+++ b/web/src/components/layout/layout.tsx
@@ -164,7 +164,10 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
   };
 
   private isChallengeEnroll = () => {
-    return this.getChallengeToken() !== undefined && this.getTeamToken() !== undefined;
+    return (
+      this.getChallengeToken() !== undefined &&
+      this.getTeamToken() !== undefined
+    );
   };
 
   private getChallengeToken = () => {
@@ -197,16 +200,15 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
       'staging-banner-is-visible': showStagingBanner,
     });
 
-    const alreadyEnrolled = this.state.showWelcomeModal && user.account !== null && user.account.enrollment.challenge !== null;
+    const alreadyEnrolled =
+      this.state.showWelcomeModal &&
+      user.account !== null &&
+      user.account.enrollment.challenge !== null;
     const redirectURL = URLS.DASHBOARD + URLS.CHALLENGE;
-
-
 
     return (
       <div id="main" className={className}>
-        {alreadyEnrolled && (
-          <Redirect to={redirectURL} />
-        )}
+        {alreadyEnrolled && <Redirect to={redirectURL} />}
         {showWelcomeModal && !alreadyEnrolled && (
           <WelcomeModal
             onRequestClose={() => {

--- a/web/src/components/layout/layout.tsx
+++ b/web/src/components/layout/layout.tsx
@@ -92,9 +92,10 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
     const challengeToken = this.getChallengeToken();
 
     this.setState({
-      challengeTeamToken,
-      challengeToken,
-      showWelcomeModal: challengeToken && challengeTeamToken,
+      challengeTeamToken: challengeTeamToken,
+      challengeToken: challengeToken,
+      showWelcomeModal:
+        challengeTeamToken !== undefined && challengeToken !== undefined,
     });
   }
 

--- a/web/src/components/layout/layout.tsx
+++ b/web/src/components/layout/layout.tsx
@@ -87,10 +87,14 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
   componentDidMount() {
     this.scroller.addEventListener('scroll', this.handleScroll);
     this.visitHash();
+
+    const challengeTeamToken = this.getTeamToken();
+    const challengeToken = this.getChallengeToken();
+
     this.setState({
-      challengeTeamToken: this.getTeamToken(),
-      challengeToken: this.getChallengeToken(),
-      showWelcomeModal: this.isChallengeEnroll(),
+      challengeTeamToken,
+      challengeToke,
+      showWelcomeModal: challengeToken && challengeTeamToken,
     });
   }
 
@@ -163,13 +167,6 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
     history.push(replacePathLocale(history.location.pathname, locale));
   };
 
-  private isChallengeEnroll = () => {
-    return (
-      this.getChallengeToken() !== undefined &&
-      this.getTeamToken() !== undefined
-    );
-  };
-
   private getChallengeToken = () => {
     return challengeTokens.find(challengeToken =>
       this.props.location.search.includes(`challenge=${challengeToken}`)
@@ -202,8 +199,9 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
 
     const alreadyEnrolled =
       this.state.showWelcomeModal &&
-      user.account !== null &&
-      user.account.enrollment.challenge !== null;
+      user.account &&
+      user.account.enrollment &&
+      user.account.enrollment.challenge;
     const redirectURL = URLS.DASHBOARD + URLS.CHALLENGE;
 
     return (

--- a/web/src/components/layout/layout.tsx
+++ b/web/src/components/layout/layout.tsx
@@ -75,8 +75,8 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
   private installApp: HTMLElement;
 
   state: LayoutState = {
-    challengeTeamToken: 'mozilla',
-    challengeToken: 'pilot',
+    challengeTeamToken: undefined,
+    challengeToken: undefined,
     isMenuVisible: false,
     hasScrolled: false,
     hasScrolledDown: false,

--- a/web/src/components/layout/layout.tsx
+++ b/web/src/components/layout/layout.tsx
@@ -93,7 +93,7 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
 
     this.setState({
       challengeTeamToken,
-      challengeToke,
+      challengeToken,
       showWelcomeModal: challengeToken && challengeTeamToken,
     });
   }


### PR DESCRIPTION
Fixes #2294 as discussed. 

Test plan: 
* Enroll user with a challenge http://localhost:9000/en?challenge=pilot&team=mozilla
* Try to enroll them again with a different team http://localhost:9000/en?challenge=pilot&team=ibm
* Should redirect to `dashboard/challenge`

I also changed the default redirect from ANY invite link to `dashboard/challenge` because that seemed like more consistent behaviour, let me know if that's an issue. 
