### PR TITLE
Give community access back to Kibana

### DIFF
--- a/server/src/config-helper.ts
+++ b/server/src/config-helper.ts
@@ -28,6 +28,7 @@ export type CommonVoiceConfig = {
   IMPORT_SENTENCES: boolean;
   REDIS_URL: string;
   KIBANA_URL: string;
+  KIBANA_ADMINS: string;
 };
 
 const DEFAULTS: CommonVoiceConfig = {
@@ -57,10 +58,6 @@ const DEFAULTS: CommonVoiceConfig = {
     'rleitan@mozilla.com',
     'rshaw@mozilla.com',
     'vioia@mozilla.com',
-    'henrik.mitsch@gmx.at',
-    'steveparmar6nov2011@gmail.com',
-    'manel.rhaiem92@gmail.com',
-    'shambhavimishra26@gmail.com',
   ]),
   S3_CONFIG: {
     signatureVersion: 'v4',
@@ -74,6 +71,12 @@ const DEFAULTS: CommonVoiceConfig = {
   IMPORT_SENTENCES: true,
   REDIS_URL: null,
   KIBANA_URL: null,
+  KIBANA_ADMINS: JSON.stringify([
+    'henrik.mitsch@gmx.at',
+    'steveparmar6nov2011@gmail.com',
+    'manel.rhaiem92@gmail.com',
+    'shambhavimishra26@gmail.com',
+  ]),
 };
 
 let injectedConfig: CommonVoiceConfig;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -78,7 +78,7 @@ export default class Server {
 
     app.use(authRouter);
     app.use('/_plugin/kibana', authMiddleware, (request, response, next) => {
-      const { KIBANA_URL: target, ADMIN_EMAILS } = getConfig();
+      const { KIBANA_URL: target, KIBANA_ADMINS } = getConfig();
       if (!target) {
         response.status(500).json({ error: 'KIBANA_URL missing in config' });
         return;
@@ -93,11 +93,12 @@ export default class Server {
 
       // For now, you either get full access of Kibana or none at all.
       const userEmail = user.emails[0].value;
+
       if (
         !userEmail ||
         !(
           userEmail.endsWith('@mozilla.com') ||
-          JSON.parse(ADMIN_EMAILS).includes(userEmail)
+          JSON.parse(KIBANA_ADMINS).includes(userEmail)
         )
       ) {
         response.status(403).json({


### PR DESCRIPTION
Separated Kibana admin list into its own property. The server-side `config.json` doesn't have these new emails in ADMIN_EMAILS and it was overriding the defaults, but it should leave KIBANA_ADMINS alone since it doesn't specify anything for that. TODO: figure out how to update server-side `config.json`. 