### PR TITLE
Node script for profile deletion

### DIFF
--- a/nubis/puppet/files/confd/templates/voice.json.tmpl
+++ b/nubis/puppet/files/confd/templates/voice.json.tmpl
@@ -21,6 +21,7 @@
   "BASKET_API_KEY": "{{ if exists "/config/Basket-API-Key" }}{{ getv "/config/Basket-API-Key" }}{{ end }}",
   "REDIS_URL": "{{ if exists "/config/Cache/Endpoint" }}redis://{{ $redis }}/{{end}}",
   "KIBANA_URL": "{{ if exists "/config/ElasticSearch/Endpoint" }}https://{{ getv "/config/ElasticSearch/Endpoint" }}{{ else }}http://localhost:9200{{ end }}/_plugin/kibana/",
+  "LAST_DATASET": "{{ if exists "/config/Last-Dataset" }}{{ getv "/config/Last-Dataset" }}{{ end }}",
   "AUTH0": {
     "DOMAIN": "{{ if exists "/config/Auth0/Domain" }}{{ getv "/config/Auth0/Domain" }}{{ end }}",
     "CLIENT_ID": "{{ if exists "/config/Auth0/Client-ID" }}{{ getv "/config/Auth0/Client-ID" }}{{ end }}",

--- a/scripts/scrub-user.js
+++ b/scripts/scrub-user.js
@@ -14,7 +14,7 @@ let deletionSummary = {
 };
 
 const parseResults = (results, email) => {
-  const SIX_MONTHS = 6 * 30 * 24 * 60 * 60 * 1000;
+  const LAST_DATASET = config.LAST_DATASET || new Date();
   const clip_total = results.reduce((acc, curr) => acc + curr.clip_count, 0);
   const client_ids = results.map(each => each.client_id);
 
@@ -30,7 +30,7 @@ const parseResults = (results, email) => {
   if (summary.clip_total) {
     summary.first_clip = results[0].first_clip;
 
-    if (new Date() - new Date(summary.first_clip) >= SIX_MONTHS)
+    if (LAST_DATASET >= new Date(summary.first_clip))
       summary.in_past_dataset = true;
   }
 

--- a/scripts/scrub-user.js
+++ b/scripts/scrub-user.js
@@ -1,5 +1,12 @@
+require('dotenv').config();
 const mysql = require('mysql');
-const config = require('../config.json');
+
+const dbConfig = {
+  host: process.env.MYSQLHOST || 'localhost',
+  user: process.env.MYSQLUSER || 'voicecommons',
+  password: process.env.MYSQLPASS || 'voicecommons',
+  database: process.env.MYSQLDBNAME || 'voiceweb',
+};
 
 const readline = require('readline').createInterface({
   input: process.stdin,
@@ -19,8 +26,8 @@ const isValidDate = dateStr => {
 };
 
 const parseResults = (results, email) => {
-  const lastDatasetDate = isValidDate(config.LAST_DATASET_DATE)
-    ? new Date(config.LAST_DATASET_DATE)
+  const lastDatasetDate = isValidDate(process.env.LAST_DATASET_DATE)
+    ? new Date(process.env.LAST_DATASET_DATE)
     : new Date();
   const clipTotal = results.reduce((acc, curr) => acc + curr.clip_count, 0);
   const clientIds = results.map(each => each.client_id);
@@ -182,15 +189,10 @@ try {
   if (process.argv.length < 3)
     throw new Error('Please enter at least one email address');
   const emails = process.argv.slice(2);
-
-  const pool = mysql.createPool({
-    host: config.MYSQLHOST,
-    user: config.MYSQLUSER,
-    password: config.MYSQLPASS,
-    database: config.MYSQLDBNAME,
-  });
+  const pool = mysql.createPool(dbConfig);
 
   pool.getConnection((err, connection) => {
+    if (err) throw err;
     emails.forEach((email, index) => {
       deleteUser(connection, email, index + 1 === emails.length);
     });

--- a/scripts/scrub-user.js
+++ b/scripts/scrub-user.js
@@ -57,14 +57,14 @@ const printSummary = summary => {
 
   if (deletionSummary.s3_ids.length)
     console.log(
-      `Please manually the following folders from S3: ${deletionSummary.s3_ids.join(
+      `Please manually remove the following folders from S3: ${deletionSummary.s3_ids.join(
         ', '
       )}.`
     );
 
   if (deletionSummary.dataset_ids.length)
     console.log(
-      `Please email past dataset downloaders and ask them to remove these folders: ${deletionSummary.dataset_ids.join(
+      `The following client_ids were included in a past dataset: ${deletionSummary.dataset_ids.join(
         ', '
       )}.`
     );

--- a/scripts/scrub-user.js
+++ b/scripts/scrub-user.js
@@ -1,0 +1,195 @@
+const mysql = require('mysql');
+const config = require('../config.json');
+
+const readline = require('readline').createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+let safeToDelete = true;
+let deletionSummary = {
+  emails: [],
+  s3_ids: [],
+  dataset_ids: [],
+};
+
+const parseResults = (results, email) => {
+  const SIX_MONTHS = 6 * 30 * 24 * 60 * 60 * 1000;
+  const clip_total = results.reduce((acc, curr) => acc + curr.clip_count, 0);
+  const client_ids = results.map(each => each.client_id);
+
+  const summary = {
+    email: email,
+    length: results.length,
+    ids: client_ids,
+    clip_total: clip_total,
+    first_clip: null,
+    in_past_dataset: false,
+  };
+
+  if (summary.clip_total) {
+    summary.first_clip = results[0].first_clip;
+
+    if (new Date() - new Date(summary.first_clip) >= SIX_MONTHS)
+      summary.in_past_dataset = true;
+  }
+
+  return summary;
+};
+
+const processIteration = last => {
+  console.log(`=======================================`);
+  safeToDelete = true;
+
+  if (last) {
+    printSummary(deletionSummary);
+    readline.close();
+    process.exit(1);
+  }
+};
+
+const printSummary = summary => {
+  console.log('Deletion summary: \n');
+  if (deletionSummary.emails.length)
+    console.log(
+      `Removed user information related to ${deletionSummary.emails.join(', ')}`
+    );
+
+  if (deletionSummary.s3_ids.length)
+    console.log(
+      `Please manually the following folders from S3: ${deletionSummary.s3_ids.join(
+        ', '
+      )}.`
+    );
+
+  if (deletionSummary.dataset_ids.length)
+    console.log(
+      `Please email past dataset downloaders and ask them to remove these folders: ${deletionSummary.dataset_ids.join(
+        ', '
+      )}.`
+    );
+};
+
+const printUserStats = stats => {
+  console.log(`
+    Email: ${stats.email}
+    Associated client_ids: ${stats.length}
+    Total clips contributed: ${stats.clip_total}
+    First contribution: ${stats.first_clip}
+    `);
+};
+
+const deleteClipRecords = (connection, userStats, isLast) => {
+  const idStrings = userStats.ids.map(id => `"${id}"`);
+  connection.query(
+    `DELETE FROM clips WHERE client_id IN (${idStrings})`,
+    (clip_error, clip_results, clip_fields) => {
+      if (clip_error) throw clip_error;
+
+      if (clip_results.affectedRows) {
+        deletionSummary.s3_ids = deletionSummary.s3_ids.concat(userStats.ids);
+
+        if (userStats.in_past_dataset)
+          deletionSummary.dataset_ids = deletionSummary.dataset_ids.concat(
+            userStats.ids
+          );
+
+        console.log(
+          `Records for ${clip_results.affectedRows} clips were deleted.\n`
+        );
+      }
+
+      processIteration(isLast);
+    }
+  );
+};
+
+const deleteUserRecords = (connection, userStats, isLast) => {
+  connection.query(
+    `DELETE FROM user_clients WHERE email = ${userStats.email}`,
+    (delete_error, delete_results, delete_fields) => {
+      if (delete_error) throw delete_error;
+
+      deletionSummary.emails.push(userStats.email);
+
+      if (userStats.clip_total) {
+        readline.question(
+          `\nWould you also like to delete the ${userStats.clip_total} associated clips? \nThis CANNOT be reversed [Y/N] `,
+          answer => {
+            if (answer.toLowerCase() === 'y')
+              deleteClipRecords(connection, userStats, isLast);
+            else processIteration(isLast);
+          }
+        );
+      } else {
+        processIteration(isLast);
+      }
+    }
+  );
+};
+
+const deleteUser = (connection, email, isLast) => {
+  if (safeToDelete) {
+    safeToDelete = false;
+    const clean_email = connection.escape(email);
+
+    connection.query(
+      `
+        SELECT email, u.client_id, COUNT(c.id) clip_count, c.created_at first_clip
+        FROM user_clients u
+        LEFT JOIN clips c ON u.client_id = c.client_id
+        WHERE email = ${clean_email}
+        GROUP BY u.client_id
+        ORDER BY c.created_at ASC;
+      `,
+      (error, results, fields) => {
+        if (error) throw error;
+        const userStats = parseResults(results, clean_email);
+
+        if (userStats.length) {
+          printUserStats(userStats);
+
+          readline.question(
+            `Are you sure you want to delete all data associated with ${clean_email}? \nThis CANNOT be reversed [Y/N] `,
+            answer => {
+              if (answer.toLowerCase() === 'y')
+                deleteUserRecords(connection, userStats, isLast);
+              else processIteration(isLast);
+            }
+          );
+        } else {
+          console.log(
+            `There are no user accounts associated with the email address ${clean_email}.`
+          );
+          processIteration(isLast);
+        }
+      }
+    );
+  } else {
+    setTimeout(() => {
+      deleteUser(connection, email, isLast);
+    }, 200);
+  }
+};
+
+try {
+  if (process.argv.length < 3)
+    throw new Error('Please enter at least one email address');
+  const emails = process.argv.slice(2);
+
+  const pool = mysql.createPool({
+    host: config.MYSQLHOST,
+    user: config.MYSQLUSER,
+    password: config.MYSQLPASS,
+    database: config.MYSQLDBNAME,
+  });
+
+  pool.getConnection((err, connection) => {
+    emails.map((email, index) => {
+      deleteUser(connection, email, index + 1 === emails.length);
+    });
+  });
+} catch (e) {
+  console.error(e.message);
+  process.exit(0);
+}

--- a/server/src/config-helper.ts
+++ b/server/src/config-helper.ts
@@ -29,6 +29,7 @@ export type CommonVoiceConfig = {
   REDIS_URL: string;
   KIBANA_URL: string;
   KIBANA_ADMINS: string;
+  LAST_DATASET: string;
 };
 
 const DEFAULTS: CommonVoiceConfig = {
@@ -61,6 +62,7 @@ const DEFAULTS: CommonVoiceConfig = {
   REDIS_URL: null,
   KIBANA_URL: null,
   KIBANA_ADMINS: null,
+  LAST_DATASET: '2019-06-12',
 };
 
 let injectedConfig: CommonVoiceConfig;


### PR DESCRIPTION
A pretty rough and basic node command line script for deleting user profiles. 

Expected behaviour: 

* Trigger by calling `node scripts/scrub-user.js [1+ email address, separated by spaces]` from root directory
* For each email address, command line will: 
  * Display a summary of the user's stats, with number of `client_id`s, number of clips, and date the first clip was submitted
  * Prompt for confirmation that this user profile should be deleted
  * If the user submitted clips, prompt for confirmation that the records for those clips should also be deleted
    * Add those `client_id`s to `deletionSummary` object for display later
    * If the first contribution from that user has been included in a past dataset, add those `client_ids` to `deletionSummary` object for display later
* Once all emails have been processed, print `deletionSummary `object with the `client_id`s to remove from S3, and any `client_id`s that we need to notify past dataset downloaders about

Right now this script doesn't automate deletion from S3, mostly because I don't have a personal instance set up with test files yet and I can't connect to the staging S3 locally. That'll be in the next iteration. I considered storing the deletion summary somewhere, but that seems like it goes against the spirit of removing user data on request, but I'm open to being persuaded otherwise. 