### PR TITLE
UI[web]: Fix centering on dataset pages

### DIFF
--- a/web/src/components/pages/datasets/dataset-info.css
+++ b/web/src/components/pages/datasets/dataset-info.css
@@ -309,6 +309,13 @@
         }
 
         & .text {
+            @media (--md-down) {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                text-align: center;
+            }
+
             & .line {
                 width: 70px;
                 height: 3px;

--- a/web/src/components/pages/datasets/resources.css
+++ b/web/src/components/pages/datasets/resources.css
@@ -5,6 +5,7 @@
     background: var(--lighter-grey);
 
     @media (--md-down) {
+        align-items: center;
         flex-direction: column;
         padding: 60px 20px 0;
     }


### PR DESCRIPTION
On a medium sized screen, the elements align to the left instead of the center.

#### Issue in focus
There are currently no issues relating to this but the alignment looks odd on the tablet screens where the layout has elements aligning both to the left and the center.

### Visual Changes
* **Before**:
Data information:
![Imgur](https://i.imgur.com/DIrB1h1.png)
Tiles:
![Imgur](https://i.imgur.com/F3y2NUD.png)

* **After**
Data information:
![Imgur](https://i.imgur.com/v2GZ42f.png)
Tiles:
![Imgur](https://i.imgur.com/9qD6AKs.png)