### PR TITLE
Upgrade TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prettier": "^1.18.2",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   },
   "devDependencies": {
     "husky": "^3.0.2",

--- a/server/package.json
+++ b/server/package.json
@@ -55,7 +55,7 @@
     "request-promise-native": "^1.0.7",
     "source-map-support": "^0.5.12",
     "stream-transcoder": "0.0.5",
-    "typescript": "3.5.3",
+    "typescript": "3.7.2",
     "universal-analytics": "^0.4.20"
   },
   "devDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -65,7 +65,7 @@
     "redux-thunk": "^2.2.0",
     "reselect": "^4.0.0",
     "style-loader": "^1.0.0",
-    "typescript": "3.6.4",
+    "typescript": "3.7.2",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.9"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9938,15 +9938,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
-  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
-
-typescript@3.6.4:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
-  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
+typescript@3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
+  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 uglify-js@3.4.x:
   version "3.4.10"


### PR DESCRIPTION
This commit ensures that we're on the latest version of TypeScript. More
importantly, it ensures we're using the same version of TypeScript across
the application.

Also… now we can finally use [Optional Chaining](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#optional-chaining)! 🎉

Test plan:

- `yarn install`
- `rm -rf server/js web/dist`
- `yarn build`
- `yarn prettier`
- `yarn test`