### PR TITLE
Update major dev dependencies

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
   "jsxBracketSameLine": true,
   "singleQuote": true,
-  "trailingComma": "es5"
+  "arrowParens": "avoid"
 }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "devDependencies": {
     "concurrently": "^5.1.0",
     "husky": "^4.2.1",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.5",
     "pretty-quick": "^2.0.1",
-    "typescript": "3.7.5"
+    "typescript": "3.8.3"
   },
   "workspaces": [
     "common",

--- a/server/package.json
+++ b/server/package.json
@@ -64,8 +64,7 @@
     "nodemon": "^2.0.2",
     "source-map-support": "^0.5.16",
     "ts-jest": "25.2.1",
-    "tsc-watch": "^4.2.3",
-    "typescript": "3.7.5"
+    "tsc-watch": "^4.2.3"
   },
   "scripts": {
     "build": "tsc",

--- a/server/src/auth-router.ts
+++ b/server/src/auth-router.ts
@@ -54,7 +54,7 @@ passport.deserializeUser((sessionUser: any, done: Function) =>
 );
 
 if (DOMAIN) {
-  Auth0Strategy.prototype.authorizationParams = function(options: any) {
+  Auth0Strategy.prototype.authorizationParams = function (options: any) {
     var options = options || {};
 
     const params: any = {};

--- a/server/src/lib/analytics.ts
+++ b/server/src/lib/analytics.ts
@@ -8,10 +8,7 @@ const GA_ID = 'UA-101237170-1';
  * Needs to behave like the client side version in /web/src/utility.ts
  */
 function hash(text: string) {
-  return crypto
-    .createHash('sha256')
-    .update(text)
-    .digest('hex');
+  return crypto.createHash('sha256').update(text).digest('hex');
 }
 
 export function trackPageView(path: string, client_id: string) {

--- a/server/src/lib/api.ts
+++ b/server/src/lib/api.ts
@@ -55,10 +55,7 @@ export default class API {
       this.metrics.countPrometheusRequest(request);
 
       const { registry } = this.metrics;
-      response
-        .type(registry.contentType)
-        .status(200)
-        .end(registry.metrics());
+      response.type(registry.contentType).status(200).end(registry.metrics());
     });
 
     router.use((request: Request, response: Response, next: NextFunction) => {
@@ -311,10 +308,7 @@ export default class API {
           .upload({
             Bucket: getConfig().BUCKET_NAME,
             Key: clipFileName,
-            Body: transcoder
-              .audioCodec('mp3')
-              .format('mp3')
-              .stream(),
+            Body: transcoder.audioCodec('mp3').format('mp3').stream(),
           })
           .promise(),
       ]);

--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -20,10 +20,7 @@ const Transcoder = require('stream-transcoder');
 const SALT = '8hd3e8sddFSdfj';
 
 export const hash = (str: string) =>
-  crypto
-    .createHmac('sha256', SALT)
-    .update(str)
-    .digest('hex');
+  crypto.createHmac('sha256', SALT).update(str).digest('hex');
 
 /**
  * Clip - Responsibly for saving and serving clips.
@@ -173,10 +170,7 @@ export default class Clip {
         .upload({
           Bucket: getConfig().BUCKET_NAME,
           Key: clipFileName,
-          Body: transcoder
-            .audioCodec('mp3')
-            .format('mp3')
-            .stream(),
+          Body: transcoder.audioCodec('mp3').format('mp3').stream(),
         })
         .promise();
 

--- a/server/src/lib/model/db/migrations/20171205171637-initialize-db.ts
+++ b/server/src/lib/model/db/migrations/20171205171637-initialize-db.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   const [row] = await db.runSql("SHOW TABLES LIKE 'version';");
   // If the version table exists, the user already has all the tables below
   return db.runSql(
@@ -57,6 +57,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20180118135749-add-timestamps.ts
+++ b/server/src/lib/model/db/migrations/20180118135749-add-timestamps.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE clips ADD COLUMN created_at DATETIME DEFAULT now();
@@ -10,6 +10,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20180221154147-add-bucket-to-user_clients-and-sentences.ts
+++ b/server/src/lib/model/db/migrations/20180221154147-add-bucket-to-user_clients-and-sentences.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   await db.runSql(
     `
       ALTER TABLE user_clients ADD COLUMN bucket ENUM ('train', 'dev', 'test') DEFAULT 'train';
@@ -8,6 +8,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20180309110854-add-requested-languages.ts
+++ b/server/src/lib/model/db/migrations/20180309110854-add-requested-languages.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       CREATE TABLE requested_languages (
@@ -16,6 +16,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20180321161005-add-sessions.ts
+++ b/server/src/lib/model/db/migrations/20180321161005-add-sessions.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       CREATE TABLE IF NOT EXISTS sessions (
@@ -11,6 +11,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20180430130010-locales.ts
+++ b/server/src/lib/model/db/migrations/20180430130010-locales.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       CREATE TABLE IF NOT EXISTS locales (
@@ -15,6 +15,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20180503112435-user_client-locale-bucket.ts
+++ b/server/src/lib/model/db/migrations/20180503112435-user_client-locale-bucket.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       CREATE TABLE IF NOT EXISTS user_client_locale_buckets (
@@ -13,6 +13,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20180517084308-sentences-text-index.ts
+++ b/server/src/lib/model/db/migrations/20180517084308-sentences-text-index.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE sentences ADD INDEX text_idx (text(300));
@@ -6,6 +6,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20180518122522-clips-sentence-index.ts
+++ b/server/src/lib/model/db/migrations/20180518122522-clips-sentence-index.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE clips ADD INDEX sentence_idx (sentence(300));
@@ -6,6 +6,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20180528105532-add-cache-columns-to-sentences-and-clips.ts
+++ b/server/src/lib/model/db/migrations/20180528105532-add-cache-columns-to-sentences-and-clips.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE clips
@@ -12,6 +12,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20180531091919-clips_and_votes-created-at-index.ts
+++ b/server/src/lib/model/db/migrations/20180531091919-clips_and_votes-created-at-index.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE clips ADD INDEX created_at_idx (created_at);
@@ -7,6 +7,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20180602125529-user-client-accents.ts
+++ b/server/src/lib/model/db/migrations/20180602125529-user-client-accents.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       CREATE TABLE user_client_accents (

--- a/server/src/lib/model/db/migrations/20180626105114-skipped-sentences.ts
+++ b/server/src/lib/model/db/migrations/20180626105114-skipped-sentences.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       CREATE TABLE skipped_sentences (

--- a/server/src/lib/model/db/migrations/20180629094740-add-basket-token-to-user.ts
+++ b/server/src/lib/model/db/migrations/20180629094740-add-basket-token-to-user.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE users

--- a/server/src/lib/model/db/migrations/20180907112935-user-client-activities.ts
+++ b/server/src/lib/model/db/migrations/20180907112935-user-client-activities.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       CREATE TABLE user_client_activities (
@@ -14,6 +14,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20180910121256-user-sso-fields.ts
+++ b/server/src/lib/model/db/migrations/20180910121256-user-sso-fields.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE user_clients
@@ -9,6 +9,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20180927134400-user-client-visible-and-skip-submission-feedback.ts
+++ b/server/src/lib/model/db/migrations/20180927134400-user-client-visible-and-skip-submission-feedback.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE user_clients
@@ -8,6 +8,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20181102093632-unique-locales.ts
+++ b/server/src/lib/model/db/migrations/20181102093632-unique-locales.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       UPDATE user_client_activities uca SET locale_id = (
@@ -42,6 +42,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20181105140705-add-avatar-url-to-user-clients.ts
+++ b/server/src/lib/model/db/migrations/20181105140705-add-avatar-url-to-user-clients.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE user_clients ADD COLUMN avatar_url TEXT;
@@ -6,6 +6,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20181123102419-change-user-clients-sso-id-to-has-login.ts
+++ b/server/src/lib/model/db/migrations/20181123102419-change-user-clients-sso-id-to-has-login.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE user_clients ADD COLUMN has_login BOOLEAN DEFAULT FALSE;
@@ -8,6 +8,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20190125140627-add-deprecated-prefix-to-various-user-fields-and-tables.ts
+++ b/server/src/lib/model/db/migrations/20190125140627-add-deprecated-prefix-to-various-user-fields-and-tables.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       RENAME TABLE users TO deprecated_users;
@@ -11,6 +11,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20190228083648-add-has-downloaded-to-user-clients.ts
+++ b/server/src/lib/model/db/migrations/20190228083648-add-has-downloaded-to-user-clients.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE user_clients
@@ -7,6 +7,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20190228085830-downloaders.ts
+++ b/server/src/lib/model/db/migrations/20190228085830-downloaders.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE user_clients DROP COLUMN has_downloaded;
@@ -14,6 +14,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20190228141220-add-is-valid-to-clips.ts
+++ b/server/src/lib/model/db/migrations/20190228141220-add-is-valid-to-clips.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE clips ADD COLUMN is_valid BOOLEAN;
@@ -6,6 +6,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20190228163137-add-is-valid-index-to-clips.ts
+++ b/server/src/lib/model/db/migrations/20190228163137-add-is-valid-index-to-clips.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE clips ADD INDEX is_valid_idx (is_valid);
@@ -6,6 +6,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20190306160153-locales-id-as-int.ts
+++ b/server/src/lib/model/db/migrations/20190306160153-locales-id-as-int.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE downloaders DROP KEY email_locale;
@@ -46,6 +46,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20190320130113-custom-goals.ts
+++ b/server/src/lib/model/db/migrations/20190320130113-custom-goals.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       CREATE TABLE custom_goals (
@@ -15,6 +15,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20190324121841-awards.ts
+++ b/server/src/lib/model/db/migrations/20190324121841-awards.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE custom_goals
@@ -18,6 +18,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20190325214214-add-seen-at-to-awards.ts
+++ b/server/src/lib/model/db/migrations/20190325214214-add-seen-at-to-awards.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE awards ADD COLUMN seen_at TIMESTAMP NULL DEFAULT NULL;
@@ -6,6 +6,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20190415120548-add-version-and-source-to-sentences.ts
+++ b/server/src/lib/model/db/migrations/20190415120548-add-version-and-source-to-sentences.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE sentences
@@ -8,6 +8,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20190418075916-change-sentence-charset.ts
+++ b/server/src/lib/model/db/migrations/20190418075916-change-sentence-charset.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE sentences MODIFY text TEXT CHARSET utf8mb4 NOT NULL;
@@ -7,6 +7,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20190503111653-add-notification-seen-at-to-awards.ts
+++ b/server/src/lib/model/db/migrations/20190503111653-add-notification-seen-at-to-awards.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE awards ADD COLUMN notification_seen_at TIMESTAMP NULL DEFAULT NULL;
@@ -6,6 +6,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20190522114028-add-avatar-clip-url-to-user-client.ts
+++ b/server/src/lib/model/db/migrations/20190522114028-add-avatar-clip-url-to-user-client.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE user_clients ADD COLUMN avatar_clip_url TEXT;
@@ -6,6 +6,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20190708095144-reported-clips-and-reported-sentences.ts
+++ b/server/src/lib/model/db/migrations/20190708095144-reported-clips-and-reported-sentences.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       CREATE TABLE reported_clips (
@@ -24,6 +24,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20190711074029-streaks-and-reached_goals.ts
+++ b/server/src/lib/model/db/migrations/20190711074029-streaks-and-reached_goals.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       CREATE TABLE streaks (
@@ -27,6 +27,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20190721130133-add-has-computed-goals-to-user-clients.ts
+++ b/server/src/lib/model/db/migrations/20190721130133-add-has-computed-goals-to-user-clients.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE user_clients
@@ -7,6 +7,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20190722114654-add-locale-id-to-custom-goals.ts
+++ b/server/src/lib/model/db/migrations/20190722114654-add-locale-id-to-custom-goals.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE custom_goals
@@ -7,6 +7,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20190805092134-rename-pt-br-to-pt.ts
+++ b/server/src/lib/model/db/migrations/20190805092134-rename-pt-br-to-pt.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       # We can ignore failing updates for portuguese as it doesn't have related
@@ -8,6 +8,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20190916114856-add-auth-token-to-user-clients.ts
+++ b/server/src/lib/model/db/migrations/20190916114856-add-auth-token-to-user-clients.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE user_clients ADD COLUMN auth_token TEXT;
@@ -6,6 +6,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20191017134955-add-teams.ts
+++ b/server/src/lib/model/db/migrations/20191017134955-add-teams.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
     CREATE TABLE teams (
@@ -11,6 +11,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20191017135015-add-challenge-team-to-user-clients.ts
+++ b/server/src/lib/model/db/migrations/20191017135015-add-challenge-team-to-user-clients.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
     ALTER TABLE user_clients ADD COLUMN challenge_team VARCHAR(255) DEFAULT NULL;
@@ -7,6 +7,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20191024074951-challenge-related-schemas.ts
+++ b/server/src/lib/model/db/migrations/20191024074951-challenge-related-schemas.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
     /* Keep user_clients clean */
@@ -76,6 +76,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20191029113543-change-visible-use-clients.ts
+++ b/server/src/lib/model/db/migrations/20191029113543-change-visible-use-clients.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
     ALTER TABLE user_clients MODIFY visible TINYINT(2) DEFAULT 0;
@@ -6,6 +6,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20191107232609-add-referer-to-challenge-enrollment.ts
+++ b/server/src/lib/model/db/migrations/20191107232609-add-referer-to-challenge-enrollment.ts
@@ -1,7 +1,7 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(`ALTER TABLE enroll ADD COLUMN referer VARCHAR(255);`);
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20191108184707-add-pilot-challenge-data.ts
+++ b/server/src/lib/model/db/migrations/20191108184707-add-pilot-challenge-data.ts
@@ -2,7 +2,7 @@
 // running this a few times, so no need to get fancy. It'll get cached anyway.
 const pilotId = `(SELECT id FROM challenges WHERE url_token='pilot')`;
 
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(`
     /* We're handling logos on the front-end. */
     ALTER TABLE teams DROP COLUMN logo_url;
@@ -42,6 +42,6 @@ export const up = async function(db: any): Promise<any> {
   `);
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20191118165637-add-lenovo-to-pilot-challenge.ts
+++ b/server/src/lib/model/db/migrations/20191118165637-add-lenovo-to-pilot-challenge.ts
@@ -1,10 +1,10 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(`
     INSERT INTO teams (url_token, name, challenge_id)
     VALUES ('lenovo', 'Lenovo', (SELECT id FROM challenges WHERE url_token='pilot'));
   `);
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20191125154623-cascade-client-id-delete.ts
+++ b/server/src/lib/model/db/migrations/20191125154623-cascade-client-id-delete.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(`
     ALTER TABLE awards DROP FOREIGN KEY awards_ibfk_1;
     ALTER TABLE awards ADD CONSTRAINT awards_ibfk_1 FOREIGN KEY (client_id) REFERENCES user_clients (client_id) ON DELETE CASCADE;
@@ -47,6 +47,6 @@ export const up = async function(db: any): Promise<any> {
   `);
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20191128165627-weekly-achievements.ts
+++ b/server/src/lib/model/db/migrations/20191128165627-weekly-achievements.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(`
     ALTER TABLE achievements ADD COLUMN week SMALLINT DEFAULT NULL;
 
@@ -9,6 +9,6 @@ export const up = async function(db: any): Promise<any> {
   `);
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20191219191744-add-clip-validated-at.ts
+++ b/server/src/lib/model/db/migrations/20191219191744-add-clip-validated-at.ts
@@ -1,10 +1,10 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   // Note: Manual backfill to follow.
   return db.runSql(`
     ALTER TABLE clips ADD COLUMN validated_at DATE DEFAULT NULL;
   `);
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20191227183100-match-clip-sentence-locale.ts
+++ b/server/src/lib/model/db/migrations/20191227183100-match-clip-sentence-locale.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   // Note: Manual backfill to follow.
   return db.runSql(`
     UPDATE clips
@@ -9,6 +9,6 @@ export const up = async function(db: any): Promise<any> {
   `);
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20200226094500-newsletter-sub-tables.ts
+++ b/server/src/lib/model/db/migrations/20200226094500-newsletter-sub-tables.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
     CREATE TABLE user_client_newsletter_prefs (
@@ -26,6 +26,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20200402174044-add-composite-index-to-sentences.ts
+++ b/server/src/lib/model/db/migrations/20200402174044-add-composite-index-to-sentences.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
       ALTER TABLE sentences ADD INDEX locale_clip_ct_idx (locale_id, clips_count);
@@ -6,6 +6,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20200406141259-sentence-tagging-structure.ts
+++ b/server/src/lib/model/db/migrations/20200406141259-sentence-tagging-structure.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
     CREATE TABLE taxonomies (
@@ -36,6 +36,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/db/migrations/20200420154137-benchmark-taxonomy.ts
+++ b/server/src/lib/model/db/migrations/20200420154137-benchmark-taxonomy.ts
@@ -1,4 +1,4 @@
-export const up = async function(db: any): Promise<any> {
+export const up = async function (db: any): Promise<any> {
   return db.runSql(
     `
     INSERT INTO taxonomies (tax_name, type)
@@ -10,6 +10,6 @@ export const up = async function(db: any): Promise<any> {
   );
 };
 
-export const down = function(): Promise<any> {
+export const down = function (): Promise<any> {
   return null;
 };

--- a/server/src/lib/model/goals.ts
+++ b/server/src/lib/model/goals.ts
@@ -19,10 +19,7 @@ const daysBetween = (date1: Date, date2: Date) =>
   Math.floor((date1.getTime() - date2.getTime()) / ONE_DAY);
 
 const formatDate = (date: Date) =>
-  date
-    .toISOString()
-    .slice(0, 19)
-    .replace('T', ' ');
+  date.toISOString().slice(0, 19).replace('T', ' ');
 
 async function hasComputedGoals(client_id: string) {
   const [

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -9,7 +9,7 @@ async function runServer() {
   await initialize();
 
   // Handle any top-level exceptions uncaught in the app.
-  process.on('uncaughtException', function(err: any) {
+  process.on('uncaughtException', function (err: any) {
     if (err.code === 'EADDRINUSE') {
       // For now, do nothing when we are unable to start the http server.
       console.error('ERROR: server already running');

--- a/server/src/test/lazy-cache.test.ts
+++ b/server/src/test/lazy-cache.test.ts
@@ -24,10 +24,7 @@ describe('lazyCache', () => {
   });
 
   test('serves old cache while refreshing', async () => {
-    const f = jest
-      .fn()
-      .mockReturnValueOnce(23)
-      .mockReturnValueOnce(42);
+    const f = jest.fn().mockReturnValueOnce(23).mockReturnValueOnce(42);
     const cachedF = lazyCache(randomString(), f, 1000);
     expect(await cachedF()).toBe(23);
     await new Promise(resolve => setTimeout(resolve, 1500));

--- a/server/src/test/lib/server-harness.ts
+++ b/server/src/test/lib/server-harness.ts
@@ -17,9 +17,7 @@ export default class ServerHarness {
       DB_PREFIX +
       config.MYSQLDBNAME +
       '_' +
-      Math.random()
-        .toString(36)
-        .substring(7);
+      Math.random().toString(36).substring(7);
     injectConfig(config);
     this.server = new RealServer({ bundleCrossLocaleMessages: false });
   }

--- a/server/src/test/lib/utility.ts
+++ b/server/src/test/lib/utility.ts
@@ -2,7 +2,7 @@
  * Generate RFC4122 compliant globally unique identifier.
  */
 export function generateGUID(): string {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
     var r = (Math.random() * 16) | 0,
       v = c == 'x' ? r : (r & 0x3) | 0x8;
     return v.toString(16);

--- a/web/package.json
+++ b/web/package.json
@@ -73,7 +73,6 @@
     "react-dev-utils": "^10.0.0",
     "style-loader": "^1.0.2",
     "ts-loader": "^6.2.1",
-    "typescript": "3.7.5",
     "webpack": "^4.41.5",
     "webpack-bundle-analyzer": "^3.6.0",
     "webpack-cli": "^3.3.10"

--- a/web/src/components/normalized-player.tsx
+++ b/web/src/components/normalized-player.tsx
@@ -43,7 +43,7 @@ export default class NormalizedPlayer implements NormalizedPlayerInterface {
     }
 
     // Ascending sort of the averages array
-    averages.sort(function(a, b) {
+    averages.sort(function (a, b) {
       return a - b;
     });
 

--- a/web/src/components/pages/contribution/contribution.tsx
+++ b/web/src/components/pages/contribution/contribution.tsx
@@ -443,9 +443,11 @@ class ContributionPage extends React.Component<Props, State> {
                         style={{
                           transform: [
                             `scale(${isActive ? 1 : 0.9})`,
-                            `translateX(${(document.dir == 'rtl' ? -1 : 1) *
+                            `translateX(${
+                              (document.dir == 'rtl' ? -1 : 1) *
                               (i - activeSentenceIndex) *
-                              -130}%)`,
+                              -130
+                            }%)`,
                           ].join(' '),
                           opacity: i < activeSentenceIndex ? 0 : 1,
                         }}>

--- a/web/src/components/pages/contribution/speak/audio-web.ts
+++ b/web/src/components/pages/contribution/speak/audio-web.ts
@@ -45,7 +45,7 @@ export default class AudioWeb {
   }
 
   private getMicrophone(): Promise<MediaStream> {
-    return new Promise(function(res: Function, rej: Function) {
+    return new Promise(function (res: Function, rej: Function) {
       function deny(error: MediaStreamError) {
         rej(
           ({

--- a/web/src/components/pages/dashboard/stats/leaderboard-card.tsx
+++ b/web/src/components/pages/dashboard/stats/leaderboard-card.tsx
@@ -128,7 +128,7 @@ class UnconnectedLeaderboard extends React.Component<Props, State> {
     );
   }
 
-  playAvatarClip = function(clipUrl: string, position: any, self: boolean) {
+  playAvatarClip = function (clipUrl: string, position: any, self: boolean) {
     const { locale } = this.props;
     trackVoiceAvatar(self ? 'self-listen' : 'listen', locale);
 

--- a/web/src/components/pages/datasets/dots.tsx
+++ b/web/src/components/pages/datasets/dots.tsx
@@ -23,10 +23,12 @@ export default ({
       style={{
         ...style,
         background: [
-          `linear-gradient(90deg, ${backgroundColor} ${space -
-            size}px, transparent 1%) center`,
-          `linear-gradient(${backgroundColor} ${space -
-            size}px, transparent 1%) center`,
+          `linear-gradient(90deg, ${backgroundColor} ${
+            space - size
+          }px, transparent 1%) center`,
+          `linear-gradient(${backgroundColor} ${
+            space - size
+          }px, transparent 1%) center`,
           color,
         ].join(', '),
         backgroundSize: `${space}px ${space}px`,

--- a/web/src/components/pages/languages/languages.tsx
+++ b/web/src/components/pages/languages/languages.tsx
@@ -186,9 +186,7 @@ class LanguagesPage extends React.PureComponent<Props, State> {
             const q = query.toLowerCase().trim();
             return (
               locale.includes(q) ||
-              getString(locale)
-                .toLowerCase()
-                .includes(q) ||
+              getString(locale).toLowerCase().includes(q) ||
               (NATIVE_NAMES[locale] || '').toLowerCase().includes(q)
             );
           })

--- a/web/src/components/pages/profile/avatar-setup/avatar-setup.tsx
+++ b/web/src/components/pages/profile/avatar-setup/avatar-setup.tsx
@@ -41,10 +41,7 @@ function resizeImage(file: File, maxSize: number): Promise<Blob> {
       dataURI.split(',')[0].indexOf('base64') >= 0
         ? atob(dataURI.split(',')[1])
         : unescape(dataURI.split(',')[1]);
-    const mime = dataURI
-      .split(',')[0]
-      .split(':')[1]
-      .split(';')[0];
+    const mime = dataURI.split(',')[0].split(':')[1].split(';')[0];
     const max = bytes.length;
     const ia = new Uint8Array(max);
     for (var i = 0; i < max; i++) ia[i] = bytes.charCodeAt(i);

--- a/web/src/components/welcome-modal/welcome-modal.tsx
+++ b/web/src/components/welcome-modal/welcome-modal.tsx
@@ -33,7 +33,7 @@ export default ({ challengeToken, teamToken, ...props }: WelcomeModalProps) => {
   const account = useAccount();
   const saveAccount = useAction(User.actions.saveAccount);
   const [locale, toLocaleRoute] = useLocale();
-  const [redirectChallenge, setRedirectChallenge] = useState();
+  const [redirectChallenge, setRedirectChallenge] = useState(null);
 
   useEffect(() => trackChallenge('modal-welcome'), []);
 

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -6,7 +6,7 @@ import './components/index.css';
 declare var require: any;
 
 // Safari hack to allow :active styles.
-document.addEventListener('touchstart', function() {}, true);
+document.addEventListener('touchstart', function () {}, true);
 
 // Start the app when DOM is ready.
 document.addEventListener('DOMContentLoaded', async () => {

--- a/web/src/utility.ts
+++ b/web/src/utility.ts
@@ -6,7 +6,7 @@ const SEARCH_REG_EXP = new RegExp('</?[^>]+(>|$)', 'g');
  * Generate RFC4122 compliant globally unique identifier.
  */
 export function generateGUID(): string {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
     var r = (Math.random() * 16) | 0,
       v = c == 'x' ? r : (r & 0x3) | 0x8;
     return v.toString(16);
@@ -106,10 +106,7 @@ export async function hash(text: string) {
 
 export function stringContains(haystack: string, needles: string) {
   return (
-    haystack
-      .toUpperCase()
-      .replace(SEARCH_REG_EXP, '')
-      .indexOf(needles) !== -1
+    haystack.toUpperCase().replace(SEARCH_REG_EXP, '').indexOf(needles) !== -1
   );
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8925,10 +8925,10 @@ prepend-http@^1.0.0, prepend-http@^1.0.1:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-error@^2.0.2:
   version "2.1.1"
@@ -11132,10 +11132,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.7.5:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 uglify-js@3.4.x:
   version "3.4.10"


### PR DESCRIPTION
**Typescript: 3.7 -> 3.8**

No breaking changes here, the most interesting feature looks like [type only imports and exports]( https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#-type-only-imports-and-export).

I removed the duplicate TS deps from our `/web` and `/server` packages since we're trying to keep those versions locked.

**Prettier: 1 -> 2**

Major version, ooooouuuu. To support the new features added in TS 3.8, we need to upgrade to Prettier 2. The [breaking changes are listed here](https://prettier.io/blog/2020/03/21/2.0.0.html#breaking-changes), which I've dealt with in the following ways:

- Change default value for trailingComma to es5

We were already setting `trailingComma` to `es5` in `.prettierrc`, so I removed the redundant declaration.

- Change default value for arrowParens to always

The documentation makes some convincing arguments for this, and I'd be happy to flip the flag in the future. However, this change alone nearly doubled the surface area of files affected by this commit, so I decided to add the old default to `.prettierrc` for the time being.

- Drop support for Node versions older than 10

Good thing we [updated Node](https://github.com/mozilla/voice-web/commit/62084c715e29b524c4053b5d9fdede587da277fb)! :)

- Change default value for endOfLine to lf
- Fix config overrides pattern matching to include dot files
- Plugin API: changes in prettier.util
- Cache plugin search results
- Remove deprecated options and option values
- Remove the version parameter of prettier.getSupportInfo

No changes required.

---

There are a few other libraries that are behind a major version, but this change seems big enough. I'll try to get a follow-on diff out later in this sprint once this code settles :)