### PR TITLE
calculate the team invites more precisely:

### DIFF
--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -661,7 +661,10 @@ export default class DB {
               LEFT JOIN enroll ON user_clients.client_id = enroll.client_id
               LEFT JOIN challenges ON enroll.challenge_id = challenges.id
               LEFT JOIN teams ON enroll.team_id = teams.id AND challenges.id = teams.challenge_id
-              LEFT JOIN enroll teammate ON enroll.id <> teammate.id AND teams.id = teammate.team_id AND challenges.id = teammate.challenge_id
+              LEFT JOIN enroll teammate ON teams.id = teammate.team_id
+                  AND challenges.id = teammate.challenge_id
+                  AND teammate.enrolled_at BETWEEN start_date AND TIMESTAMPADD(WEEK, 1, start_date)
+                  AND teammate.invited_by IS NULL
               WHERE user_clients.client_id = ? AND challenges.url_token = ?
               GROUP BY user_clients.client_id, start_date, end_date, week
           ) user

--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -578,7 +578,7 @@ export default class DB {
   async createSkippedSentence(id: string, client_id: string) {
     await this.mysql.query(
       `
-        INSERT INTO skipped_sentences (sentence_id, client_id) VALUES (?, ?) 
+        INSERT INTO skipped_sentences (sentence_id, client_id) VALUES (?, ?)
       `,
       [id, client_id]
     );
@@ -664,7 +664,8 @@ export default class DB {
               LEFT JOIN enroll teammate ON teams.id = teammate.team_id
                   AND challenges.id = teammate.challenge_id
                   AND teammate.enrolled_at BETWEEN start_date AND TIMESTAMPADD(WEEK, 1, start_date)
-                  AND teammate.invited_by IS NULL
+                  /* TODO: Uncomment this for the second week of the challenge.
+                  AND teammate.invited_by IS NOT NULL */
               WHERE user_clients.client_id = ? AND challenges.url_token = ?
               GROUP BY user_clients.client_id, start_date, end_date, week
           ) user


### PR DESCRIPTION
1) signed up within the first week;
2) signed up without invited_by;
3) including the current user if it should;

Currently, the number of team invites doesn't include current user.
@rileyjshaw , I made the bold statement in the stand-up that the current code base is correct about the team invites.
I realized that I was wrong after rechecking.