### PR TITLE
Fix type error on achievements sql

### DIFF
--- a/server/src/lib/model/achievements.ts
+++ b/server/src/lib/model/achievements.ts
@@ -118,7 +118,7 @@ export const hasEarnedBonus = async (
   type: AchievementType,
   client_id: string,
   challenge: ChallengeToken
-) => {
+): Promise<boolean> => {
   const earned = await db.query(
     `
       SELECT earn.client_id IS NOT NULL AS earned
@@ -132,7 +132,5 @@ export const hasEarnedBonus = async (
     [type, client_id, challenge]
   );
 
-  return (
-    (earned && earned[0] && earned[0][0] && earned[0][0]['earned']) || false
-  );
+  return !!(earned && earned[0] && earned[0][0] && earned[0][0].earned);
 };

--- a/server/src/lib/model/achievements.ts
+++ b/server/src/lib/model/achievements.ts
@@ -119,7 +119,7 @@ export const hasEarnedBonus = async (
   client_id: string,
   challenge: ChallengeToken
 ) => {
-  const [[{ earned }]] = await db.query(
+  const earned = await db.query(
     `
       SELECT earn.client_id IS NOT NULL AS earned
       FROM challenges
@@ -131,5 +131,6 @@ export const hasEarnedBonus = async (
       `,
     [type, client_id, challenge]
   );
-  return earned;
+
+  return (earned && earned[0] && earned[0] && earned[0][0]['earned']) || false;
 };

--- a/server/src/lib/model/achievements.ts
+++ b/server/src/lib/model/achievements.ts
@@ -132,5 +132,7 @@ export const hasEarnedBonus = async (
     [type, client_id, challenge]
   );
 
-  return (earned && earned[0] && earned[0] && earned[0][0]['earned']) || false;
+  return (
+    (earned && earned[0] && earned[0][0] && earned[0][0]['earned']) || false
+  );
 };


### PR DESCRIPTION
This is a tiny change for a big bug, so here's my logic as to what's happening: 

* The clips are still being stored in the db and uploaded to S3
* If you comment out the upload code locally (153-215 in `server/src/lib/clip.ts`) you can fake submitting clips without actually uploading
* A faked submission gave me the following error: 

`web        | [BE] TypeError: Cannot destructure property `earned` of 'undefined' or 'null'.`
`web        | [BE]     at Object.exports.hasEarnedBonus (/code/server/src/lib/model/achievements.ts:122:26)`
`web        | [BE]     at <anonymous>`
`web        | [BE]     at process._tickDomainCallback (internal/process/next_tick.js:229:7)`

Fake submissions work now on my local. The intermittentness of the error, and particularly why Lindsay and I were able to submit clips, makes sense in context of the error only showing up if earned achievements are null, whereas both Lindsay and I have done enough testing that we probably have achievements everywhere. Let me know if this makes sense to you.