### PR TITLE
RFC: Add validated_at column to clips table

### DIFF
--- a/server/src/lib/model/db/migrations/20191219191744-add-clip-validated-at.ts
+++ b/server/src/lib/model/db/migrations/20191219191744-add-clip-validated-at.ts
@@ -1,0 +1,10 @@
+export const up = async function(db: any): Promise<any> {
+  // Note: Manual backfill to follow.
+  return db.runSql(`
+    ALTER TABLE clips ADD COLUMN validated_at DATE DEFAULT NULL;
+  `);
+};
+
+export const down = function(): Promise<any> {
+  return null;
+};


### PR DESCRIPTION
To reduce server load, we want to cache some dynamic properties on clips so we
don't need to query the votes table as often. We're already storing `is_valid`,
but knowing _when_ validation happens is also important.

This RFC includes an example of how existing queries could be simplified. See
the modified query in getClipsStats().