### PR TITLE
Remove JSON log outputs

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -13,7 +13,6 @@ import {
 } from './lib/model/leaderboard';
 import { trackPageView } from './lib/analytics';
 import API from './lib/api';
-import Logger from './lib/logger';
 import { redis, redlock } from './lib/redis';
 import { APIError, ClientError, getElapsedSeconds } from './lib/utility';
 import { importSentences } from './lib/model/db/import-sentences';
@@ -59,7 +58,6 @@ export default class Server {
   server: http.Server;
   model: Model;
   api: API;
-  logger: Logger;
   isLeader: boolean;
 
   get version() {
@@ -71,13 +69,7 @@ export default class Server {
     options = { bundleCrossLocaleMessages: true, ...options };
     this.model = new Model();
     this.api = new API(this.model);
-    this.logger = new Logger();
     this.isLeader = null;
-
-    // Make console.log output json.
-    if (PROD) {
-      this.logger.overrideConsole();
-    }
 
     const app = (this.app = express());
 


### PR DESCRIPTION
Back in the days when Kibana was our main logging viewer we needed JSON logs. Now that we're on Papertrail, JSON logs are very messy and hard to read. Dev/Sandbox have been using the default console.log with no issues, so let's try also doing this on stage. cc @The-smooth-operator 

I'm leaving `lib/logger.ts` for now in case we end up needing it for something else.