### PR TITLE
Add a mailto form to the Invite modal

### DIFF
--- a/web/src/components/invite-modal/invite-modal.css
+++ b/web/src/components/invite-modal/invite-modal.css
@@ -18,7 +18,7 @@
         font-weight: normal;
     }
 
-    input {
+    .visuallyhidden {
         position: absolute;
         overflow: hidden;
         clip: rect(0 0 0 0);
@@ -50,5 +50,23 @@
             margin-left: 12px;
             font-size: 0.6em;
         }
+    }
+
+    .or {
+        font-family: var(--base-font-family);
+        font-size: 24px;
+        font-weight: 300;
+        letter-spacing: 1px;
+        color: var(--black);
+        margin: 30px 0;
+    }
+
+    .email-form {
+        max-width: 400px;
+        margin: auto;
+    }
+
+    .labeled-form-control {
+        margin-bottom: 30px;
     }
 }

--- a/web/src/components/invite-modal/invite-modal.tsx
+++ b/web/src/components/invite-modal/invite-modal.tsx
@@ -3,10 +3,10 @@ import { useEffect, useRef, useState } from 'react';
 import BalanceText from 'react-balance-text';
 import Modal, { ModalProps } from '../modal/modal';
 import { FontIcon } from '../ui/icons';
-import { Button } from '../ui/ui';
+import { Button, LabeledInput, LabeledTextArea } from '../ui/ui';
 import { useAPI } from '../../hooks/store-hooks';
 import { trackChallenge } from '../../services/tracker';
-import { Enrollment } from 'common/challenge';
+import { Enrollment, challengeTeams } from 'common/challenge';
 
 import './invite-modal.css';
 
@@ -14,66 +14,72 @@ export interface InviteModalProps extends ModalProps {
   enrollment: Enrollment;
 }
 
+// Check whether or not it is the first invite, for achievements.
+function handleInvite() {
+  useAPI()
+    .fetchInviteStatus()
+    .then(
+      ({
+        showInviteSendToast = false,
+        hasEarnedSessionToast = false,
+        challengeEnded = true,
+      }) => {
+        sessionStorage.setItem(
+          'showInviteSendToast',
+          JSON.stringify(showInviteSendToast)
+        );
+        sessionStorage.setItem(
+          'hasEarnedSessionToast',
+          JSON.stringify(hasEarnedSessionToast)
+        );
+        sessionStorage.setItem(
+          'challengeEnded',
+          JSON.stringify(challengeEnded)
+        );
+      }
+    );
+  sessionStorage.setItem('hasShared', 'true');
+}
+
 export default ({
   enrollment: { challenge, team, invite },
   ...props
 }: InviteModalProps) => {
+  const inviteLink = `${window.location.origin}/?challenge=${challenge}&team=${team}&invite=${invite}`;
   const [copiedRecently, setCopiedRecently] = useState<boolean>(false);
+  const [emailRecipients, setEmailRecipients] = useState<string>('');
+  const [emailBody, setEmailBody] = useState<string>(
+    `Join the ${challengeTeams[team].readableName} team in the Open Voice Challenge! We're helping Mozilla's Common Voice project build an open, public voice dataset and earn prizes for charity.
+
+Go to ${inviteLink} in your browser to get started.`
+  );
   const inputRef = useRef();
-  const api = useAPI();
   // Reset the button's copied state after a brief timeout.
   useEffect(() => {
     if (copiedRecently) {
       const timer = setTimeout(() => {
         setCopiedRecently(false);
       }, 2000);
-      // To check whether or not it is the first invite.
-      api
-        .fetchInviteStatus()
-        .then(
-          ({
-            showInviteSendToast = false,
-            hasEarnedSessionToast = false,
-            challengeEnded = true,
-          }) => {
-            sessionStorage.setItem(
-              'showInviteSendToast',
-              JSON.stringify(showInviteSendToast)
-            );
-            sessionStorage.setItem(
-              'hasEarnedSessionToast',
-              JSON.stringify(hasEarnedSessionToast)
-            );
-            sessionStorage.setItem(
-              'challengeEnded',
-              JSON.stringify(challengeEnded)
-            );
-          }
-        );
-      sessionStorage.setItem('hasShared', 'true');
-
+      handleInvite();
       return () => clearTimeout(timer);
     }
   }, [copiedRecently]);
   useEffect(() => trackChallenge('modal-invite'), []);
-
   return (
     <Modal {...props} innerClassName="invite-modal">
       <img alt="" src={require('./images/mail.svg')} role="presentation" />
-
       <h1>
         <BalanceText>
           Invite colleagues and friends to join your challenge team
         </BalanceText>
       </h1>
-
       <input
         readOnly
         ref={inputRef}
         type="text"
-        value={`${window.location.origin}/?challenge=${challenge}&team=${team}&invite=${invite}`}
+        value={inviteLink}
+        className="visuallyhidden"
       />
-
       <Button
         rounded
         onClick={() => {
@@ -86,6 +92,46 @@ export default ({
         {copiedRecently ? 'Copied' : 'Copy link'}
         <FontIcon type="link" className="icon" />
       </Button>
+      <div className="or">or</div>
+      {/* TODO: If the client's default mailto handler is a web interface (eg.
+                Gmail), the current tab location will change before any
+                achievements are awarded. target="_blank" is not reliable for
+                mailto links.
+
+                Investigate adding a delay between triggering the submission
+                and actually submitting the form.  */}
+      <form
+        action={`mailto:${emailRecipients.replace(/ /g, '')}`}
+        onSubmit={handleInvite}
+        method="GET"
+        target="_blank"
+        className="email-form">
+        <input type="hidden" name="subject" value="Open Voice Challenge" />
+        <LabeledInput
+          required
+          name="email"
+          type="text"
+          label="Email address"
+          placeholder="address@email.com"
+          value={emailRecipients}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setEmailRecipients(e.target.value)
+          }
+        />
+        <LabeledTextArea
+          required
+          name="body"
+          label="Message"
+          value={emailBody}
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+            setEmailBody(e.target.value)
+          }
+          rows={6}
+        />
+        <Button rounded type="submit">
+          Submit
+        </Button>
+      </form>
     </Modal>
   );
 };


### PR DESCRIPTION
re: https://miro.com/app/board/o9J_kwpdQeg=/?moveToWidget=3074457346920414536

Test plan:

- Go to http://localhost:9000/en/dashboard/challenge
- Click "Invite +"

A form should appear in the invite modal below the "Copy link" button.

- Click "Submit"

The form should block submission due to an empty "Email address" field.

- Fill one, or multiple, emails in the "Email address" field. eg. `friend@email.com, other@email.com`
- Click "Submit"

An email should open in your default client with the following attributes:

To: <Inputted user(s)>
Subject: Open Voice Challenge
Body: <Inputted body>