### PR TITLE
Remove the "last" reference from audio-web.ts

### DIFF
--- a/web/src/components/pages/contribution/speak/audio-web.ts
+++ b/web/src/components/pages/contribution/speak/audio-web.ts
@@ -21,7 +21,6 @@ export default class AudioWeb {
   audioContext: AudioContext;
   recorder: any;
   chunks: any[];
-  last: AudioInfo;
   frequencyBins: Uint8Array;
   volumeCallback: Function;
   jsNode: any;
@@ -188,10 +187,7 @@ export default class AudioWeb {
       );
 
       // Update the stored listeners.
-      this.recorderListeners.start = (e: Event) => {
-        this.clear();
-        res();
-      };
+      this.recorderListeners.start = (e: Event) => res();
       this.recorderListeners.dataavailable = (e: BlobEvent) => {
         this.chunks.push(e.data);
       };
@@ -223,11 +219,10 @@ export default class AudioWeb {
       this.recorder.removeEventListener('stop', this.recorderListeners.stop);
       this.recorderListeners.stop = (e: Event) => {
         let blob = new Blob(this.chunks, { type: getAudioFormat() });
-        this.last = {
+        res({
           url: URL.createObjectURL(blob),
           blob: blob,
-        };
-        res(this.last);
+        });
       };
       this.recorder.addEventListener('stop', this.recorderListeners.stop);
       this.recorder.stop();
@@ -241,13 +236,5 @@ export default class AudioWeb {
       }
     }
     this.microphone = null;
-  }
-
-  clear() {
-    if (this.last) {
-      URL.revokeObjectURL(this.last.url);
-    }
-
-    this.last = null;
   }
 }

--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -251,10 +251,10 @@ class SpeakPage extends React.Component<Props, State> {
   };
 
   private getRecordingIndex() {
-    const { rerecordIndex } = this.state;
-    return rerecordIndex === null
-      ? this.state.clips.findIndex(({ recording }) => !recording)
-      : rerecordIndex;
+    return (
+      this.state.rerecordIndex ??
+      this.state.clips.findIndex(({ recording }) => !recording)
+    );
   }
 
   private releaseMicrophone = () => {
@@ -274,13 +274,13 @@ class SpeakPage extends React.Component<Props, State> {
       return this.setState({ error });
     }
 
-    const { clips } = this.state;
-    this.setState({
-      clips: clips.map(({ recording, sentence }, i) => ({
-        recording: i === this.getRecordingIndex() ? info : recording,
-        sentence,
-      })),
-      rerecordIndex: null,
+    this.setState(({ clips }) => {
+      const newClips = [...clips];
+      newClips[this.getRecordingIndex()].recording = info;
+      return {
+        clips: newClips,
+        rerecordIndex: null,
+      };
     });
 
     trackRecording('record', this.props.locale);
@@ -356,6 +356,9 @@ class SpeakPage extends React.Component<Props, State> {
   };
 
   private saveRecording = () => {
+    // We noticed that some people hit the Stop button too early, cutting off
+    // the recording prematurely. To compensate, we add a short buffer to the
+    // end of each recording (issue #1648).
     const RECORD_STOP_DELAY = 500;
     setTimeout(async () => {
       const info = await this.audio.stop();
@@ -380,16 +383,18 @@ class SpeakPage extends React.Component<Props, State> {
 
   private handleSkip = async () => {
     const { api, removeSentences } = this.props;
-    const { clips } = this.state;
     await this.discardRecording();
     const current = this.getRecordingIndex();
-    const { id } = clips[current]?.sentence || {};
+    const id = this.state.clips[current]?.sentence?.id;
     removeSentences([id]);
-    this.setState({
-      clips: clips.map((clip, i) =>
-        current === i ? { recording: null, sentence: null } : clip
-      ),
-      error: null,
+    this.setState(({ clips }) => {
+      const newClips = [...clips];
+      newClips[current] = { recording: null, sentence: null };
+      URL.revokeObjectURL(clips[current].recording.url);
+      return {
+        clips: newClips,
+        error: null,
+      };
     });
     await api.skipSentence(id);
   };
@@ -433,6 +438,7 @@ class SpeakPage extends React.Component<Props, State> {
               sentence.id,
               sentence.text
             );
+            URL.revokeObjectURL(recording.url);
             sessionStorage.setItem(
               'challengeEnded',
               JSON.stringify(challengeEnded)


### PR DESCRIPTION
Due to some overaggressive revoking of URLs, we were seeing bugs in
replaying and re-recording audio on the /speak page (eg. #2716, and
perhaps related to #2553). `this.last` was a huge vector for bugs, and
only used for `URL.revokeObjectURL` calls, so this commit moves URL
cleanup to `speak.tsx` and defers it until a Skip or Upload action
occurs.

This commit contains various other cleanups and small fixes, such as
making sure the most recent version of state.clips is referenced in our
setState calls. We paired on this together, so I won't go into any
further detail :)