### PR TITLE
Remove iOS banner until we know what we're doing with the app

### DIFF
--- a/web/src/components/layout/layout.tsx
+++ b/web/src/components/layout/layout.tsx
@@ -217,17 +217,6 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
             teamToken={challengeTeamToken}
           />
         )}
-        {isIOS() && !isNativeIOS() && !isSafari() && (
-          <div
-            id="install-app"
-            onClick={this.openInApp}
-            ref={div => {
-              this.installApp = div as HTMLElement;
-            }}>
-            Open in App
-            <a onClick={this.closeOpenInApp}>X</a>
-          </div>
-        )}
         {showStagingBanner && (
           <div className="staging-banner">
             You're on the staging server. Voice data is not collected here.{' '}


### PR DESCRIPTION
Have deliberately left the CSS in case we need to restore this in the future, and have also tagged this as `tags/remove-iOS-banner` for easy referencing. 