### PR TITLE
Move GitHub link from pre-footer to footer

### DIFF
--- a/web/src/components/layout/footer.tsx
+++ b/web/src/components/layout/footer.tsx
@@ -38,11 +38,6 @@ export default React.memo(() => {
           </Localized>
         </LocaleLink>
         <div className="divider" />
-        <GitHubLink id="contribute">
-          <GithubIcon />
-          <div>GitHub</div>
-        </GitHubLink>
-        <div className="divider" />
         <DiscourseLink id="discourse">
           <DiscourseIcon />
           <div>Discourse</div>
@@ -76,15 +71,16 @@ export default React.memo(() => {
           <div>
             <LocalizedLocaleLink id="privacy" to={URLS.PRIVACY} />
             <LocalizedLocaleLink id="terms" to={URLS.TERMS} />
-          </div>
-          <div>
             <Localized id="cookies">
               <a
                 target="_blank"
                 href="https://www.mozilla.org/en-US/privacy/websites/#cookies"
               />
             </Localized>
+          </div>
+          <div>
             <LocalizedLocaleLink id="faq" to={URLS.FAQ} />
+            <GitHubLink>GitHub</GitHubLink>
           </div>
         </div>
 


### PR DESCRIPTION
Addresses https://jira.mozilla.com/browse/OI-1446

Before:

<img width="613" alt="Screen Shot 2020-02-19 at 5 56 15 PM" src="https://user-images.githubusercontent.com/1840854/74893459-498a4700-5341-11ea-987e-d40161b7caa7.png">

After:

<img width="607" alt="Screen Shot 2020-02-19 at 5 56 24 PM" src="https://user-images.githubusercontent.com/1840854/74893469-4d1dce00-5341-11ea-98a3-c283b95e00c2.png">
