### PR TITLE
Fix: Team progress ranking display should depend on the current week

### DIFF
--- a/web/src/components/pages/dashboard/challenge/challenge-list.tsx
+++ b/web/src/components/pages/dashboard/challenge/challenge-list.tsx
@@ -189,7 +189,7 @@ class ChallengeList extends React.Component<Props, State> {
               </div>
             </div>
             <div className="week" title="Week">
-              {row.w1_points && week === 0 ? (
+              {row.w1_points && week >= 0 ? (
                 <>
                   <PointsIcon
                     className={row.w1 <= 3 ? `star-points-${row.w1}` : ''}
@@ -201,7 +201,7 @@ class ChallengeList extends React.Component<Props, State> {
               )}
             </div>
             <div className="week" title="Week">
-              {row.w2_points && week === 1 ? (
+              {row.w2_points && week >= 1 ? (
                 <>
                   <PointsIcon
                     className={row.w2 <= 3 ? `star-points-${row.w2}` : ''}

--- a/web/src/components/pages/dashboard/challenge/challenge-list.tsx
+++ b/web/src/components/pages/dashboard/challenge/challenge-list.tsx
@@ -34,6 +34,7 @@ interface Props extends PropsFromState {
   service: string;
   team?: boolean;
   type?: 'clip' | 'vote';
+  week?: number;
 }
 
 interface State {
@@ -148,7 +149,7 @@ class ChallengeList extends React.Component<Props, State> {
 
   render() {
     const { rows, isAtEnd } = this.state;
-    const { user, team } = this.props;
+    const { user, team, week } = this.props;
     // TODO: Render <Fetchrow>s outside of `items` to flatten the list.
 
     const items = rows.map((row, i) => {
@@ -188,7 +189,7 @@ class ChallengeList extends React.Component<Props, State> {
               </div>
             </div>
             <div className="week" title="Week">
-              {row.w1_points ? (
+              {row.w1_points && week === 0 ? (
                 <>
                   <PointsIcon
                     className={row.w1 <= 3 ? `star-points-${row.w1}` : ''}
@@ -200,7 +201,7 @@ class ChallengeList extends React.Component<Props, State> {
               )}
             </div>
             <div className="week" title="Week">
-              {row.w2_points ? (
+              {row.w2_points && week === 1 ? (
                 <>
                   <PointsIcon
                     className={row.w2 <= 3 ? `star-points-${row.w2}` : ''}
@@ -212,7 +213,7 @@ class ChallengeList extends React.Component<Props, State> {
               )}
             </div>
             <div className="week" title="Week">
-              {row.w3_points ? (
+              {row.w3_points && week === 2 ? (
                 <>
                   <PointsIcon
                     className={row.w3 <= 3 ? `star-points-${row.w3}` : ''}

--- a/web/src/components/pages/dashboard/challenge/team-card.tsx
+++ b/web/src/components/pages/dashboard/challenge/team-card.tsx
@@ -108,6 +108,7 @@ export default function TeamboardCard({
             service="top-teams"
             ref={teamboardRef}
             team
+            week={week}
           />
         </div>
       </div>


### PR DESCRIPTION
For now, the data structure for the top team from the back-end is like below:
``` json
[{
 "position":0,
"id":13,
"name":"SAP",
"w1_points":"100",
"w1":"1",
"w2_points":"100",
"w2":"1",
"w3_points":"100",
"w3":"1",
"nextRank":2,
"avatarClipUrl":null,
"clientHash":"***",
"you":false
}]
```
`w1,w2,w3` is the weekly ranking of a team separately. But for the front-end,  I need to show the ranking of the current week 