### PR TITLE
Create 2500 validated hours target on lanugages page

### DIFF
--- a/web/src/components/pages/contribution/success.tsx
+++ b/web/src/components/pages/contribution/success.tsx
@@ -5,7 +5,7 @@ import {
 } from 'fluent-react/compat';
 import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
-import { DAILY_GOAL } from '../../../constants';
+import { DAILY_GOALS } from '../../../constants';
 import { useAccount, useAPI } from '../../../hooks/store-hooks';
 import { useTypedSelector } from '../../../stores/tree';
 import URLS from '../../../urls';
@@ -47,7 +47,7 @@ function Success({
   const hasAccount = Boolean(account);
   const customGoal =
     hasAccount && account.custom_goals?.find(g => g.locale == locale);
-  const goalValue = DAILY_GOAL[type];
+  const goalValue = DAILY_GOALS[type][0];
 
   const killAnimation = useRef(false);
   const startedAt = useRef(null);

--- a/web/src/components/pages/dashboard/stats/progress-card.tsx
+++ b/web/src/components/pages/dashboard/stats/progress-card.tsx
@@ -1,7 +1,7 @@
 import { Localized } from 'fluent-react/compat';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
-import { DAILY_GOAL } from '../../../../constants';
+import { DAILY_GOALS } from '../../../../constants';
 import { useAccount, useAPI } from '../../../../hooks/store-hooks';
 import { trackDashboard } from '../../../../services/tracker';
 import URLS from '../../../../urls';
@@ -50,7 +50,7 @@ export default function ProgressCard({
     fetchAndSetOverallCount();
   }, []);
 
-  const overallGoal = DAILY_GOAL[type];
+  const overallGoal = DAILY_GOALS[type][0];
   const isSpeak = type == 'speak';
   const customGoal = customGoals?.find(g => g.locale == locale);
   const currentCustomGoal = customGoal ? customGoal.current[type] : undefined;

--- a/web/src/components/pages/home/hero.tsx
+++ b/web/src/components/pages/home/hero.tsx
@@ -1,7 +1,7 @@
 import { Localized } from 'fluent-react/compat';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { DAILY_GOAL } from '../../../constants';
+import { DAILY_GOALS } from '../../../constants';
 import API from '../../../services/api';
 import { trackHome } from '../../../services/tracker';
 import { Locale } from '../../../stores/locale';
@@ -122,7 +122,7 @@ class Hero extends React.Component<
           />
           <div {...this.getToggleableProps(1, 'line ' + type)} />
           <div {...this.getToggleableProps(2)}>
-            <Localized id="help-reach-goal" $goal={DAILY_GOAL[type]}>
+            <Localized id="help-reach-goal" $goal={DAILY_GOALS[type][0]}>
               <div className="cta-message" />
             </Localized>
           </div>
@@ -135,7 +135,7 @@ class Hero extends React.Component<
             <span className="current">{count === null ? '?' : count}</span>
             <span className="total">
               {' / '}
-              {DAILY_GOAL[type]}
+              {DAILY_GOALS[type][0]}
             </span>
           </span>
           <p>

--- a/web/src/components/pages/languages/localization-box.tsx
+++ b/web/src/components/pages/languages/localization-box.tsx
@@ -1,6 +1,7 @@
 const { LocalizationProvider, Localized } = require('fluent-react/compat');
 import * as React from 'react';
 import { useState } from 'react';
+import { DAILY_GOALS } from '../../../constants';
 import { RouteComponentProps, withRouter } from 'react-router';
 import ContentLoader from 'react-content-loader';
 import { InProgressLanguage, LaunchedLanguage } from 'common';
@@ -13,7 +14,6 @@ import { Hr } from '../../ui/ui';
 import GetInvolvedModal from './get-involved-modal';
 
 const SENTENCE_COUNT_TARGET = 5000;
-const HOURS_TARGET = 1200;
 
 function formatSeconds(totalSeconds: number) {
   const seconds = totalSeconds % 60;
@@ -190,7 +190,10 @@ const LocalizationBox = React.memo((props: Props) => {
             </Localized>
           }
           progress={props.seconds}
-          progressTotal={HOURS_TARGET * 3600}
+          progressTotal={
+            (DAILY_GOALS.speak.find(goal => goal * 3600 > props.seconds) ||
+              DAILY_GOALS.speak[DAILY_GOALS.speak.length - 1]) * 3600
+          }
           formatProgress={formatSeconds}
           progressSecondary
           onClick={() => {

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -1,4 +1,7 @@
-export const DAILY_GOAL = Object.freeze({ speak: 1200, listen: 2400 });
+export const DAILY_GOALS = Object.freeze({
+  speak: [1200, 2500],
+  listen: [2400],
+});
 
 export const BENEFITS = [
   'rich-data',


### PR DESCRIPTION
Implements [OI-1458](https://jira.mozilla.com/browse/OI-1458)

re: https://discourse.mozilla.org/t/english-has-reached-its-goal-of-1200-hours-of-validated-hours-what-will-be-the-next-goal/53826,
this commit adds a _list_ of hour goals, so that popular languages (eg. English) can reach for higher targets.

I made the decision to keep all goals on the site the same except for
the language cards on /languages. I _think_ this makes sense, but I'm
happy to discuss! Let me know if you think we should do something
different.