### PR TITLE
challenge board will crash if challenge has finished or not started

### DIFF
--- a/server/src/lib/challenge.ts
+++ b/server/src/lib/challenge.ts
@@ -84,7 +84,7 @@ export default class Challenge {
       challenge
     );
     const weeklyProgress = {
-      week: progress.week,
+      week: progress.week < 0 ? 0 : progress.week > 2 ? 2 : progress.week,
       user: {
         speak: progress.clip_count,
         speak_total: progress.week === 1 ? 50 : 100,


### PR DESCRIPTION
make current week the first week if challenge has not started yet;
make current week the last week if challenge has already finished;

This PR fixes: https://github.com/mozilla/voice-web/issues/2410
@rileyjshaw  FYI.