### PR TITLE
Fix #2283: Improve onboarding modal display

### DIFF
--- a/web/src/components/onboarding-modal/onboarding-modal.css
+++ b/web/src/components/onboarding-modal/onboarding-modal.css
@@ -53,7 +53,7 @@
     margin-left: 34px;
 }
 .onboarding-modal > .wave {
-    margin: 0 -89px 24px;
+    margin: 0 -89px 2rem;
     height: 390px;
     background: url('./images/wave.svg');
     background-size: 100% 100%;
@@ -63,7 +63,7 @@
     width: 242px;
     height: 288px;
     object-fit: contain;
-    margin: 61px auto 41px;
+    margin: 6rem auto 0;
 }
 .onboarding-modal .operation-buttons {
     display: flex;
@@ -75,6 +75,7 @@
     z-index: var(--middle-z-index);
     width: 156px;
     height: 57px;
+    margin: 0;
     > a {
         display: flex;
         width: 100%;
@@ -93,8 +94,12 @@
     }
 }
 
-.operation-buttons > .listen-btn {
+.onboarding-modal .operation-buttons > .listen-btn {
     margin-left: 20px;
+}
+
+.onboarding-modal .close {
+    opacity: 0.4;
 }
 
 @media (--sm-down) {


### PR DESCRIPTION
- Set the `close` button grey

- Move the `robot` icon down

- Reduce the margin between buttons