### PR TITLE
Add prettier ignore file for sentence data

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+server/data/*


### PR DESCRIPTION
If you try to merge `master` into a local branch, prettier will try to process all the sentence text files it adds and format them. Mostly this is just annoying, sometimes this actually breaks prettier and results in a GC out of memory error, and either way you'll probably end up with annoying merge conflicts. 