### PR TITLE
UI[web]: Fix background size in dataset page

### DIFF
--- a/web/src/components/pages/datasets/dataset-info.css
+++ b/web/src/components/pages/datasets/dataset-info.css
@@ -47,7 +47,7 @@
         @media (--md-down) {
             padding: 70px 0;
             background: url('images/intro-bg-md.svg');
-            background-size: 100% 100%;
+            background-size: cover;
 
             & h1,
             & button,

--- a/web/src/components/pages/datasets/subscribe.css
+++ b/web/src/components/pages/datasets/subscribe.css
@@ -10,7 +10,7 @@
         padding: 30px 20px;
         flex-direction: column;
         background: url('images/email-bg-md.svg');
-        background-size: 100% 100%;
+        background-size: cover;
     }
 
     @media (--lg-up) {


### PR DESCRIPTION
The background image set using CSS contained within the div instead of covering the entire background. This led to issues like:
* Displeasing UI
* The heading getting hidden in the white background
This is prominent on screens of tablet.

### Visual Changes
#### Heading
Before:
![Imgur](https://i.imgur.com/Bwvyw1x.png) 
After:
![Imgur](https://i.imgur.com/L5WtBCM.png)

#### Newsletter Subscription
Before:
![Imgur](https://i.imgur.com/SdBgzSH.png)
After:
![Imgur](https://i.imgur.com/089s6s3.png)

**Edit**
Issue in focus: #2520 