### PR TITLE
prevent multiple invite_contribute_same_session AFTER challenge

### DIFF
--- a/server/src/lib/challenge.ts
+++ b/server/src/lib/challenge.ts
@@ -47,17 +47,17 @@ export default class Challenge {
         ])
       );
     } else if (bonus_type == 'invite') {
-      // return { firstInvite: boolean, hasAchieved: boolean } in the json
+      // return { showInviteSendToast: boolean, hasEarnedSessionToast: boolean } in the json
       // NOTE: easy to get confused about how should return true or false
-      // if invite_send achievement is not earned yet, earn that achievement and return firstInvite: true
-      // if invite_contribute_same_session is not earned yet, return hasAchieved: false
+      // if invite_send achievement is not earned yet, earn that achievement and return showInviteSendToast: true
+      // if invite_contribute_same_session is not earned yet, return hasEarnedSessionToast: false
       const achievement = {
-        firstInvite: await earnBonus('invite_send', [
+        showInviteSendToast: await earnBonus('invite_send', [
           client_id,
           client_id,
           challenge,
         ]),
-        hasAchieved: await hasEarnedBonus(
+        hasEarnedSessionToast: await hasEarnedBonus(
           'invite_contribute_same_session',
           client_id,
           challenge

--- a/server/src/lib/challenge.ts
+++ b/server/src/lib/challenge.ts
@@ -62,6 +62,7 @@ export default class Challenge {
           client_id,
           challenge
         ),
+        challengeEnded: await this.model.db.hasChallengeEnded(challenge),
       };
       response.json(achievement);
     }

--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -129,6 +129,7 @@ export default class Clip {
             client_id,
             challenge,
           ]),
+          challengeEnded: await this.model.db.hasChallengeEnded(challenge),
         }
       : { glob };
     response.json(ret);
@@ -236,6 +237,7 @@ export default class Clip {
               client_id,
               challenge,
             ]),
+            challengeEnded: await this.model.db.hasChallengeEnded(challenge),
           }
         : { filePrefix };
       response.json(ret);

--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -115,16 +115,16 @@ export default class Clip {
     const ret = challenge
       ? {
           glob: glob,
-          firstContribute: await earnBonus('first_contribution', [
+          showFirstContributionToast: await earnBonus('first_contribution', [
             challenge,
             client_id,
           ]),
-          hasAchieved: await hasEarnedBonus(
+          hasEarnedSessionToast: await hasEarnedBonus(
             'invite_contribute_same_session',
             client_id,
             challenge
           ),
-          firstStreak: await earnBonus('three_day_streak', [
+          showFirstStreakToast: await earnBonus('three_day_streak', [
             client_id,
             client_id,
             challenge,
@@ -221,18 +221,18 @@ export default class Clip {
       const ret = challenge
         ? {
             filePrefix: filePrefix,
-            firstContribute: await earnBonus('first_contribution', [
+            showFirstContributionToast: await earnBonus('first_contribution', [
               challenge,
               client_id,
             ]),
-            hasAchieved: await hasEarnedBonus(
+            hasEarnedSessionToast: await hasEarnedBonus(
               'invite_contribute_same_session',
               client_id,
               challenge
             ),
             // can't simply reduce the number of the calls to DB through streak_days in checkGoalsAfterContribution()
             // since the the streak_days may start before the time when user set custom_goals, check to win bonus for each contribution
-            firstStreak: await earnBonus('three_day_streak', [
+            showFirstStreakToast: await earnBonus('three_day_streak', [
               client_id,
               client_id,
               challenge,

--- a/server/src/lib/model/achievements.ts
+++ b/server/src/lib/model/achievements.ts
@@ -134,7 +134,7 @@ export const hasEarnedBonus = async (
       LEFT JOIN achievements ON challenges.id = achievements.challenge_id AND achievements.name = ?
       LEFT JOIN earn ON achievements.id = earn.achievement_id
           AND earn.client_id = ?
-          AND earn.earned_at BETWEEN start_date AND TIMESTAMPADD(WEEK, 3, start_date)
+          AND earn.earned_at < TIMESTAMPADD(WEEK, 3, start_date)
       WHERE challenges.url_token = ?
       `,
     [type, client_id, challenge]

--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -690,6 +690,8 @@ export default class DB {
       [challenge]
     );
     if (row) {
+      // row.start_date_utc is utc time (timezone offset is 0);
+      // startDateServer = start_date_utc + backend timezone offset (in minutes);
       const startDateServer = new Date(row.start_date_utc);
       const startDateUtc = new Date(
         startDateServer.valueOf() -

--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -681,7 +681,7 @@ export default class DB {
   }
 
   async hasChallengeEnded(challenge: ChallengeToken) {
-    let hasChallengeEnded = false;
+    let hasChallengeEnded = true;
     const [[row]] = await this.mysql.query(
       `SELECT TIMESTAMPADD(MINUTE, -TIMESTAMPDIFF(MINUTE, UTC_TIMESTAMP(), NOW()), start_date) AS start_date_utc
       FROM challenges

--- a/web/src/components/invite-modal/invite-modal.tsx
+++ b/web/src/components/invite-modal/invite-modal.tsx
@@ -32,12 +32,18 @@ export default ({
         .fetchInviteStatus()
         .then(
           ({
-            firstInvite = false,
-            hasAchieved = false,
+            showInviteSendToast = false,
+            hasEarnedSessionToast = false,
             challengeEnded = true,
           }) => {
-            sessionStorage.setItem('firstInvite', JSON.stringify(firstInvite));
-            sessionStorage.setItem('hasAchieved', JSON.stringify(hasAchieved));
+            sessionStorage.setItem(
+              'showInviteSendToast',
+              JSON.stringify(showInviteSendToast)
+            );
+            sessionStorage.setItem(
+              'hasEarnedSessionToast',
+              JSON.stringify(hasEarnedSessionToast)
+            );
             sessionStorage.setItem(
               'challengeEnded',
               JSON.stringify(challengeEnded)

--- a/web/src/components/invite-modal/invite-modal.tsx
+++ b/web/src/components/invite-modal/invite-modal.tsx
@@ -30,10 +30,20 @@ export default ({
       // To check whether or not it is the first invite.
       api
         .fetchInviteStatus()
-        .then(({ firstInvite = false, hasAchieved = false }) => {
-          sessionStorage.setItem('firstInvite', JSON.stringify(firstInvite));
-          sessionStorage.setItem('hasAchieved', JSON.stringify(hasAchieved));
-        });
+        .then(
+          ({
+            firstInvite = false,
+            hasAchieved = false,
+            challengeEnded = true,
+          }) => {
+            sessionStorage.setItem('firstInvite', JSON.stringify(firstInvite));
+            sessionStorage.setItem('hasAchieved', JSON.stringify(hasAchieved));
+            sessionStorage.setItem(
+              'challengeEnded',
+              JSON.stringify(challengeEnded)
+            );
+          }
+        );
       sessionStorage.setItem('hasShared', 'true');
 
       return () => clearTimeout(timer);

--- a/web/src/components/pages/contribution/listen/listen.tsx
+++ b/web/src/components/pages/contribution/listen/listen.tsx
@@ -141,6 +141,8 @@ class ListenPage extends React.Component<Props, State> {
 
     this.stop();
     await this.props.vote(isValid, this.state.clips[this.getClipIndex()].id);
+    // this.props.vote() will update props values like challengeEnded, showFirstStreakBonus etc.
+    // So the following line must be run AFTER this.props.vote() has finished synchronously.
     const {
       showFirstContributionToast,
       hasEarnedSessionToast,

--- a/web/src/components/pages/contribution/listen/listen.tsx
+++ b/web/src/components/pages/contribution/listen/listen.tsx
@@ -48,9 +48,9 @@ interface PropsFromState {
   clips: Clips.Clip[];
   isLoading: boolean;
   locale: Locale.State;
-  firstContribute: boolean;
-  hasAchieved: boolean;
-  firstStreak: boolean;
+  showFirstContributionToast: boolean;
+  hasEarnedSessionToast: boolean;
+  showFirstStreakToast: boolean;
   challengeEnded: boolean;
 }
 
@@ -142,23 +142,23 @@ class ListenPage extends React.Component<Props, State> {
     this.stop();
     await this.props.vote(isValid, this.state.clips[this.getClipIndex()].id);
     const {
-      firstContribute,
-      hasAchieved,
+      showFirstContributionToast,
+      hasEarnedSessionToast,
       addAchievement,
       api,
-      firstStreak,
+      showFirstStreakToast,
       challengeEnded,
     } = this.props;
     sessionStorage.setItem('challengeEnded', JSON.stringify(challengeEnded));
     sessionStorage.setItem('hasContributed', 'true');
-    if (firstContribute) {
+    if (showFirstContributionToast) {
       addAchievement(
         50,
         "You're on your way! Congrats on your first contribution.",
         'success'
       );
     }
-    if (firstStreak) {
+    if (showFirstStreakToast) {
       addAchievement(
         50,
         'You completed a three-day streak! Keep it up.',
@@ -168,7 +168,7 @@ class ListenPage extends React.Component<Props, State> {
     if (
       !JSON.parse(sessionStorage.getItem('challengeEnded')) &&
       JSON.parse(sessionStorage.getItem('hasShared')) &&
-      !hasAchieved
+      !hasEarnedSessionToast
     ) {
       addAchievement(
         50,
@@ -367,18 +367,18 @@ const mapStateToProps = (state: StateTree) => {
   const {
     clips,
     isLoading,
-    firstContribute,
-    hasAchieved,
-    firstStreak,
+    showFirstContributionToast,
+    hasEarnedSessionToast,
+    showFirstStreakToast,
     challengeEnded,
   } = Clips.selectors.localeClips(state);
   const { api } = state;
   return {
     clips,
     isLoading,
-    firstContribute,
-    hasAchieved,
-    firstStreak,
+    showFirstContributionToast,
+    hasEarnedSessionToast,
+    showFirstStreakToast,
     challengeEnded,
     api,
     locale: state.locale,

--- a/web/src/components/pages/contribution/listen/listen.tsx
+++ b/web/src/components/pages/contribution/listen/listen.tsx
@@ -51,6 +51,7 @@ interface PropsFromState {
   firstContribute: boolean;
   hasAchieved: boolean;
   firstStreak: boolean;
+  challengeEnded: boolean;
 }
 
 interface PropsFromDispatch {
@@ -146,7 +147,9 @@ class ListenPage extends React.Component<Props, State> {
       addAchievement,
       api,
       firstStreak,
+      challengeEnded,
     } = this.props;
+    sessionStorage.setItem('challengeEnded', JSON.stringify(challengeEnded));
     sessionStorage.setItem('hasContributed', 'true');
     if (firstContribute) {
       addAchievement(
@@ -162,7 +165,11 @@ class ListenPage extends React.Component<Props, State> {
         'success'
       );
     }
-    if (JSON.parse(sessionStorage.getItem('hasShared')) && !hasAchieved) {
+    if (
+      !JSON.parse(sessionStorage.getItem('challengeEnded')) &&
+      JSON.parse(sessionStorage.getItem('hasShared')) &&
+      !hasAchieved
+    ) {
       addAchievement(
         50,
         "You're on a roll! You sent an invite and contributed in the same session.",
@@ -363,6 +370,7 @@ const mapStateToProps = (state: StateTree) => {
     firstContribute,
     hasAchieved,
     firstStreak,
+    challengeEnded,
   } = Clips.selectors.localeClips(state);
   const { api } = state;
   return {
@@ -371,6 +379,7 @@ const mapStateToProps = (state: StateTree) => {
     firstContribute,
     hasAchieved,
     firstStreak,
+    challengeEnded,
     api,
     locale: state.locale,
   };

--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -393,10 +393,15 @@ class SpeakPage extends React.Component<Props, State> {
               firstContribute = false,
               hasAchieved = false,
               firstStreak = false,
+              challengeEnded = true,
             } = await api.uploadClip(
               recording.blob,
               sentence.id,
               sentence.text
+            );
+            sessionStorage.setItem(
+              'challengeEnded',
+              JSON.stringify(challengeEnded)
             );
             sessionStorage.setItem('hasContributed', 'true');
             if (firstContribute) {
@@ -414,6 +419,7 @@ class SpeakPage extends React.Component<Props, State> {
               );
             }
             if (
+              !JSON.parse(sessionStorage.getItem('challengeEnded')) &&
               JSON.parse(sessionStorage.getItem('hasShared')) &&
               !hasAchieved
             ) {

--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -390,9 +390,9 @@ class SpeakPage extends React.Component<Props, State> {
         while (retries) {
           try {
             const {
-              firstContribute = false,
-              hasAchieved = false,
-              firstStreak = false,
+              showFirstContributionToast = false,
+              hasEarnedSessionToast = false,
+              showFirstStreakToast = false,
               challengeEnded = true,
             } = await api.uploadClip(
               recording.blob,
@@ -404,14 +404,14 @@ class SpeakPage extends React.Component<Props, State> {
               JSON.stringify(challengeEnded)
             );
             sessionStorage.setItem('hasContributed', 'true');
-            if (firstContribute) {
+            if (showFirstContributionToast) {
               addAchievement(
                 50,
                 "You're on your way! Congrats on your first contribution.",
                 'success'
               );
             }
-            if (firstStreak) {
+            if (showFirstStreakToast) {
               addAchievement(
                 50,
                 'You completed a three-day streak! Keep it up.',
@@ -421,7 +421,7 @@ class SpeakPage extends React.Component<Props, State> {
             if (
               !JSON.parse(sessionStorage.getItem('challengeEnded')) &&
               JSON.parse(sessionStorage.getItem('hasShared')) &&
-              !hasAchieved
+              !hasEarnedSessionToast
             ) {
               addAchievement(
                 50,

--- a/web/src/components/pages/dashboard/dashboard.tsx
+++ b/web/src/components/pages/dashboard/dashboard.tsx
@@ -289,6 +289,7 @@ export default function Dashboard() {
               sessionStorage.removeItem('firstInvite');
             }
             if (
+              !JSON.parse(sessionStorage.getItem('challengeEnded')) &&
               !JSON.parse(sessionStorage.getItem('hasAchieved')) &&
               JSON.parse(sessionStorage.getItem('hasContributed'))
             ) {

--- a/web/src/components/pages/dashboard/dashboard.tsx
+++ b/web/src/components/pages/dashboard/dashboard.tsx
@@ -284,20 +284,20 @@ export default function Dashboard() {
           enrollment={account.enrollment}
           onRequestClose={() => {
             setShowInviteModal(false);
-            if (JSON.parse(sessionStorage.getItem('firstInvite'))) {
+            if (JSON.parse(sessionStorage.getItem('showInviteSendToast'))) {
               addAchievement(50, 'You sent your first invite!');
-              sessionStorage.removeItem('firstInvite');
+              sessionStorage.removeItem('showInviteSendToast');
             }
             if (
               !JSON.parse(sessionStorage.getItem('challengeEnded')) &&
-              !JSON.parse(sessionStorage.getItem('hasAchieved')) &&
+              !JSON.parse(sessionStorage.getItem('hasEarnedSessionToast')) &&
               JSON.parse(sessionStorage.getItem('hasContributed'))
             ) {
               addAchievement(
                 50,
                 "You're on a roll! You sent an invite and contributed in the same session."
               );
-              sessionStorage.removeItem('hasAchieved');
+              sessionStorage.removeItem('hasEarnedSessionToast');
               sessionStorage.removeItem('hasContributed');
               // Tell back-end user get unexpected achievement: invite + contribute in the same session
               // Each user can only get once.

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -27,6 +27,7 @@ interface Vote extends Event {
   hasAchieved?: boolean;
   firstContribute?: boolean;
   firstStreak?: boolean;
+  challengeEnded?: boolean;
 }
 
 const API_PATH = location.origin + '/api/v1';
@@ -124,6 +125,7 @@ export default class API {
     firstContribute?: boolean;
     hasAchieved?: boolean;
     firstStreak?: boolean;
+    challengeEnded: boolean;
   }> {
     return this.fetch(this.getClipPath(), {
       method: 'POST',
@@ -412,7 +414,11 @@ export default class API {
     return null;
   }
   // check whether or not is the first invite
-  fetchInviteStatus(): Promise<{ firstInvite: boolean; hasAchieved: boolean }> {
+  fetchInviteStatus(): Promise<{
+    firstInvite: boolean;
+    hasAchieved: boolean;
+    challengeEnded: boolean;
+  }> {
     if (getChallenge(this.user)) {
       return this.fetch(
         `${API_PATH}/challenge/${this.user.account.enrollment.challenge}/achievement/invite`

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -24,9 +24,9 @@ interface FetchOptions {
 }
 
 interface Vote extends Event {
-  hasAchieved?: boolean;
-  firstContribute?: boolean;
-  firstStreak?: boolean;
+  hasEarnedSessionToast?: boolean;
+  showFirstContributionToast?: boolean;
+  showFirstStreakToast?: boolean;
   challengeEnded?: boolean;
 }
 
@@ -122,9 +122,9 @@ export default class API {
     sentenceId: string,
     sentence: string
   ): Promise<{
-    firstContribute?: boolean;
-    hasAchieved?: boolean;
-    firstStreak?: boolean;
+    showFirstContributionToast?: boolean;
+    hasEarnedSessionToast?: boolean;
+    showFirstStreakToast?: boolean;
     challengeEnded: boolean;
   }> {
     return this.fetch(this.getClipPath(), {
@@ -415,8 +415,8 @@ export default class API {
   }
   // check whether or not is the first invite
   fetchInviteStatus(): Promise<{
-    firstInvite: boolean;
-    hasAchieved: boolean;
+    showInviteSendToast: boolean;
+    hasEarnedSessionToast: boolean;
     challengeEnded: boolean;
   }> {
     if (getChallenge(this.user)) {

--- a/web/src/stores/clips.ts
+++ b/web/src/stores/clips.ts
@@ -20,6 +20,7 @@ export namespace Clips {
       firstContribute: boolean;
       firstStreak: boolean;
       hasAchieved: boolean;
+      challengeEnded: boolean;
       next?: Clip;
     };
   }
@@ -44,6 +45,7 @@ export namespace Clips {
     firstContribute?: boolean;
     hasAchieved?: boolean;
     firstStreak?: boolean;
+    challengeEnded?: boolean;
   }
 
   interface RefillCacheAction extends ReduxAction {
@@ -117,6 +119,7 @@ export namespace Clips {
         firstContribute,
         hasAchieved,
         firstStreak,
+        challengeEnded,
       } = await state.api.saveVote(id, isValid);
       if (!state.user.account) {
         dispatch(User.actions.tallyVerification());
@@ -127,6 +130,7 @@ export namespace Clips {
           firstContribute,
           hasAchieved,
           firstStreak,
+          challengeEnded,
         });
       }
       User.actions.refresh()(dispatch, getState);
@@ -188,6 +192,7 @@ export namespace Clips {
             hasAchieved: false,
             firstContribute: false,
             firstStreak: false,
+            challengeEnded: true,
             next,
           },
         };
@@ -207,6 +212,7 @@ export namespace Clips {
             hasAchieved: action.hasAchieved,
             firstContribute: action.firstContribute,
             firstStreak: action.firstStreak,
+            challengeEnded: action.challengeEnded,
           },
         };
       }

--- a/web/src/stores/clips.ts
+++ b/web/src/stores/clips.ts
@@ -17,9 +17,9 @@ export namespace Clips {
     [locale: string]: {
       clips: Clip[];
       isLoading: boolean;
-      firstContribute: boolean;
-      firstStreak: boolean;
-      hasAchieved: boolean;
+      showFirstContributionToast: boolean;
+      showFirstStreakToast: boolean;
+      hasEarnedSessionToast: boolean;
       challengeEnded: boolean;
       next?: Clip;
     };
@@ -42,9 +42,9 @@ export namespace Clips {
 
   interface AchievementAction extends ReduxAction {
     type: ActionType.ACHIEVEMENT;
-    firstContribute?: boolean;
-    hasAchieved?: boolean;
-    firstStreak?: boolean;
+    showFirstContributionToast?: boolean;
+    hasEarnedSessionToast?: boolean;
+    showFirstStreakToast?: boolean;
     challengeEnded?: boolean;
   }
 
@@ -116,9 +116,9 @@ export namespace Clips {
       const id = clipId || localeClips(state).next.id;
       dispatch({ type: ActionType.REMOVE_CLIP, clipId: id });
       const {
-        firstContribute,
-        hasAchieved,
-        firstStreak,
+        showFirstContributionToast,
+        hasEarnedSessionToast,
+        showFirstStreakToast,
         challengeEnded,
       } = await state.api.saveVote(id, isValid);
       if (!state.user.account) {
@@ -127,9 +127,9 @@ export namespace Clips {
       if (state.user.account.enrollment.challenge) {
         dispatch({
           type: ActionType.ACHIEVEMENT,
-          firstContribute,
-          hasAchieved,
-          firstStreak,
+          showFirstContributionToast,
+          hasEarnedSessionToast,
+          showFirstStreakToast,
           challengeEnded,
         });
       }
@@ -155,9 +155,9 @@ export namespace Clips {
           clips: [],
           next: null,
           isLoading: false,
-          firstContribute: false,
-          firstStreak: false,
-          hasAchieved: false,
+          showFirstContributionToast: false,
+          showFirstStreakToast: false,
+          hasEarnedSessionToast: false,
         },
       }),
       {}
@@ -189,9 +189,9 @@ export namespace Clips {
                 clips.findIndex(clip2 => clip2.id === clip1.id) === i
             ),
             isLoading: false,
-            hasAchieved: false,
-            firstContribute: false,
-            firstStreak: false,
+            hasEarnedSessionToast: false,
+            showFirstContributionToast: false,
+            showFirstStreakToast: false,
             challengeEnded: true,
             next,
           },
@@ -209,9 +209,9 @@ export namespace Clips {
           ...state,
           [locale]: {
             ...localeState,
-            hasAchieved: action.hasAchieved,
-            firstContribute: action.firstContribute,
-            firstStreak: action.firstStreak,
+            hasEarnedSessionToast: action.hasEarnedSessionToast,
+            showFirstContributionToast: action.showFirstContributionToast,
+            showFirstStreakToast: action.showFirstStreakToast,
             challengeEnded: action.challengeEnded,
           },
         };


### PR DESCRIPTION
- prevent multiple `invite_contribute_same_session ` toasts AFTER challenge by checking challenge time under different timezone;
- change `firstInvite `to `showInviteSendToast`;
- change `hasAchieved `to `hasEarnedSessionToast`;
- change `firstContribute `to `showFirstContributionToast`;
- change `firstStreak `to `showFirstStreakToast`;
- set the default value of `challengeEnded `to true;

@rileyjshaw , as mentioned in PR: https://github.com/mozilla/voice-web/pull/2382, this PR will not show any `invite_contribute_same_session `bonus once challenge has ended.