### PR TITLE
Fix deployment condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ deploy:
   provider: script
   on:
     all_branches: true
-    condition: ($TRAVIS_TAG != "" || $TRAVIS_BRANCH =~ ^(master|production|stage)$) && !$TRAVIS_COMMIT_MESSAGE =~ ^Pontoon:*
+    condition: ($TRAVIS_TAG != "" || $TRAVIS_BRANCH =~ ^(master|production|stage)$) && ! $TRAVIS_COMMIT_MESSAGE =~ ^Pontoon:*
   script: docker push "$IMAGE_NAME:$REVISION_TAG" && docker push "$IMAGE_NAME:$SYMBOLIC_TAG"
 env:
   global:


### PR DESCRIPTION
@rileyjshaw found yesterday that after pushing a tag `stage-v1.25.2-ios-recording-web ` the deployment to stage wasn't done.
I've been looking into it and I'm mostly sure it was due to a missing space between the logical negation operator and the variable name.

Merging this to try to validate the assumption before your workday starts.