### PR TITLE
Fix #2284:  Modify invite modal styles

### DIFF
--- a/web/src/components/invite-modal/invite-modal.css
+++ b/web/src/components/invite-modal/invite-modal.css
@@ -38,12 +38,11 @@
         font-weight: 600;
         background: transparent;
         color: var(--black);
-        border-color: var(--black);
+        border: 2px solid rgba(0, 0, 0, 0.1);
 
         &:hover,
         &:focus {
-            border-color: transparent;
-            background: var(--valid-green) !important;
+            background: var(--light-grey) !important;
         }
 
         .icon {

--- a/web/src/components/modal/modal.css
+++ b/web/src/components/modal/modal.css
@@ -32,6 +32,7 @@
         right: 20px;
         top: 20px;
         border: none;
+        opacity: 0.4;
     }
 
     & .inner {


### PR DESCRIPTION
Add `opacity` to the `close` button and change the color of the `Copy link` button.