### PR TITLE
Move Sentence and Clip types into common folder

### DIFF
--- a/common/clips.ts
+++ b/common/clips.ts
@@ -1,0 +1,12 @@
+export type Sentence = {
+  id: string;
+  text: string;
+  taxonomy?: string;
+};
+
+export type Clip = {
+  id: string;
+  glob: string;
+  sentence: string;
+  audioSrc: string;
+};

--- a/server/src/lib/model.ts
+++ b/server/src/lib/model.ts
@@ -1,6 +1,6 @@
 import * as request from 'request-promise-native';
-import { LanguageStats } from 'common';
-import DB, { Sentence } from './model/db';
+import { LanguageStats, Sentence } from 'common';
+import DB from './model/db';
 import { DBClipWithVoters } from './model/db/tables/clip-table';
 import lazyCache from './lazy-cache';
 

--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -4,7 +4,7 @@ import Mysql, { getMySQLInstance } from './db/mysql';
 import Schema from './db/schema';
 import ClipTable, { DBClipWithVoters } from './db/tables/clip-table';
 import VoteTable from './db/tables/vote-table';
-import { ChallengeToken } from 'common';
+import { ChallengeToken, Sentence } from 'common';
 
 // When getting new sentences/clips we need to fetch a larger pool and shuffle it to make it less
 // likely that different users requesting at the same time get the same data
@@ -63,11 +63,6 @@ export async function getLocaleId(locale: string): Promise<number> {
   }
 
   return localeIds[locale];
-}
-
-export interface Sentence {
-  id: string;
-  text: string;
 }
 
 export default class DB {

--- a/web/src/components/pages/contribution/contribution.tsx
+++ b/web/src/components/pages/contribution/contribution.tsx
@@ -10,6 +10,7 @@ import { Flags } from '../../../stores/flags';
 import { Locale } from '../../../stores/locale';
 import StateTree from '../../../stores/tree';
 import { User } from '../../../stores/user';
+import { Sentence } from 'common';
 import {
   trackListening,
   trackProfile,

--- a/web/src/components/pages/contribution/listen/listen.tsx
+++ b/web/src/components/pages/contribution/listen/listen.tsx
@@ -1,6 +1,7 @@
 import { Localized } from 'fluent-react/compat';
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { Clip as ClipType } from 'common';
 import { trackListening, getTrackClass } from '../../../../services/tracker';
 import { Clips } from '../../../../stores/clips';
 import { Locale } from '../../../../stores/locale';
@@ -50,7 +51,7 @@ const VoteButton = ({
 
 interface PropsFromState {
   api: API;
-  clips: Clips.Clip[];
+  clips: ClipType[];
   isLoading: boolean;
   locale: Locale.State;
   showFirstContributionToast: boolean;
@@ -68,7 +69,7 @@ interface PropsFromDispatch {
 interface Props extends PropsFromState, PropsFromDispatch {}
 
 interface State {
-  clips: (Clips.Clip & { isValid?: boolean })[];
+  clips: (ClipType & { isValid?: boolean })[];
   hasPlayed: boolean;
   hasPlayedSome: boolean;
   isPlaying: boolean;

--- a/web/src/components/pages/contribution/speak/sentence-recording.ts
+++ b/web/src/components/pages/contribution/speak/sentence-recording.ts
@@ -1,4 +1,4 @@
-import { Sentences } from '../../../../stores/sentences';
+import { Sentence as SentenceType } from 'common';
 
 interface Recording {
   blob: Blob;
@@ -6,6 +6,6 @@ interface Recording {
 }
 
 export interface SentenceRecording {
-  sentence: Sentences.Sentence;
+  sentence: SentenceType;
   recording?: Recording;
 }

--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -10,6 +10,7 @@ const NavigationPrompt = require('react-router-navigation-prompt').default;
 import { Locale } from '../../../../stores/locale';
 import { Notifications } from '../../../../stores/notifications';
 import { Sentences } from '../../../../stores/sentences';
+import { Sentence as SentenceType } from 'common';
 import StateTree from '../../../../stores/tree';
 import { Uploads } from '../../../../stores/uploads';
 import { User } from '../../../../stores/user';
@@ -32,7 +33,7 @@ import {
   FirefoxColor,
   ChromeColor,
 } from '../../../ui/icons';
-import { Button, TextButton, StyledLink, LinkButton } from '../../../ui/ui';
+import { Button, TextButton, LinkButton } from '../../../ui/ui';
 import { getItunesURL, isFirefoxFocus, isNativeIOS } from '../../../../utility';
 import ContributionPage, {
   ContributionPillProps,
@@ -102,7 +103,7 @@ const NoSentencesAvailable = () => (
 interface PropsFromState {
   api: API;
   locale: Locale.State;
-  sentences: Sentences.Sentence[];
+  sentences: SentenceType[];
   user: User.State;
   isLoading: boolean;
 }

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -2,10 +2,10 @@ import { AllGoals, CustomGoalParams } from 'common';
 import { LanguageStats } from 'common';
 import { UserClient } from 'common';
 import { WeeklyChallenge, Challenge, TeamChallenge } from 'common';
+import { Sentence } from 'common';
 import { Locale } from '../stores/locale';
 import { User } from '../stores/user';
 import { USER_KEY } from '../stores/root';
-import { Sentences } from '../stores/sentences';
 
 export interface Clip {
   id: string;
@@ -106,7 +106,7 @@ export default class API {
     return this.getLocalePath() + '/clips';
   }
 
-  fetchRandomSentences(count: number = 1): Promise<Sentences.Sentence[]> {
+  fetchRandomSentences(count: number = 1): Promise<Sentence[]> {
     return this.fetch(`${this.getLocalePath()}/sentences?count=${count}`);
   }
 

--- a/web/src/stores/clips.ts
+++ b/web/src/stores/clips.ts
@@ -2,17 +2,11 @@ import { Action as ReduxAction, Dispatch } from 'redux';
 const contributableLocales = require('../../../locales/contributable.json') as string[];
 import StateTree from './tree';
 import { User } from './user';
+import { Clip } from 'common';
 
 const MIN_CACHE_SIZE = 10;
 
 export namespace Clips {
-  export interface Clip {
-    id: string;
-    glob: string;
-    sentence: string;
-    audioSrc: string;
-  }
-
   export interface State {
     [locale: string]: {
       clips: Clip[];

--- a/web/src/stores/sentences.ts
+++ b/web/src/stores/sentences.ts
@@ -1,15 +1,11 @@
 import { Action as ReduxAction, Dispatch } from 'redux';
 const contributableLocales = require('../../../locales/contributable.json') as string[];
 import StateTree from './tree';
+import { Sentence } from 'common';
 
 const CACHE_SET_COUNT = 10;
 
 export namespace Sentences {
-  export interface Sentence {
-    id: string;
-    text: string;
-  }
-
   export interface State {
     [locale: string]: { sentences: Sentence[]; isLoading: boolean };
   }


### PR DESCRIPTION
The `Sentence` interface was being separately defined in both `web` and `server`, this just pulls that as well as `Clip` into the 'common' module for easier sharing. 