### PR TITLE
Fix #2447: re-center custom goals progress

### DIFF
--- a/web/src/components/pages/dashboard/goals/custom-goal.css
+++ b/web/src/components/pages/dashboard/goals/custom-goal.css
@@ -422,6 +422,7 @@
         }
 
         & .goal-box {
+            align-items: center;
             border: 1.6px solid var(--grey);
             border-radius: 5px;
             margin-bottom: 70px;
@@ -442,11 +443,6 @@
 
             color: var(--color);
             --type-color: var(--color);
-
-            & .fraction {
-                position: relative;
-                top: 9px;
-            }
 
             & .relative {
                 display: flex;

--- a/web/src/components/pages/dashboard/ui.tsx
+++ b/web/src/components/pages/dashboard/ui.tsx
@@ -48,7 +48,7 @@ const RADIUS = 32;
 const STROKE = 2;
 
 export function CircleProgress({
-  className,
+  className = '',
   value,
   denominator,
   radius = RADIUS,


### PR DESCRIPTION
From this:

![image](https://user-images.githubusercontent.com/1840854/71279461-d0617a00-2326-11ea-8e97-8ac43f69dbfa.png)

to this:

<img width="377" alt="image" src="https://user-images.githubusercontent.com/1840854/71279091-b7f15f80-2326-11ea-99bd-09589ead1645.png">

Tested on http://localhost:9000/en/dashboard/en/goals