### PR TITLE
UI[web]: Alignheading in awards section of dashboard

### DIFF
--- a/web/src/components/pages/dashboard/awards/awards.css
+++ b/web/src/components/pages/dashboard/awards/awards.css
@@ -17,6 +17,7 @@
         margin-bottom: 30px;
         font-family: var(--base-font-family);
         font-size: 48px;
+        text-align: center;
         font-weight: normal;
     }
 
@@ -33,6 +34,7 @@
     & p {
         max-width: 270px;
         line-height: 1.5;
+        text-align: center;
     }
 }
 


### PR DESCRIPTION
This center aligns the heading in the `no-awards-page` section in the awards page. The page is designed to center align the paragraphs and the buttons but the heading is left aligned. This disrupts the page styling on tablet screen especially that of an iPad.

#### Issue in focus
There are no issues related to this. This make the design consistent for smaller screen devices.

### Visual Changes
* **Before**
![Imgur](https://i.imgur.com/rF22yUX.png)
* **After**
![Imgur](https://i.imgur.com/UFciqCy.png)

The changes were tested using the responsive mode on Firefox 71 and Chromium 79