### PR TITLE
Add condition for checking file type

### DIFF
--- a/web/src/components/pages/profile/avatar-setup/avatar-setup.tsx
+++ b/web/src/components/pages/profile/avatar-setup/avatar-setup.tsx
@@ -75,7 +75,7 @@ function resizeImage(file: File, maxSize: number): Promise<Blob> {
   };
 
   return new Promise((ok, no) => {
-    if (!file.type.match(/image.*/)) {
+    if (!file || !file.type.match(/image.*/)) {
       no(new Error('Not an image'));
       return;
     }


### PR DESCRIPTION
Throws an error on web when the user has canceled the image file selection. After that, the user can't select a new avatar again. I've added a condition for fixing this problem.

Scenario:
- Open the avatar page.
- Click the browse button. 
- Select an image file.
- Click the browse button, again.
- Press ESC or click the cancel.