### PR TITLE
UI[web]:Solve padding issue with the login/signup button in dropdown

### DIFF
--- a/web/src/components/ui/ui.css
+++ b/web/src/components/ui/ui.css
@@ -44,7 +44,7 @@
     color: var(--white);
     width: 100%;
 
-    @media (--md-up) {
+    @media (--lg-up) {
         width: auto;
         height: auto;
     }


### PR DESCRIPTION
The `LinkButton` used for `Login/Signup` and `Logout` button in options dropdown that appear for smaller viewport  used the CSS rule "height: auto", for --md-up whereas most of the UI transition, if not all happen at --lg-up for the Tablet viewport. Due to this fact, this change will not cause any regression for existing LinkButton in other places (dataset page, landing page, contribution, dashboard, notification-banner) - Most have them have custom CSS properties that override the `height: auto` and `width:auto` property

#### Issue in focus

There aren't any issues open dealing with this inconsistency.  The button's padding suddenly appears for width below `--md-up` and this leads to UI inconsistency.

#### Visualizing Changes:
* **Before**
![Imgur](https://i.imgur.com/WuZZkl6.png)
Going below the size defined by `--md-up`, the button expands as can be seen below:

![Imgur](https://i.imgur.com/hJa0zS5.png)

* **After**
![Imgur](https://i.imgur.com/lgj41uC.png)

To the best of my knowledge and testing, this doesn't cause any rogue behavior with `LinkButton`. I have checked with all the places that I found after running `grep -rn "<LinkButton" ./src `.
