### PR TITLE
Turn on logging for AWS

### DIFF
--- a/server/src/config-helper.ts
+++ b/server/src/config-helper.ts
@@ -77,10 +77,7 @@ const BASE_CONFIG: CommonVoiceConfig = {
   ADMIN_EMAILS: configEntry('CV_ADMIN_EMAILS', null),
   S3_CONFIG: configEntry(
     'CV_S3_CONFIG',
-    {
-      signatureVersion: 'v4',
-      useDualstack: true,
-    },
+    {},
     castJson
   ),
   SSM_ENABLED: configEntry('CV_SSM_ENABLED', false, castBoolean),

--- a/server/src/lib/aws.ts
+++ b/server/src/lib/aws.ts
@@ -1,6 +1,12 @@
 import { getConfig } from '../config-helper';
 import { config, S3 } from 'aws-sdk';
 
+const awsDefaults = {
+  signatureVersion: 'v4',
+  useDualstack: true,
+  logger: console
+}
+
 if (process.env.HTTP_PROXY) {
   // Currently have no TS typings for proxy-agent, so have to use plain require().
   const proxy = require('proxy-agent');
@@ -11,7 +17,7 @@ if (process.env.HTTP_PROXY) {
 }
 
 export namespace AWS {
-  let s3 = new S3(getConfig().S3_CONFIG);
+  let s3 = new S3({...awsDefaults, ...getConfig().S3_CONFIG});
 
   export function getS3() {
     return s3;


### PR DESCRIPTION
This should turn on the logging that AWS has by default so we can hopefully see more detail when weird file access bugs happen:

https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/logging-sdk-calls.html

cc. @The-smooth-operator 