### PR TITLE
UI[web]: Center Get Involved sectionfor tablet viewport size

### DIFF
--- a/web/src/components/pages/about/get-involved.css
+++ b/web/src/components/pages/about/get-involved.css
@@ -96,6 +96,7 @@
             display: flex;
             flex-direction: column;
             justify-content: center;
+            width: 100%;
             z-index: var(--middle-z-index);
             position: relative;
             p {


### PR DESCRIPTION
The Get Involved section of the About page wasn't centered once the viewport width dropped below 768px and flex-direction changed as a result of media query. The section snapped to the left. The UI inconsistency isn't noticeable much on desktop or mobile device but its much more pronounced in tablets.
Adding width:100% expands the div to the maximum width effectively centering the section.

**Issue in Focus**
There are no issues related to this PR. This fixes a small disruption in the UI making the whole page consistent with everything centered. The rogue div snapping to left is brought in line.

### Changes Visualized

* **Before**
![Imgur](https://i.imgur.com/6h0emC9.png)

* **After**
![Imgur](https://i.imgur.com/TnYPoxo.png)

Above, 768px, the UI is still consistent with the previous version and this doesn't break the UI anywhere.

![Imgur](https://i.imgur.com/1yHFOUm.png)