### PR TITLE
add hashing to bundle output

### DIFF
--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
   entry: './src/main.ts',
   output: {
     path: OUTPUT_PATH,
-    filename: 'bundle.js',
+    filename: 'bundle.[chunkhash].js',
     publicPath: '/dist/',
   },
   devtool: 'source-map',


### PR DESCRIPTION
Based on [this thread and associated links](https://github.com/webpack/webpack/issues/7502), I think we can solve all of the "failed loading chunk" issues with this setting. However, I just turned on Moz-hosted Sentry on staging, and our freebie version of Sentry never separated by environment, so I have a hard time figuring out how much that is actually an issue on staging. 

I'm just leaving this here pending all the other dependency updates, and once there's a bit more info in staging Sentry we can push this to master to test the actual impact. No rush on this.