### PR TITLE
Finish recording Prompt

### DIFF
--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -16,16 +16,12 @@ import { User } from '../../../../stores/user';
 import API from '../../../../services/api';
 import { trackRecording, getTrackClass } from '../../../../services/tracker';
 import URLS from '../../../../urls';
-import {
-  localeConnector,
-  LocaleLink,
-  LocalePropsFromState,
-} from '../../../locale-helpers';
+import { localeConnector, LocalePropsFromState } from '../../../locale-helpers';
 import Modal, { ModalButtons } from '../../../modal/modal';
 import TermsModal from '../../../terms-modal';
 import { CheckIcon, FontIcon, MicIcon, StopIcon } from '../../../ui/icons';
 import { Button, TextButton } from '../../../ui/ui';
-import { getItunesURL, isFirefoxFocus, isNativeIOS } from '../../../../utility';
+import { isFirefoxFocus, isNativeIOS } from '../../../../utility';
 import ContributionPage, {
   ContributionPillProps,
   SET_COUNT,

--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -517,6 +517,7 @@ class SpeakPage extends React.Component<Props, State> {
                     className={getTrackClass('fs', 'exit-submit-clips')}
                     onClick={() => {
                       if (this.upload()) onConfirm();
+                      this.resetAndGoHome();
                     }}
                   />
                 </Localized>


### PR DESCRIPTION
Adding `resetAndGoHome() ` to the Submit Recording Button which will close the Prompt when the Clip Recording is Uploaded.
This Pull request will Solve #2038 
