### PR TITLE
Fix empty value check

### DIFF
--- a/web/src/components/pages/contribution/report/report.tsx
+++ b/web/src/components/pages/contribution/report/report.tsx
@@ -104,7 +104,7 @@ export function ReportModal({
         rounded
         disabled={
           submitStatus == 'submitting' ||
-          otherText == '' ||
+          otherText.trim() == '' ||
           (!Object.values(selectedReasons).some(Boolean) && otherText == null)
         }
         onClick={() => {


### PR DESCRIPTION
Its accepting space to bypass the check, if someone put space in it the button gets enabled and the user can submit the report