### PR TITLE
Update Sentry configs

### DIFF
--- a/web/src/components/app.tsx
+++ b/web/src/components/app.tsx
@@ -346,9 +346,12 @@ class App extends React.Component {
       return;
     }
     const Sentry = await import('@sentry/browser');
-    Sentry.init({
-      dsn: 'https://e0ca8e37ef77492eb3ff46caeca385e5@sentry.io/1352219',
-    });
+
+    const dsn = isProduction()
+      ? 'https://4a940c31e4e14d8fa6984e919a56b9fa@sentry.prod.mozaws.net/491'
+      : 'https://553b76047f07421790c3a7a2fc71ecb6@sentry.prod.mozaws.net/492';
+
+    Sentry.init({ dsn });
     Sentry.withScope(scope => {
       Object.keys(errorInfo).forEach(key => {
         scope.setExtra(key, errorInfo[key]);

--- a/web/src/components/app.tsx
+++ b/web/src/components/app.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-router';
 import { Router } from 'react-router-dom';
 import { createBrowserHistory } from 'history';
+import * as Sentry from '@sentry/browser';
 import { UserClient } from 'common/user-clients';
 import store from '../stores/root';
 import URLS from '../urls';
@@ -329,6 +330,13 @@ class App extends React.Component {
     }
 
     this.userLocales = negotiateLocales(navigator.languages);
+
+    Sentry.init({
+      dsn:
+        'https://4a940c31e4e14d8fa6984e919a56b9fa@sentry.prod.mozaws.net/491',
+      environment: isProduction() ? 'prod' : 'stage',
+      release: process.env.GIT_COMMIT_SHA || null,
+    });
   }
 
   async componentDidMount() {
@@ -342,16 +350,8 @@ class App extends React.Component {
   async componentDidCatch(error: Error, errorInfo: any) {
     this.setState({ error });
 
-    if (!isProduction() && !isStaging()) {
-      return;
-    }
-    const Sentry = await import('@sentry/browser');
+    if (!isProduction() && !isStaging()) return;
 
-    const dsn = isProduction()
-      ? 'https://4a940c31e4e14d8fa6984e919a56b9fa@sentry.prod.mozaws.net/491'
-      : 'https://553b76047f07421790c3a7a2fc71ecb6@sentry.prod.mozaws.net/492';
-
-    Sentry.init({ dsn });
     Sentry.withScope(scope => {
       Object.keys(errorInfo).forEach(key => {
         scope.setExtra(key, errorInfo[key]);


### PR DESCRIPTION
* Moves our Sentry logging from a free Sentry.io instance to the paid version we get through the Mozilla Ops Sentry
* Adds an environment variable to differentiate staging and prod
* Adds release tagging for when we move to K8s
* Moves Sentry importing and initializing out of `componentDidCatch` - if I was reading that correctly it was being re-initialized with every error, which can't have been good for performance. 