### PR TITLE
Architecture for single sentence record limit

### DIFF
--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -330,7 +330,7 @@ export default class DB {
             FROM votes
             WHERE votes.clip_id = clips.id AND client_id = ?
           )
-        AND (sentences.clips_count <= 10 OR sentences.clips_count = 0)
+        AND sentences.clips_count <= 10
         AND sentences.has_valid_clip = 0
         ORDER BY sentences.clips_count ASC, clips.created_at ASC
         LIMIT ?

--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -224,6 +224,7 @@ export default class DB {
             WHERE skipped.sentence_id = sentences.id AND
               skipped.client_id = ?
           )
+          AND (clips_count = 0 OR has_valid_clip = 0)
           ORDER BY clips_count ASC
           LIMIT ?
         ) t
@@ -329,7 +330,8 @@ export default class DB {
             FROM votes
             WHERE votes.clip_id = clips.id AND client_id = ?
           )
-        AND (sentences.clips_count <= 10 OR sentences.clips_count IS NULL)
+        AND (sentences.clips_count <= 10 OR sentences.clips_count = 0)
+        AND sentences.has_valid_clip = 0
         ORDER BY sentences.clips_count ASC, clips.created_at ASC
         LIMIT ?
       ) t
@@ -492,6 +494,12 @@ export default class DB {
         WHERE updated_clips.id = ${id}
       `
     );
+
+    await this.mysql.query(
+      `UPDATE sentences
+        SET has_valid_clip = EXISTS (SELECT * FROM clips WHERE original_sentence_id = ? AND is_valid = 1 LIMIT 1)
+          WHERE id = ?`,
+          [id, id]);
   }
 
   async saveClip({
@@ -521,10 +529,12 @@ export default class DB {
       await this.mysql.query(
         `
           UPDATE sentences
-          SET clips_count = clips_count + 1
+          SET
+            clips_count = clips_count + 1,
+            has_valid_clip = EXISTS (SELECT * FROM clips WHERE original_sentence_id = ? AND is_valid = 1 LIMIT 1)
           WHERE id = ?
         `,
-        [original_sentence_id]
+        [original_sentence_id, original_sentence_id]
       );
     } catch (e) {
       console.error('error saving clip', e);

--- a/server/src/lib/model/db/migrations/20200529173455-add-valid-clip-column.ts
+++ b/server/src/lib/model/db/migrations/20200529173455-add-valid-clip-column.ts
@@ -1,0 +1,12 @@
+export const up = async function (db: any): Promise<any> {
+  // Note: Manual backfill to follow.
+  return db.runSql(`
+    ALTER TABLE sentences
+    	ADD COLUMN has_valid_clip BOOLEAN DEFAULT FALSE,
+    	ADD INDEX (has_valid_clip);
+  `);
+};
+
+export const down = function (): Promise<any> {
+  return null;
+};


### PR DESCRIPTION
After some pretty extensive testing, I couldn't figure out a query that excludes all sentences that already have a valid clip without dramatically increasingly the query time (depending on user activity levels and implementation style, anywhere from 2-4 seconds per query, up from an average of 0.01s). This may not be a huge issue _now_ since we preload sentences as soon as users come to the site and there should always be sentences available for recording, but it's not something that'll scale well at all, especially since I'm only one person testing and I have no idea what will happen when 700 users all try to load a query that takes 2-4 seconds to run at the same time. 

So instead, this implementation lays the ground-work for future-forward single sentence record limits, with some gradual backfill: 

* Add `has_valid_clip` column to sentences table
* Alter regular sentence and clip serving logic to filter out sentences that have `has_valid_clip`
* Alter recording and voting logic to update `has_valid_clip` in the sentences table

This means that any clips that are deemed valid will have the original sentence removed from the sentence queue, and other clips for that sentence will also be removed from the validation queue. If a user records a sentence that happens to already have a valid clip, they will still be able to record that sentence, but the sentence will be subsequently removed from the sentence queue, and all clips including the one they just recorded will be removed from the validation queue. None of this will affect segment collection, because that's a whole separate mechanism. 

Our sentence serving logic already prioritizes sentences with the lowest numbers of recorded clips, so for the largest language communities, this won't change much of anything because there are still hundreds of thousands of unrecorded sentences. For smaller languages where the entire corpus of sentences has already been recorded, this means that each sentence will allow at most one more clip, and as the community validates they will fill up the `has_valid_clip` column with data. (The actual performance of this will need to be monitored after release to see how it behaves IRL and further adjustments may be required.)

This implementation isn't ideal because we will still allow some degree of redundant sentences before all the data is caught up. However, the alternatives would involve partitioning our database tables, which is a pretty big structural change that comes with other longer-term tradeoffs, OR immediately backfilling the `has_valid_clip` column, which involves updating 9 million sentences by cross-referencing 5 million clips and would most likely require a chunk of site downtime so that the database can do its thing without being affected by incoming new user data changing conditions. 

Let me know if you have any questions or concerns @mbransn!