### PR TITLE
Remove emails from config-helper.ts, add kibana_admins to confd template

### DIFF
--- a/nubis/puppet/files/confd/templates/voice.json.tmpl
+++ b/nubis/puppet/files/confd/templates/voice.json.tmpl
@@ -17,6 +17,7 @@
   "RELEASE_VERSION": "{{ if exists "/config/Version" }}{{ getv "/config/Version" }}{{ end }}",
   "SECRET": "{{ if exists "/config/Secret" }}{{ ( replace  ( getv "/config/Secret" ) "\"" "\\\"" -1 )}}{{ end }}",
   "ADMIN_EMAILS": "{{ if exists "/config/Admin-Emails" }}{{ getv "/config/Admin-Emails" }}{{ end }}",
+  "KIBANA_ADMINS": "{{ if exists "/config/Kibana-Admins" }}{{ getv "/config/Kibana-Admins" }}{{ end }}",
   "BASKET_API_KEY": "{{ if exists "/config/Basket-API-Key" }}{{ getv "/config/Basket-API-Key" }}{{ end }}",
   "REDIS_URL": "{{ if exists "/config/Cache/Endpoint" }}redis://{{ $redis }}/{{end}}",
   "KIBANA_URL": "{{ if exists "/config/ElasticSearch/Endpoint" }}https://{{ getv "/config/ElasticSearch/Endpoint" }}{{ else }}http://localhost:9200{{ end }}/_plugin/kibana/",

--- a/server/src/config-helper.ts
+++ b/server/src/config-helper.ts
@@ -47,18 +47,7 @@ const DEFAULTS: CommonVoiceConfig = {
   BUCKET_LOCATION: '',
   ENVIRONMENT: 'default',
   SECRET: 'TODO: Set a secure SECRET in config.json',
-  ADMIN_EMAILS: JSON.stringify([
-    'adelbarrio@mozilla.com',
-    'aklepel@mozilla.com',
-    'gozer@mozilla.com',
-    'jennyzhang@mozilla.com',
-    'lsaunders@mozilla.com',
-    'martin@mozilla.com',
-    'mbranson@mozilla.com',
-    'rleitan@mozilla.com',
-    'rshaw@mozilla.com',
-    'vioia@mozilla.com',
-  ]),
+  ADMIN_EMAILS: null,
   S3_CONFIG: {
     signatureVersion: 'v4',
     useDualstack: true,
@@ -71,12 +60,7 @@ const DEFAULTS: CommonVoiceConfig = {
   IMPORT_SENTENCES: true,
   REDIS_URL: null,
   KIBANA_URL: null,
-  KIBANA_ADMINS: JSON.stringify([
-    'henrik.mitsch@gmx.at',
-    'steveparmar6nov2011@gmail.com',
-    'manel.rhaiem92@gmail.com',
-    'shambhavimishra26@gmail.com',
-  ]),
+  KIBANA_ADMINS: null,
 };
 
 let injectedConfig: CommonVoiceConfig;


### PR DESCRIPTION
Have already updated the `ADMIN_EMAILS` and `KIBANA_ADMINS` values via consul on both prod and stage, this just removes the PII and relies entirely on that KV store.