### PR TITLE
Fix #2290: Add "Visible within challenge team" option to profile page

### DIFF
--- a/web/src/components/pages/profile/info/info.tsx
+++ b/web/src/components/pages/profile/info/info.tsx
@@ -237,6 +237,9 @@ function ProfilePage({
             <Localized id="visible">
               <option value={1} />
             </Localized>
+            {account && account.enrollment && (
+              <option value={2}>Visible within challenge team</option>
+            )}
           </LabeledSelect>
         </Localized>
 


### PR DESCRIPTION
Test plan:

- Enroll in the challenge
- Navigate to http://localhost:9000/en/profile/info
- Click the "Leaderboard Visibility" dropdown

"Visible within challenge team" option should appear.

- Select "Visible within challenge team"
- Click "Save"
- Navigate to http://localhost:9000/en/dashboard/challenge?date=2019-11-24
- Click the eyeball in one of the leaderboards

"Visible" / "Visible for team only" should be selected.