### PR TITLE
Improve activity queries

### DIFF
--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -470,7 +470,7 @@ export default class DB {
     const hours = Array.from({ length: 10 }).map((_, i) => i);
 
     const [rows] = await this.mysql.query(
-      `SELECT date, count(activity.created_at)
+      `SELECT date, count(activity.created_at) AS value
           FROM (
             SELECT (TIMESTAMP(DATE_FORMAT(NOW(), '%Y-%m-%d %H:00')) - INTERVAL hour HOUR) AS date
             FROM (${hours

--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -437,18 +437,22 @@ export default class DB {
   async getVoicesStats(
     locale?: string
   ): Promise<{ date: string; value: number }[]> {
+    // It's necesary to manually create an array of all of the hours, because otherwise
+    // if a time interval has no contributions, that hour will just get dropped entirely
     const hours = Array.from({ length: 10 }).map((_, i) => i);
 
     const [rows] = await this.mysql.query(
       `
-        SELECT date, COUNT(DISTINCT client_id) AS value
+        SELECT date, COUNT(DISTINCT activity.client_id) AS value
         FROM (
           SELECT (TIMESTAMP(DATE_FORMAT(NOW(), '%Y-%m-%d %H:00')) - INTERVAL hour HOUR) AS date
           FROM (${hours.map(i => `SELECT ${i} AS hour`).join(' UNION ')}) hours
         ) date_alias
-        LEFT JOIN user_client_activities ON created_at BETWEEN date AND (date + INTERVAL 1 HOUR) ${
-          locale ? 'AND locale_id = ?' : ''
-        }
+        LEFT JOIN (
+          SELECT created_at, client_id FROM user_client_activities
+          WHERE created_at > (TIMESTAMP(DATE_FORMAT(NOW(), '%Y-%m-%d %H:00')) - INTERVAL 9 hour)
+          ${locale ? 'AND locale_id = ?' : ''}
+        ) activity ON created_at BETWEEN date AND (date + INTERVAL 1 HOUR)
         GROUP BY date
     `,
       [locale ? await getLocaleId(locale) : '']
@@ -461,48 +465,34 @@ export default class DB {
     locale?: string,
     client_id?: string
   ): Promise<{ date: string; value: number }[]> {
+    // It's necesary to manually create an array of all of the hours, because otherwise
+    // if a time interval has no contributions, that hour will just get dropped entirely
+    const hours = Array.from({ length: 10 }).map((_, i) => i);
+
     const [rows] = await this.mysql.query(
-      `
-    SELECT
-        date,
-        sum(value) AS value
-    FROM
-        ( SELECT
-            count(*) as value,
-            date_format( votes.created_at,
-            '%Y-%m-%d %H:00' ) AS date
-        FROM
-            votes
-        LEFT JOIN
-            clips
-                on clips.id = votes.clip_id
-        WHERE
-            votes.created_at > (
-                NOW() - INTERVAL 10 hour
-            )
+      `SELECT date, count(activity.created_at)
+          FROM (
+            SELECT (TIMESTAMP(DATE_FORMAT(NOW(), '%Y-%m-%d %H:00')) - INTERVAL hour HOUR) AS date
+            FROM (${hours
+              .map(i => `SELECT ${i} AS hour`)
+              .join(' UNION ')}) hours
+          ) date_alias
+          LEFT JOIN (
+            SELECT created_at
+            FROM clips
+            WHERE clips.created_at > (TIMESTAMP(DATE_FORMAT(NOW(), '%Y-%m-%d %H:00')) - INTERVAL 9 hour)
+            ${locale ? 'AND clips.locale_id = :locale_id' : ''}
+            ${client_id ? 'AND clips.client_id = :client_id' : ''}
+
+            UNION
+
+            SELECT created_at
+            FROM votes
+            WHERE votes.created_at > (TIMESTAMP(DATE_FORMAT(NOW(), '%Y-%m-%d %H:00')) - INTERVAL 9 hour)
             ${locale ? 'AND clips.locale_id = :locale_id' : ''}
             ${client_id ? 'AND votes.client_id = :client_id' : ''}
-        GROUP BY
-            HOUR(votes.created_at)
-        UNION
-        SELECT
-            count(*) as value,
-            date_format( clips.created_at,
-            '%Y-%m-%d %H:00' ) as date
-        FROM
-            clips
-        WHERE
-            clips.created_at > (
-                NOW() - INTERVAL 10 hour
-            )
-          ${locale ? 'AND clips.locale_id = :locale_id' : ''}
-          ${client_id ? 'AND clips.client_id = :client_id' : ''}
-        GROUP BY
-            HOUR(clips.created_at)
-    ) as summary
-      GROUP BY date
-      ORDER BY date desc
-      LIMIT 10
+          ) activity ON created_at BETWEEN date AND (date + INTERVAL 1 HOUR)
+          GROUP BY date
     `,
       {
         locale_id: locale ? await getLocaleId(locale) : null,


### PR DESCRIPTION
This update affects two functions related to serving the activity cards on the dashboard and homepage. 

`getVoicesStats`: Instead of joining to the entire user_client_activities table and then filtering by hours, this now just grabs the last 10 hours of records from that table before doing the hourly grouping.

`getContributionStats`: this reverses a [change from back in December](https://github.com/mozilla/voice-web/commit/7505bcb27f) when we were first trying to speed up these queries. Gozer figured out a method that was way faster, but we didn't realize this entire time that if there was an hour in which no activity happened at all, that hour just wouldn't exist in the result set. This leads to interesting graphs like this one from stage: 

<img width="543" alt="Screen Shot 2020-04-15 at 16 28 20" src="https://user-images.githubusercontent.com/582683/79388672-b84be100-7f3b-11ea-9b11-d2def780fc57.png">
 
So I went back to the old slow query from before that commit and did the same cleanup as `getVoiceStats`. This was the original query, in case you don't want to have to dig it up: 

```
SELECT date,
(
  SELECT COUNT(*)
  FROM clips
  WHERE clips.created_at BETWEEN date AND (date + INTERVAL 1 HOUR)
  ${locale ? 'AND clips.locale_id = :locale_id' : ''}
  ${client_id ? 'AND clips.client_id = :client_id' : ''}
) + (
  SELECT COUNT(*)
  FROM votes
  LEFT JOIN clips on clips.id = votes.clip_id
  WHERE votes.created_at BETWEEN date AND (date + INTERVAL 1 HOUR)
  ${locale ? 'AND clips.locale_id = :locale_id' : ''}
  ${client_id ? 'AND votes.client_id = :client_id' : ''}
) AS value
FROM (
  SELECT (TIMESTAMP(DATE_FORMAT(NOW(), '%Y-%m-%d %H:00')) - INTERVAL hour HOUR) AS date
  FROM (${hours.map(i => `SELECT ${i} AS hour`).join(' UNION ')}) hours
) date_alias
ORDER BY date ASC
```