### PR TITLE
Add indexing to sentences table

### DIFF
--- a/server/src/lib/model/db/migrations/20200402174044-add-composite-index-to-sentences.ts
+++ b/server/src/lib/model/db/migrations/20200402174044-add-composite-index-to-sentences.ts
@@ -1,0 +1,11 @@
+export const up = async function(db: any): Promise<any> {
+  return db.runSql(
+    `
+      ALTER TABLE sentences ADD INDEX locale_clip_ct_idx (locale_id, clips_count);
+    `
+  );
+};
+
+export const down = function(): Promise<any> {
+  return null;
+};


### PR DESCRIPTION
This adds a composite index to the `sentences` table which will dramatically increase the speed of serving up fresh sentences when users come to the site, which I've tested both with dummy data locally and on stage. This primarily targets the `findSentencesWithFewClips` function in `db.ts`, which does the horrifying thing of sorting the entire sentence set of a language by `clips_count`. If this deploys smoothly I imagine we'll want to revisit the indexes on the votes and clips table as well to see what gains we can get there.

I'm mostly following off logic from [this article](https://use-the-index-luke.com/sql/where-clause/the-equals-operator/concatenated-keys), happy to chat through offline.