### PR TITLE
Fixing Menu

### DIFF
--- a/web/src/components/layout/nav.css
+++ b/web/src/components/layout/nav.css
@@ -346,6 +346,10 @@ header {
         pointer-events: all;
         transition-duration: var(--transition-duration-slow);
         visibility: visible;
+
+        @media (--lg-up) {
+            display: none;
+        }
     }
 
     & .nav-list,


### PR DESCRIPTION
Fixes  #1631 
Follows the following properties :
If the mobile navigation was open at small screen size, it should:
-  close when the user resizes the screen to be a full desktop size
-  re-open if the user resizes the screen to be a small size again

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/43513114/76337656-ae700600-631d-11ea-9127-73ba7c0d8726.gif)
