### PR TITLE
Add a note about Docker's memory settings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,8 @@ This is going to:
 
 You can visit the website at [http://localhost:9000](http://localhost:9000).
 
+**Note: running the development server is a memory-intensive process. If you notice intermittent failures, or if features like auto-rebuilding crash, try increasing Docker's available memory from within Docker's _Preferences > Resources_ settings.**
+
 ##### Importing sentences
 
 To decrease the workload for your machine, by default sentence importing is deactivated for the Docker setup. This means that


### PR DESCRIPTION
Auto-rebuilding from `/web` has been broken on my machine for the past
week. I had time to look into it this afternoon. Turns out Docker was
running out of memory and crashing with a cryptic error.

I was already allocating 2GB to Docker, so hopefully we can continue to
reduce the memory footprint of `voice-web`. Until then, I thought this
would be a useful note for folks running the app for the first time.