### PR TITLE
Tighten query for enrolling registered users

### DIFF
--- a/server/src/lib/model/user-client.ts
+++ b/server/src/lib/model/user-client.ts
@@ -299,6 +299,7 @@ const UserClient = {
         LEFT JOIN enroll ON user_clients.client_id = enroll.client_id
         LEFT JOIN challenges ON enroll.challenge_id = challenges.id AND challenges.url_token = ?
         WHERE user_clients.email = ?
+        AND user_clients.has_login
         `,
         [challenge, email]
       );


### PR DESCRIPTION
Another simple fix! Rationale: 

* there are zero duplicate emails within the realm of `has_login = true`
* the `findClientId` method from Gregor uses `has_login` as a uniqueness check
  * this method was last updated in the same commit that created the `has_login` field
* `has_login` is set to true anytime `saveAccount` is called

¯\_(ツ)_/¯ 