### PR TITLE
Run optional chaining codemod and Prettier

### DIFF
--- a/server/src/auth-router.ts
+++ b/server/src/auth-router.ts
@@ -119,7 +119,7 @@ router.get(
         session.passport.user = old_user;
       }
       response.redirect('/profile/settings?success=' + success.toString());
-    } else if (enrollment && enrollment.challenge && enrollment.team) {
+    } else if (enrollment?.challenge && enrollment.team) {
       if (
         !(await UserClient.enrollRegisteredUser(
           user.emails[0].value,

--- a/server/src/config-helper.ts
+++ b/server/src/config-helper.ts
@@ -3,7 +3,7 @@ import { S3, SSM } from 'aws-sdk';
 import { config } from 'dotenv';
 
 if (process.env.DOTENV_CONFIG_PATH) {
-  const result = config({path: process.env.DOTENV_CONFIG_PATH});
+  const result = config({ path: process.env.DOTENV_CONFIG_PATH });
   if (result.error) {
     console.log(result.error);
     console.log('Failed loading dotenv file, using defaults');
@@ -51,7 +51,8 @@ const castDefault = (value: string): any => value;
 const castBoolean = (value: string): boolean => value === 'true';
 const castInt = (value: string): number => parseInt(value);
 const castJson = (value: string): object => JSON.parse(value);
-const configEntry = (key: string, defaultValue: any, cast = castDefault) => ((process.env[key]) ? cast(process.env[key]) : defaultValue);
+const configEntry = (key: string, defaultValue: any, cast = castDefault) =>
+  process.env[key] ? cast(process.env[key]) : defaultValue;
 
 const BASE_CONFIG: CommonVoiceConfig = {
   VERSION: configEntry('CV_VERSION', null), // Migration number (e.g. 20171205171637), null = most recent
@@ -72,10 +73,14 @@ const BASE_CONFIG: CommonVoiceConfig = {
   ENVIRONMENT: configEntry('ENVIRONMENT', 'default'),
   SECRET: configEntry('CV_SECRET', 'super-secure-secret'),
   ADMIN_EMAILS: configEntry('CV_ADMIN_EMAILS', null),
-  S3_CONFIG: configEntry('CV_S3_CONFIG', {
-    signatureVersion: 'v4',
-    useDualstack: true,
-  }, castJson),
+  S3_CONFIG: configEntry(
+    'CV_S3_CONFIG',
+    {
+      signatureVersion: 'v4',
+      useDualstack: true,
+    },
+    castJson
+  ),
   SSM_ENABLED: configEntry('CV_SSM_ENABLED', false, castBoolean),
   SSM_CONFIG: configEntry('CV_SSM_CONFIG', {}, castJson),
   AUTH0: {
@@ -89,7 +94,7 @@ const BASE_CONFIG: CommonVoiceConfig = {
   KIBANA_PREFIX: configEntry('CV_KIBANA_PREFIX', '/_plugin/kibana'),
   KIBANA_ADMINS: configEntry('CV_KIBANA_ADMINS', null),
   LAST_DATASET: configEntry('CV_LAST_DATASET', '2019-06-12'),
-  SENTRY_DSN: configEntry('CV_SENTRY_DSN', '')
+  SENTRY_DSN: configEntry('CV_SENTRY_DSN', ''),
 };
 
 let injectedConfig: CommonVoiceConfig;
@@ -98,14 +103,14 @@ let loadedConfig: CommonVoiceConfig;
 const ssm = new SSM(BASE_CONFIG.SSM_CONFIG);
 
 async function getSecret(key: string) {
-  const path = `/voice/${BASE_CONFIG.ENVIRONMENT}/${key}`
+  const path = `/voice/${BASE_CONFIG.ENVIRONMENT}/${key}`;
   const params = {
     Name: path,
-    WithDecryption: true
-  }
-  const secret = await ssm.getParameter(params).promise()
+    WithDecryption: true,
+  };
+  const secret = await ssm.getParameter(params).promise();
 
-  return secret.Parameter.Value
+  return secret.Parameter.Value;
 }
 
 let loadedSecrets: Partial<CommonVoiceConfig>;
@@ -113,13 +118,13 @@ let loadedSecrets: Partial<CommonVoiceConfig>;
 export async function getSecrets(): Promise<Partial<CommonVoiceConfig>> {
   if (loadedSecrets) {
     console.log('Use pre-loaded secrets');
-    return loadedSecrets
+    return loadedSecrets;
   }
 
-  loadedSecrets = {}
+  loadedSecrets = {};
 
   if (BASE_CONFIG.SSM_ENABLED) {
-    console.log('Fetch SSM secrets.')
+    console.log('Fetch SSM secrets.');
     loadedSecrets = {
       MYSQLPASS: await getSecret('mysql-user-pw'),
       DB_ROOT_PASS: await getSecret('mysql-root-pw'),
@@ -129,9 +134,9 @@ export async function getSecrets(): Promise<Partial<CommonVoiceConfig>> {
       AUTH0: {
         DOMAIN: await getSecret('auth0-domain'),
         CLIENT_ID: await getSecret('auth0-client-id'),
-        CLIENT_SECRET: await getSecret('auth0-client-secret')
-      }
-    }
+        CLIENT_SECRET: await getSecret('auth0-client-secret'),
+      },
+    };
   }
   return loadedSecrets;
 }
@@ -160,7 +165,7 @@ export function getConfig(): CommonVoiceConfig {
     }
   }
 
-  loadedConfig = {...BASE_CONFIG, ...loadedSecrets, ...fileConfig}
+  loadedConfig = { ...BASE_CONFIG, ...loadedSecrets, ...fileConfig };
 
-  return loadedConfig
+  return loadedConfig;
 }

--- a/server/src/lib/model/achievements.ts
+++ b/server/src/lib/model/achievements.ts
@@ -117,7 +117,7 @@ export const earnBonus = async (type: AchievementType, args: any[]) => {
           `,
       [type, bonus_winner]
     );
-    earned = ret && ret[0] && ret[0].affectedRows > 0 ? true : false;
+    earned = ret?.[0]?.affectedRows > 0;
   }
   return earned;
 };
@@ -140,5 +140,5 @@ export const hasEarnedBonus = async (
     [type, client_id, challenge]
   );
 
-  return !!(earned && earned[0] && earned[0][0] && earned[0][0].earned);
+  return !!earned?.[0]?.[0]?.earned;
 };

--- a/server/src/lib/model/user-client.ts
+++ b/server/src/lib/model/user-client.ts
@@ -1,5 +1,5 @@
 import pick = require('lodash.pick');
-import { UserClient } from 'common';
+import { UserClient as UserClientType } from 'common';
 import Awards from './awards';
 import CustomGoal from './custom-goal';
 import { getLocaleId } from './db';
@@ -97,7 +97,7 @@ const UserClient = {
     );
   },
 
-  async findAccount(email: string): Promise<UserClient> {
+  async findAccount(email: string): Promise<UserClientType> {
     const [rows] = await db.query(
       `
         SELECT DISTINCT
@@ -134,7 +134,7 @@ const UserClient = {
     return rows.length == 0
       ? null
       : rows.reduce(
-          (client: UserClient, row: any) => ({
+          (client: UserClientType, row: any) => ({
             ...pick(
               row,
               'accent',
@@ -169,8 +169,8 @@ const UserClient = {
 
   async saveAccount(
     email: string,
-    { client_id, locales, ...data }: UserClient
-  ): Promise<UserClient> {
+    { client_id, locales, ...data }: UserClientType
+  ): Promise<UserClientType> {
     let [accountClientId, [clients]] = await Promise.all([
       UserClient.findClientId(email),
       email
@@ -214,8 +214,7 @@ const UserClient = {
     ]);
 
     if (
-      data &&
-      data.enrollment &&
+      data?.enrollment &&
       (await this.enrollRegisteredUser(
         email,
         data.enrollment.challenge,
@@ -246,7 +245,7 @@ const UserClient = {
       [client_id]
     );
 
-    if (row && row.has_login) return false;
+    if (row?.has_login) return false;
 
     if (row) {
       await db.query(
@@ -364,7 +363,7 @@ const UserClient = {
             referer || null,
           ]
         );
-        return res && res[0] && res[0].affectedRows > 0;
+        return res?.[0]?.affectedRows > 0;
       }
     }
     return false;

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,15 +1,15 @@
-import { getConfig, getSecrets } from './config-helper'
-import Server from './server'
+import { getConfig, getSecrets } from './config-helper';
+import Server from './server';
 
 async function initialize() {
   await getSecrets();
 }
 
 async function runServer() {
-  await initialize()
+  await initialize();
 
   // Handle any top-level exceptions uncaught in the app.
-  process.on('uncaughtException', function (err: any) {
+  process.on('uncaughtException', function(err: any) {
     if (err.code === 'EADDRINUSE') {
       // For now, do nothing when we are unable to start the http server.
       console.error('ERROR: server already running');

--- a/web/src/components/app.tsx
+++ b/web/src/components/app.tsx
@@ -116,12 +116,11 @@ let LocalizedPage: any = class extends React.Component<
       await this.prepareBundleGenerator(nextProps);
     }
 
-    const award =
-      account && account.awards
-        ? account.awards.find(
-            a => !a.notification_seen_at && !this.seenAwardIds.includes(a.id)
-          )
-        : null;
+    const award = account?.awards
+      ? account.awards.find(
+          a => !a.notification_seen_at && !this.seenAwardIds.includes(a.id)
+        )
+      : null;
 
     if (award) {
       this.seenAwardIds.push(...account.awards.map(a => a.id));

--- a/web/src/components/layout/layout.tsx
+++ b/web/src/components/layout/layout.tsx
@@ -202,10 +202,7 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
     });
 
     const alreadyEnrolled =
-      this.state.showWelcomeModal &&
-      user.account &&
-      user.account.enrollment &&
-      user.account.enrollment.challenge;
+      this.state.showWelcomeModal && user.account?.enrollment?.challenge;
     const redirectURL = URLS.DASHBOARD + URLS.CHALLENGE;
 
     return (

--- a/web/src/components/pages/contribution/contribution.tsx
+++ b/web/src/components/pages/contribution/contribution.tsx
@@ -172,7 +172,7 @@ class ContributionPage extends React.Component<Props, State> {
       isPlaying ? this.wave.play() : this.wave.idle();
     }
 
-    if (isSubmitted && user.account && user.account.skip_submission_feedback) {
+    if (isSubmitted && user.account?.skip_submission_feedback) {
       onReset();
     }
   }

--- a/web/src/components/pages/contribution/speak/audio-web.ts
+++ b/web/src/components/pages/contribution/speak/audio-web.ts
@@ -57,7 +57,7 @@ export default class AudioWeb {
         res(stream);
       }
 
-      if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+      if (navigator.mediaDevices?.getUserMedia) {
         navigator.mediaDevices
           .getUserMedia({ audio: true })
           .then(resolve, deny);
@@ -77,7 +77,7 @@ export default class AudioWeb {
   // Check all the browser prefixes for microhpone support.
   isMicrophoneSupported() {
     return (
-      (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) ||
+      navigator.mediaDevices?.getUserMedia ||
       navigator.getUserMedia ||
       navigator.webkitGetUserMedia ||
       navigator.mozGetUserMedia

--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -640,7 +640,7 @@ class SpeakPage extends React.Component<Props, State> {
                 ? null
                 : clips[recordingIndex].sentence.id,
           }}
-          sentences={clips.map(({ sentence }) => sentence && sentence.text)}
+          sentences={clips.map(({ sentence }) => sentence?.text)}
           shortcuts={[
             {
               key: 'shortcut-record-toggle',

--- a/web/src/components/pages/dashboard/challenge/challenge.tsx
+++ b/web/src/components/pages/dashboard/challenge/challenge.tsx
@@ -104,11 +104,7 @@ function ChallengePage(props: Props & RouteComponentProps<any, any, any>) {
   }, []);
   useEffect(() => trackChallenge('dashboard-view'), []);
 
-  const isEnrolled =
-    account &&
-    account.enrollment &&
-    account.enrollment.team &&
-    account.enrollment.challenge;
+  const isEnrolled = account?.enrollment?.team && account.enrollment.challenge;
 
   return !isEnrolled ? (
     <Redirect to={URLS.DASHBOARD} /> // TODO: it shouldn't even try to fetch any challenge data in useEffect if not enrolled
@@ -128,7 +124,7 @@ function ChallengePage(props: Props & RouteComponentProps<any, any, any>) {
         />
       )}
       {weekly && <WeeklyChallenge weekly={weekly} />}
-      {account && account.enrollment && (
+      {account?.enrollment && (
         <div className={`range-container ${showOverlay ? 'has-overlay' : ''}`}>
           {showOverlay && <Overlay hideOverlay={() => setShowOverlay(false)} />}
           <div className="leader-board">

--- a/web/src/components/pages/dashboard/challenge/constants.ts
+++ b/web/src/components/pages/dashboard/challenge/constants.ts
@@ -30,7 +30,7 @@ const isValidDate = (dateStr: string) => {
 const getNow = () => {
   const dateParam =
     location.search && location.search.match(/date=(\d+-\d+-\d+)/);
-  const date = dateParam && dateParam[1];
+  const date = dateParam?.[1];
   return date && isValidDate(date) ? new Date(date) : new Date();
 };
 
@@ -50,7 +50,7 @@ export const pilotDates: ChallengeDuration = {
 };
 
 export const isEnrolled = (account: UserClient) =>
-  account && account.enrollment && account.enrollment.challenge;
+  account?.enrollment?.challenge;
 
 export const weeklyChallengeCopy = [
   {

--- a/web/src/components/pages/dashboard/stats/leaderboard-card.tsx
+++ b/web/src/components/pages/dashboard/stats/leaderboard-card.tsx
@@ -347,7 +347,7 @@ export default function LeaderboardCard() {
       title="top-contributors"
       iconButtons={
         <div className="icon-buttons">
-          {Boolean(account && account.visible) && (
+          {Boolean(account?.visible) && (
             <>
               <button
                 type="button"

--- a/web/src/components/pages/datasets/subscribe.tsx
+++ b/web/src/components/pages/datasets/subscribe.tsx
@@ -71,7 +71,7 @@ class Subscribe extends React.Component<Props, State> {
     const privacyAgreed = account || this.state.privacyAgreed;
     const emailInput = this.emailInputRef.current;
 
-    if ((account && account.basket_token) || submitStatus == 'submitted') {
+    if (account?.basket_token || submitStatus == 'submitted') {
       return null;
     }
 

--- a/web/src/components/pages/landing/landing.tsx
+++ b/web/src/components/pages/landing/landing.tsx
@@ -10,9 +10,7 @@ import { LinkButton } from '../../ui/ui';
 import './landing.css';
 
 export default function Landing() {
-  const hasAccount = useTypedSelector(({ user }) =>
-    Boolean(user && user.account)
-  );
+  const hasAccount = useTypedSelector(({ user }) => Boolean(user?.account));
   return (
     <div className="partner-landing">
       <div className="partner-header">

--- a/web/src/components/pages/profile/info/info.tsx
+++ b/web/src/components/pages/profile/info/info.tsx
@@ -110,7 +110,7 @@ function ProfilePage({
 
     setUserFields({
       ...userFields,
-      sendEmails: !!(account && account.basket_token),
+      sendEmails: !!account?.basket_token,
       visible: 0,
       ...pick(user, 'age', 'username', 'gender'),
       ...(account
@@ -173,7 +173,7 @@ function ProfilePage({
     addUploads([
       async () => {
         await saveAccount(data);
-        if (!(user.account && user.account.basket_token) && sendEmails) {
+        if (!user.account?.basket_token && sendEmails) {
           await api.subscribeToNewsletter(user.userClients[0].email);
         }
 
@@ -337,7 +337,7 @@ function ProfilePage({
 
       <Hr />
 
-      {!(user.account && user.account.basket_token) && (
+      {!user.account?.basket_token && (
         <React.Fragment>
           <div className="signup-section">
             <Tooltip

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -33,10 +33,7 @@ interface Vote extends Event {
 const API_PATH = location.origin + '/api/v1';
 
 const getChallenge = (user: User.State): string => {
-  return user &&
-    user.account &&
-    user.account.enrollment &&
-    user.account.enrollment.challenge
+  return user?.account?.enrollment?.challenge
     ? user.account.enrollment.challenge
     : null;
 };

--- a/web/src/services/localization.ts
+++ b/web/src/services/localization.ts
@@ -30,9 +30,7 @@ function* asBundleGenerator(
     const bundle = new FluentBundle(locale, { useIsolating: false });
     bundle.addMessages(
       messages +
-        (messageOverwrites && messageOverwrites[locale]
-          ? '\n' + messageOverwrites[locale]
-          : '')
+        (messageOverwrites?.[locale] ? '\n' + messageOverwrites[locale] : '')
     );
     yield bundle;
   }

--- a/web/src/stores/clips.ts
+++ b/web/src/stores/clips.ts
@@ -124,12 +124,7 @@ export namespace Clips {
       if (!state.user.account) {
         dispatch(User.actions.tallyVerification());
       }
-      if (
-        state.user &&
-        state.user.account &&
-        state.user.account.enrollment &&
-        state.user.account.enrollment.challenge
-      ) {
+      if (state.user?.account?.enrollment?.challenge) {
         dispatch({
           type: ActionType.ACHIEVEMENT,
           showFirstContributionToast,

--- a/web/src/utility.ts
+++ b/web/src/utility.ts
@@ -38,11 +38,7 @@ export function countSyllables(text: string): number {
  * Test if we are running in the iOS native app wrapper.
  */
 export function isNativeIOS(): boolean {
-  return (
-    window['webkit'] &&
-    webkit.messageHandlers &&
-    webkit.messageHandlers.scriptHandler
-  );
+  return window.webkit && webkit.messageHandlers?.scriptHandler;
 }
 
 export function isFirefoxFocus(): boolean {


### PR DESCRIPTION
This is a pretty big change, so if it looks good we should land it sooner than later to avoid conflicts building up.

If we need to re-run it, here are the steps to reproduce:

```
npm i -g optional-chaining-codemod # https://github.com/villesau/optional-chaining-codemod
# From each source directory:
for d in $(find . -type d); do
  optional-chaining-codemod $d/*.ts --parser=ts;
  optional-chaining-codemod $d/*.tsx --parser=tsx;
done
yarn prettier
```

I did a bit of manual cleanup afterwards, but nothing to difficult.