### PR TITLE
Fix #2322, fix #2337: stop caching other point requests outside the leaderboards

### DIFF
--- a/server/src/lib/challenge.ts
+++ b/server/src/lib/challenge.ts
@@ -71,7 +71,7 @@ export default class Challenge {
     { client_id, params: { challenge } }: ChallengeRequestArgument & Request,
     response: Response
   ) => {
-    response.json(await this.model.getPoints(client_id, challenge));
+    response.json(await this.model.db.getPoints(client_id, challenge));
   };
 
   getWeeklyProgress = async (
@@ -79,7 +79,10 @@ export default class Challenge {
     response: Response
   ) => {
     // week starts from zero
-    const progress = await this.model.getWeeklyProgress(client_id, challenge);
+    const progress = await this.model.db.getWeeklyProgress(
+      client_id,
+      challenge
+    );
     const weeklyProgress = {
       week: progress.week,
       user: {

--- a/server/src/lib/model.ts
+++ b/server/src/lib/model.ts
@@ -221,18 +221,4 @@ export default class Model {
     (locale?: string) => this.db.getContributionStats(locale),
     20 * MINUTE
   );
-
-  getPoints = lazyCache(
-    'points-challenge',
-    (client_id: string, challenge: string) =>
-      this.db.getPoints(client_id, challenge),
-    20 * MINUTE
-  );
-
-  getWeeklyProgress = lazyCache(
-    'progress-challenge',
-    (client_id: string, challenge: string) =>
-      this.db.getWeeklyProgress(client_id, challenge),
-    20 * MINUTE
-  );
 }


### PR DESCRIPTION
@rileyjshaw , @phirework , if the final decision is caching only the leaderboard as we do for the original Stats dashboard and removing the cache, and the delay, for My points and Individual progress, this PR can serve the purpose.
Otherwise, we can close the PR.