### PR TITLE
Fix #2386: No points earned for first Listen contribution, until all 5 are submitted

### DIFF
--- a/web/src/components/pages/contribution/listen/listen.tsx
+++ b/web/src/components/pages/contribution/listen/listen.tsx
@@ -134,19 +134,18 @@ class ListenPage extends React.Component<Props, State> {
     trackListening('listen', this.props.locale);
   };
 
-  private vote = (isValid: boolean) => {
-    const { clips } = this.state;
+  private showAchievementToast = async () => {
+    if (!(this && this.props)) {
+      return;
+    }
     const {
-      firstContribute,
-      hasAchieved,
       addAchievement,
       api,
+      firstContribute,
       firstStreak,
+      hasAchieved,
     } = this.props;
-    const clipIndex = this.getClipIndex();
 
-    this.stop();
-    this.props.vote(isValid, this.state.clips[this.getClipIndex()].id);
     sessionStorage.setItem('hasContributed', 'true');
     if (firstContribute) {
       addAchievement(
@@ -173,6 +172,16 @@ class ListenPage extends React.Component<Props, State> {
       // Each user can only get once.
       api.setInviteContributeAchievement();
     }
+  };
+
+  private vote = (isValid: boolean) => {
+    const { clips } = this.state;
+    const clipIndex = this.getClipIndex();
+
+    this.stop();
+    Promise.all([
+      this.props.vote(isValid, this.state.clips[this.getClipIndex()].id),
+    ]).then(this.showAchievementToast);
     this.setState({
       hasPlayed: false,
       hasPlayedSome: false,

--- a/web/src/components/pages/contribution/listen/listen.tsx
+++ b/web/src/components/pages/contribution/listen/listen.tsx
@@ -134,18 +134,19 @@ class ListenPage extends React.Component<Props, State> {
     trackListening('listen', this.props.locale);
   };
 
-  private showAchievementToast = () => {
-    if (!(this && this.props)) {
-      return;
-    }
+  private vote = async (isValid: boolean) => {
+    const { clips } = this.state;
+    const clipIndex = this.getClipIndex();
+
+    this.stop();
+    await this.props.vote(isValid, this.state.clips[this.getClipIndex()].id);
     const {
+      firstContribute,
+      hasAchieved,
       addAchievement,
       api,
-      firstContribute,
       firstStreak,
-      hasAchieved,
     } = this.props;
-
     sessionStorage.setItem('hasContributed', 'true');
     if (firstContribute) {
       addAchievement(
@@ -172,16 +173,6 @@ class ListenPage extends React.Component<Props, State> {
       // Each user can only get once.
       api.setInviteContributeAchievement();
     }
-  };
-
-  private vote = (isValid: boolean) => {
-    const { clips } = this.state;
-    const clipIndex = this.getClipIndex();
-
-    this.stop();
-    Promise.all([
-      this.props.vote(isValid, this.state.clips[this.getClipIndex()].id),
-    ]).then(this.showAchievementToast);
     this.setState({
       hasPlayed: false,
       hasPlayedSome: false,

--- a/web/src/components/pages/contribution/listen/listen.tsx
+++ b/web/src/components/pages/contribution/listen/listen.tsx
@@ -134,7 +134,7 @@ class ListenPage extends React.Component<Props, State> {
     trackListening('listen', this.props.locale);
   };
 
-  private showAchievementToast = async () => {
+  private showAchievementToast = () => {
     if (!(this && this.props)) {
       return;
     }


### PR DESCRIPTION
show toast after the `async` `vote()` is returned, otherwise toast will never show up, this is done in the following steps:

1) extract the toast functionality into a separate `async `method of the same _tsx_ file,
2) use the `promise.all().then() `to make sure that the achievement attributes piggy-backed in vote request already update the `props `before showing toasts.

This is PR should resolve issue: https://github.com/mozilla/voice-web/issues/2386.

@rileyjshaw , @phirework  please take a look at it, and help to identify whether it would obviously break other functionalities.