### PR TITLE
Improve alignment of "How does it work" icons on /about

### DIFF
--- a/web/src/components/pages/about/how-it-works.css
+++ b/web/src/components/pages/about/how-it-works.css
@@ -101,8 +101,9 @@
 
         & .icon {
             position: absolute;
-            left: -32px;
+            left: 0;
             top: 1rem;
+            transform: translateX(-50%);
         }
 
         & .center-arrow {
@@ -151,8 +152,8 @@
 
             .icon {
                 position: relative;
-                left: 0;
                 top: 0;
+                transform: none;
                 margin-bottom: 1.25rem;
             }
 


### PR DESCRIPTION
In the screenshots for #2516, icons are not properly centered on the
left edge of their corresponding textboxes. This commit updates the icon
CSS to not rely on image dimensions; they should always be properly
aligned now.

Test plan:

• Navigate to /about
• Scroll down to "How does it work?"
• Ensure icons are centered on the left edge of their textboxes, at both
  desktop and mobile widths (and in any language).