### PR TITLE
Change default retry count

### DIFF
--- a/server/src/lib/redis.ts
+++ b/server/src/lib/redis.ts
@@ -4,7 +4,7 @@ import { getConfig } from '../config-helper';
 
 export const redis = new Redis(getConfig().REDIS_URL);
 
-export const redlock = new Redlock([redis], { retryCount: -1 });
+export const redlock = new Redlock([redis]);
 
 export const useRedis = new Promise(resolve => {
   redis.on('ready', () => {


### PR DESCRIPTION
Hey @Gregoor - we're running into a bunch of issues with Redis just spinning itself into a frenzy trying to acquire a lock and literally `eval`ing thousands of times per minute. Is there any danger you can think of if we changed the retryCount from infinite to the default of ten (or some other finite value)? 