### PR TITLE
Set default value for importing sentences

### DIFF
--- a/docker/local-docker-config.json
+++ b/docker/local-docker-config.json
@@ -6,5 +6,6 @@
     "accessKeyId": "local-identity",
     "secretAccessKey": "local-credential",
     "s3ForcePathStyle": true
-  }
+  },
+  "IMPORT_SENTENCES": false
 }


### PR DESCRIPTION
Small quibble of a commit, I would argue that in local dev you're much more likely to turn this off than need it on and I would like the default to be `false` just so I don't keep accidentally maxing out my system resources :P 