### PR TITLE
Add migration script for rewriting locale_ids

### DIFF
--- a/server/src/lib/model/db/migrations/20191227183100-match-clip-sentence-locale.ts
+++ b/server/src/lib/model/db/migrations/20191227183100-match-clip-sentence-locale.ts
@@ -1,0 +1,14 @@
+export const up = async function(db: any): Promise<any> {
+  // Note: Manual backfill to follow.
+  return db.runSql(`
+    UPDATE clips
+    INNER JOIN sentences
+    	ON clips.original_sentence_id = sentences.id
+  	SET clips.locale_id = sentences.locale_id
+    WHERE clips.locale_id <> sentences.locale_id
+  `);
+};
+
+export const down = function(): Promise<any> {
+  return null;
+};


### PR DESCRIPTION
In investigating issue #2488, discovered that there are ~650 clips whose `locale_id` do not match that of the original sentence. I'm not sure why this is happening because it seems pretty intermittent: the issue happened a BUNCH on May 9th 2018, then a handful of times on June 1st 2019, July 16 2019, Oct 18th 2019, Nov 2nd 2019, Nov 23rd 2019, and then steadily but not overwhelmingly since Dec 7th. My best guess based on timing is that this might be related to server load, since the dates in Oct/Nov coincide with big bugs we had to fix, and we've been fighting server performance issues all December but I haven't been able to find anything in the code that would point to that being a problem.

In the absence of any sort of useful debugging information, I want to update all of the offending clips so that the `locale_ids` DO match so that the users aren't affected, and keep an eye on this. Hopefully, the next time this happens again we might actually be able to correlate Kibana/Sentry error logs with the timing of the clip being saved. 