### PR TITLE
Revert PR #2225

### DIFF
--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -597,9 +597,9 @@ class SpeakPage extends React.Component<Props, State> {
           isFirstSubmit={user.recordTally === 0}
           isPlaying={this.isRecording}
           isSubmitted={isSubmitted}
-          onReset={this.resetState}
+          onReset={() => this.resetState()}
           onSkip={this.handleSkip}
-          onSubmit={this.upload}
+          onSubmit={() => this.upload()}
           primaryButtons={
             <RecordButton
               status={recordingStatus}

--- a/web/src/components/pages/contribution/success.tsx
+++ b/web/src/components/pages/contribution/success.tsx
@@ -31,26 +31,6 @@ const GoalPercentage = ({
   </span>
 );
 
-const ContributeMoreButton = (props: {
-  hasAccount: boolean;
-  children: React.ReactNode;
-  onClick: () => any;
-}) =>
-  props.hasAccount ? (
-    <Button
-      className="contribute-more-button"
-      rounded
-      onClick={props.onClick}
-      children={props.children}
-    />
-  ) : (
-    <TextButton
-      className="contribute-more-button secondary"
-      onClick={props.onClick}
-      children={props.children}
-    />
-  );
-
 function Success({
   getString,
   onReset,
@@ -110,6 +90,22 @@ function Success({
   const finalPercentage = Math.ceil(
     (100 * (contributionCount || 0)) / goalValue
   );
+
+  const ContributeMoreButton = (props: { children: React.ReactNode }) =>
+    hasAccount ? (
+      <Button
+        className="contribute-more-button"
+        rounded
+        onClick={onReset}
+        {...props}
+      />
+    ) : (
+      <TextButton
+        className="contribute-more-button secondary"
+        onClick={onReset}
+        {...props}
+      />
+    );
 
   const goalPercentage = (
     <GoalPercentage
@@ -173,7 +169,7 @@ function Success({
         </div>
       )}
 
-      <ContributeMoreButton hasAccount={hasAccount} onClick={onReset}>
+      <ContributeMoreButton>
         {type === 'speak' ? <MicIcon /> : <PlayOutlineIcon />}
         <Localized id="contribute-more" $count={SET_COUNT}>
           <span />


### PR DESCRIPTION
This addresses a new spike in Sentry error logs after the deployment to Prod on Dec 6th, and I think is related to bug #2459: 
* https://sentry.io/organizations/mozilla-q6/issues/1376071679/?query=is%3Aunresolved&sort=freq&statsPeriod=7d
* https://sentry.io/organizations/mozilla-q6/issues/1376100317/?query=is%3Aunresolved&sort=freq&statsPeriod=7d

Looking through the history of `speak.tsx` it looks like the `onReset` and `onSubmit` callbacks were intentionally passed as functions rather than references. It would be worth revisiting the purpose of the original PR to avoid re-rendering the contribute button unnecessarily, but as there is a December snippet campaign launching midnight UTC of Dec 10 I wanted to make sure core site functions were working first. 