### PR TITLE
Improve challenge referer tracking

### DIFF
--- a/common/challenge.ts
+++ b/common/challenge.ts
@@ -35,7 +35,8 @@ export type ChallengeTeamToken = 'ibm' | 'mozilla' | 'sap';
 export type Enrollment = {
   challenge: ChallengeToken;
   team: ChallengeTeamToken;
-  invite: string;
+  invite?: string; // Friend's code on initial sign-up, otherwise the user's personal code.
+  referer?: string; // Only exists on initial sign-up.
 };
 
 export type ChallengeDuration = {

--- a/server/src/auth-router.ts
+++ b/server/src/auth-router.ts
@@ -126,7 +126,7 @@ router.get(
           enrollment.challenge,
           enrollment.team,
           enrollment.invite,
-          request.header('Referer')
+          enrollment.referer
         ))
       ) {
         // if the user is unregistered, pass enrollment to frontend
@@ -180,6 +180,7 @@ router.get('/login', (request: Request, response: Response) => {
           challenge: query.challenge || null,
           team: query.team || null,
           invite: query.invite || null,
+          referer: query.referer || null,
         },
       }),
       SECRET

--- a/server/src/lib/api.ts
+++ b/server/src/lib/api.ts
@@ -185,13 +185,7 @@ export default class API {
     if (!user) {
       throw new ClientParameterError();
     }
-    response.json(
-      await UserClient.saveAccount(
-        user.emails[0].value,
-        body,
-        request.header('Referer')
-      )
-    );
+    response.json(await UserClient.saveAccount(user.emails[0].value, body));
   };
 
   getAccount = async ({ user }: Request, response: Response) => {

--- a/server/src/lib/model/user-client.ts
+++ b/server/src/lib/model/user-client.ts
@@ -162,8 +162,7 @@ const UserClient = {
 
   async saveAccount(
     email: string,
-    { client_id, locales, ...data }: UserClient,
-    referer?: string
+    { client_id, locales, ...data }: UserClient
   ): Promise<UserClient> {
     let [accountClientId, [clients]] = await Promise.all([
       UserClient.findClientId(email),
@@ -215,7 +214,7 @@ const UserClient = {
         data.enrollment.challenge,
         data.enrollment.team,
         data.enrollment.invite,
-        referer
+        data.enrollment.referer
       ))
     ) {
       await earnBonus('sign_up_first_three_days', [

--- a/web/src/components/welcome-modal/welcome-modal.tsx
+++ b/web/src/components/welcome-modal/welcome-modal.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import BalanceText from 'react-balance-text';
 import Modal, { ModalProps } from '../modal/modal';
-import { ArrowLeft } from '../ui/icons';
 import { Button, Checkbox } from '../ui/ui';
 import { trackChallenge } from '../../services/tracker';
 import {
@@ -61,7 +60,14 @@ export default ({ challengeToken, teamToken, ...props }: WelcomeModalProps) => {
         rounded
         disabled={!hasAgreed}
         onClick={() => {
-          window.location.pathname = `/login`;
+          const enrollmentDetails = window.location.search;
+          // `enrollmentDetails` should always exist here, but in case it
+          // doesn't we abort the login flow.
+          if (enrollmentDetails) {
+            window.location.href = `/login${enrollmentDetails}&referer=${document.referrer}`;
+          } else {
+            window.location.reload();
+          }
         }}>
         Join the {readableTeamName} team
       </Button>

--- a/web/src/components/welcome-modal/welcome-modal.tsx
+++ b/web/src/components/welcome-modal/welcome-modal.tsx
@@ -64,7 +64,10 @@ export default ({ challengeToken, teamToken, ...props }: WelcomeModalProps) => {
           // `enrollmentDetails` should always exist here, but in case it
           // doesn't we abort the login flow.
           if (enrollmentDetails) {
-            window.location.href = `/login${enrollmentDetails}&referer=${document.referrer}`;
+            const { referrer } = document;
+            window.location.href = `/login${enrollmentDetails}${
+              referrer ? `&referer=${referrer}` : ''
+            }`;
           } else {
             window.location.reload();
           }


### PR DESCRIPTION
TIL [`document.referrer`](https://developer.mozilla.org/en-US/docs/Web/API/Document/referrer) is standard across all major browsers, and reports the same value we would see on the server. This reduces the headache of sending it from the server, to the client, back to the server, that we were discussing earlier.

This change means we'll get the original inbound referer, and will hopefully catch more sources like Twitter, Facebook, etc. Fingers crossed!

Note: Referrer? Referer? Typo [theirs](https://tools.ietf.org/html/rfc1945#section-10.13), not mine :)