### PR TITLE
UI[web]: Fix accessibility issue with checkbox of Newsletter subscription

### DIFF
--- a/web/src/components/pages/datasets/subscribe.css
+++ b/web/src/components/pages/datasets/subscribe.css
@@ -107,6 +107,10 @@
             border-radius: 2px;
         }
 
+        & .checkbox-container input {
+            background-color: var(--near-black);
+        }
+
         & .checkmark path {
             fill: #f9f9f8;
         }


### PR DESCRIPTION
Checkbox's white background masked the tick mark.
This led to the scenario where one couldn't say whether the checkbox was clicked or not.

There is currently no open issue regarding this however this seems like an inconvenience to the users.

### Changes visualized
* Before when box was checked
![Imgur](https://i.imgur.com/MCbNDrM.png)
* Now when the box is checked
![Imgur](https://i.imgur.com/lFCxRH4.png)
One can clearly make out whether the checkbox is ticked in the second photo as compared to the first one where the check mark blends with the white background.