### PR TITLE
Handle HTTP => HTTPS redirection in prod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
     fi
   - echo "Branch $SAFE_BRANCH_NAME"
   - echo "Tag $TRAVIS_TAG"
-  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; fi
   - if [ "$TRAVIS_TAG" == "" ]; then docker pull "$IMAGE_NAME:$SYMBOLIC_TAG" || true
     ; fi
 after_script:

--- a/nubis/puppet/web.pp
+++ b/nubis/puppet/web.pp
@@ -112,11 +112,4 @@ apache::vhost { $project_name:
 
       # Security Headers
     ],
-    rewrites           => [
-      {
-        comment      => 'HTTPS redirect',
-        rewrite_cond => ['%{HTTP:X-Forwarded-Proto} =http'],
-        rewrite_rule => ['. https://%{HTTP:Host}%{REQUEST_URI} [L,R=permanent]'],
-      }
-    ]
 }

--- a/nubis/puppet/web.pp
+++ b/nubis/puppet/web.pp
@@ -111,12 +111,6 @@ apache::vhost { $project_name:
       "set X-Nubis-Build   ${packer_build_name}",
 
       # Security Headers
-      'set X-Content-Type-Options "nosniff"',
-      'set X-XSS-Protection "1; mode=block"',
-      'set X-Frame-Options "DENY"',
-      'set Strict-Transport-Security "max-age=31536000"',
-      # media-src blob: is required for recording audio.
-      'set Content-Security-Policy "default-src \'none\'; style-src \'self\' \'unsafe-inline\' https://fonts.googleapis.com https://optimize.google.com; img-src \'self\' www.google-analytics.com www.gstatic.com https://optimize.google.com https://www.gstatic.com https://gravatar.com data:; media-src data: blob: https://*.amazonaws.com https://*.amazon.com; script-src \'self\' \'unsafe-eval\' \'sha256-yybRmIqa26xg7KGtrMnt72G0dH8BpYXt7P52opMh3pY=\' \'sha256-jfhv8tvvalNCnKthfpd8uT4imR5CXYkGdysNzQ5599Q=\' https://www.google-analytics.com https://pontoon.mozilla.org https://optimize.google.com https://sentry.io; font-src \'self\' https://fonts.gstatic.com; connect-src \'self\' https://pontoon.mozilla.org/graphql https://www.gstatic.com https://www.google-analytics.com https://*.amazonaws.com https://sentry.io https://basket.mozilla.org; frame-src https://optimize.google.com;"'
     ],
     rewrites           => [
       {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "concurrently": "^4.1.1",
     "fluent-syntax": "^0.14.0",
+    "http-status-codes": "^1.4.0",
     "prettier": "^1.18.2",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4747,6 +4747,11 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+http-status-codes@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/http-status-codes/-/http-status-codes-1.4.0.tgz#6e4c15d16ff3a9e2df03b89f3a55e1aae05fb477"
+  integrity sha512-JrT3ua+WgH8zBD3HEJYbeEgnuQaAnUeRRko/YojPAJjGmIfGD3KPU/asLdsLwKjfxOmQe5nXMQ0pt/7MyapVbQ==
+
 https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"


### PR DESCRIPTION
Handle HTTP => HTTPS redirection in PROD

This is based on the X-Forwarded-Protocol header set by upstream reverse-proxies, like ELBs and the like

Fixes #2482
Depends On #2481 

Sneaking in:
- http-status-codes for human-readeable http status codes
- [travis] skip docker login when building a PR