### PR TITLE
[web] UI: Fix alignment of registration section

### DIFF
--- a/web/src/components/register-section/register-section.css
+++ b/web/src/components/register-section/register-section.css
@@ -13,6 +13,7 @@
 
         @media (--md-down) {
             flex-direction: column;
+            align-items: center;
 
             & .cta-container {
                 display: flex;


### PR DESCRIPTION
Registration section aligned left for niche screen size especially for devices like Kindle Fire HDX and certain other tablets

#### Previously:
![Imgur](https://i.imgur.com/vviP9wk.png)
![Imgur](https://i.imgur.com/HuDY4YY.png)

#### After the changes:
![Imgur](https://i.imgur.com/ugSbG10.png)
![Imgur](https://i.imgur.com/DRQrabI.png)

Currently there are no issues opened related t this. I thought it would be good to have consistent styling throughout for even the niche screen sizes.
In case this is an unnecessary change, please let me know and I'll close the PR. In case the changes need refinement, drop a comment below and I'll address them asap