### PR TITLE
Change minimum volume handling code for /speak

### DIFF
--- a/server/src/lib/api.ts
+++ b/server/src/lib/api.ts
@@ -275,6 +275,7 @@ export default class API {
     response.json(error ? { error } : {});
   };
 
+  // TODO: Check for empty or silent clips before uploading.
   saveAvatarClip = async (request: Request, response: Response) => {
     const { client_id, headers, user } = request;
 

--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -123,6 +123,7 @@ export default class Clip {
 
   /**
    * Save the request body as an audio file.
+   * TODO: Check for empty or silent clips before uploading.
    */
   saveClip = async (request: Request, response: Response) => {
     const { client_id, headers, params } = request;

--- a/web/src/components/pages/contribution/speak/audio-web.ts
+++ b/web/src/components/pages/contribution/speak/audio-web.ts
@@ -37,7 +37,7 @@ export default class AudioWeb {
       dataavailable: null,
       stop: null,
     };
-    this.visualize = this.visualize.bind(this);
+    this.analyze = this.analyze.bind(this);
   }
 
   private isReady(): boolean {
@@ -93,27 +93,12 @@ export default class AudioWeb {
     );
   }
 
-  private visualize() {
+  private analyze() {
     this.analyzerNode.getByteFrequencyData(this.frequencyBins);
 
-    let sum = 0;
-    for (var i = 0; i < this.frequencyBins.length; i++) {
-      sum += this.frequencyBins[i];
-    }
-
-    let average = sum / this.frequencyBins.length;
-
     if (this.volumeCallback) {
-      this.volumeCallback(average);
+      this.volumeCallback(Math.max(...this.frequencyBins));
     }
-  }
-
-  private startVisualize() {
-    this.jsNode.onaudioprocess = this.visualize;
-  }
-
-  private stopVisualize() {
-    this.jsNode.onaudioprocess = undefined;
   }
 
   setVolumeCallback(cb: Function) {
@@ -136,11 +121,12 @@ export default class AudioWeb {
     const microphone = await this.getMicrophone();
 
     this.microphone = microphone;
-    var audioContext = new (window.AudioContext || window.webkitAudioContext)();
-    var sourceNode = audioContext.createMediaStreamSource(microphone);
-    var volumeNode = audioContext.createGain();
-    var analyzerNode = audioContext.createAnalyser();
-    var outputNode = audioContext.createMediaStreamDestination();
+    const audioContext = new (window.AudioContext ||
+      window.webkitAudioContext)();
+    const sourceNode = audioContext.createMediaStreamSource(microphone);
+    const volumeNode = audioContext.createGain();
+    const analyzerNode = audioContext.createAnalyser();
+    const outputNode = audioContext.createMediaStreamDestination();
 
     // Make sure we're doing mono everywhere.
     sourceNode.channelCount = 1;
@@ -158,13 +144,17 @@ export default class AudioWeb {
 
     // Set up the analyzer node, and allocate an array for its data
     // FFT size 64 gives us 32 bins. But those bins hold frequencies up to
-    // 22kHz or more, and we only care about visualizing lower frequencies
-    // which is where most human voice lies, so we use fewer bins
+    // 22kHz or more, and we only care about lower frequencies which is where
+    // most human voice lies, so we use fewer bins.
     analyzerNode.fftSize = 128;
     analyzerNode.smoothingTimeConstant = 0.96;
     this.frequencyBins = new Uint8Array(analyzerNode.frequencyBinCount);
 
-    // Setup audio visualizer.
+    // Setup jsNode for audio analysis callbacks.
+    // TODO: `createScriptProcessor` is deprecated, and is a heavy solution for
+    //       what it’s doing (checking recording volume). It should be replaced
+    //       with something lighter, or AudioWorklets once they become more
+    //       widely adopted.
     this.jsNode = audioContext.createScriptProcessor(256, 1, 1);
     this.jsNode.connect(audioContext.destination);
 
@@ -207,7 +197,7 @@ export default class AudioWeb {
       // We want to be able to record up to 60s of audio in a single blob.
       // Without this argument to start(), Chrome will call dataavailable
       // very frequently.
-      this.startVisualize();
+      this.jsNode.onaudioprocess = this.analyze;
       this.recorder.start(20000);
     });
   }
@@ -219,7 +209,7 @@ export default class AudioWeb {
     }
 
     return new Promise((res: Function, rej: Function) => {
-      this.stopVisualize();
+      this.jsNode.onaudioprocess = undefined;
       this.recorder.removeEventListener('stop', this.recorderListeners.stop);
       this.recorderListeners.stop = (e: Event) => {
         let blob = new Blob(this.chunks, { type: getAudioFormat() });

--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -48,7 +48,7 @@ import './speak.css';
 
 const MIN_RECORDING_MS = 1000;
 const MAX_RECORDING_MS = 10000;
-const MIN_VOLUME = 1;
+const MIN_VOLUME = 8; // Range: [0, 255].
 
 enum RecordingError {
   TOO_SHORT = 'TOO_SHORT',
@@ -167,7 +167,7 @@ class SpeakPage extends React.Component<Props, State> {
 
   audio: AudioWeb;
   isUnsupportedPlatform = false;
-  maxVolume = 0;
+  maxVolume = -1;
   recordingStartTime = 0;
   recordingStopTime = 0;
 
@@ -294,7 +294,9 @@ class SpeakPage extends React.Component<Props, State> {
     if (length > MAX_RECORDING_MS) {
       return RecordingError.TOO_LONG;
     }
-    if (this.maxVolume < MIN_VOLUME) {
+    // If updateVolume was never called, we assume there’s a problem with the
+    // AnalyserNode and skip this error.
+    if (this.maxVolume !== -1 && this.maxVolume < MIN_VOLUME) {
       return RecordingError.TOO_QUIET;
     }
     return null;
@@ -341,7 +343,7 @@ class SpeakPage extends React.Component<Props, State> {
   private startRecording = async () => {
     try {
       await this.audio.start();
-      this.maxVolume = 0;
+      this.maxVolume = -1; // Initialize to -1 in case updateVolume is never called.
       this.recordingStartTime = Date.now();
       this.recordingStopTime = 0;
       this.setState({


### PR DESCRIPTION
We've had some reports of loud clips being flagged as silent (eg.
https://discourse.mozilla.org/t/cant-submit-recordings-because-im-told-they-are-too-quiet-even-though-theyre-not/59373).

This commit ensures that a low volume error is thrown only if our
volume-checking utility is working and has been called. For various
reasons, some platforms may never receive an `onaudioprocess` event. In
such cases, we shouldn't assume that the recording is silent. I’ve added
notes to the server to check for silent clips.

This commit also removes any mention of "visualizer" from `audio-web.ts`,
since our visualizer is not audio-reactive.