### PR TITLE
Add newrelic_agent.log to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 config.json
+newrelic_agent.log
 web/dist/
 web/index.html
 server/js/


### PR DESCRIPTION
I've started through docker locally and I got the newrelic log file. I don't think we ever need that in git.