### PR TITLE
Add resolutions pin for minimist

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "resolutions": {
     "cryptiles": "4.1.2",
     "event-stream": "3.3.4",
-    "@types/react": "16.9.19"
+    "@types/react": "16.9.19",
+    "minimist": "1.2.3"
   },
   "scripts": {
     "build": "yarn build-common && concurrently \"cd server && yarn build\" \"cd web/ && yarn build\"",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6590,20 +6590,10 @@ minimatch@3.0.4, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-minimist@^1.1.1, minimist@^1.2.0, minimist@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
-  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
+minimist@0.0.8, minimist@1.2.3, minimist@^1.1.1, minimist@^1.2.0, minimist@~0.0.1, minimist@~1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.3.tgz#3db5c0765545ab8637be71f333a104a965a9ca3f"
+  integrity sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==
 
 mississippi@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
There's a security vulnerability in `minimist`, which in our repo is mainly used by `db-migrate` and its dependencies: https://snyk.io/vuln/SNYK-JS-MINIMIST-559764

I've pinned a resolution for v1.2.3, which gave me some errors as some of db-migrate's dependencies are relying on minimist versions 0.0.1 (!!) and 0.0.8. I dropped my local db and re-ran all migrations and didn't have an error, so I think this is fine, but let me know if you found something in testing. 