### PR TITLE
Don't rely on client's locale when saving clips

### DIFF
--- a/server/src/lib/bucket.ts
+++ b/server/src/lib/bucket.ts
@@ -1,7 +1,6 @@
 import { S3 } from 'aws-sdk';
 import { getConfig } from '../config-helper';
 import Model from './model';
-import { ServerError } from './utility';
 import { Sentence, Clip } from 'common';
 /**
  * Bucket

--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -121,9 +121,9 @@ export default class Clip {
    * TODO: Check for empty or silent clips before uploading.
    */
   saveClip = async (request: Request, response: Response) => {
-    const { client_id, headers, params } = request;
-    const sentence = decodeURIComponent(headers.sentence as string);
-    const sentenceId = headers.sentence_id;
+    const { client_id, headers } = request;
+    const sentenceId = headers.sentence_id as string;
+    const sentence = await this.model.db.findSentence(sentenceId);
 
     if (!client_id || !sentence || !sentenceId) {
       console.log(`sent headers: ${JSON.stringify(headers)}`);
@@ -176,14 +176,14 @@ export default class Clip {
 
       await this.model.saveClip({
         client_id: client_id,
-        locale: params.locale,
+        locale: sentence.locale_id,
         original_sentence_id: sentenceId,
         path: clipFileName,
-        sentence,
+        sentence: sentence.text,
       });
-      await Awards.checkProgress(client_id, { name: params.locale });
+      await Awards.checkProgress(client_id, { id: sentence.locale_id });
 
-      await checkGoalsAfterContribution(client_id, { name: params.locale });
+      await checkGoalsAfterContribution(client_id, { id: sentence.locale_id });
 
       Basket.sync(client_id).catch(e => console.error(e));
 

--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -721,9 +721,10 @@ export default class DB {
 
   async findSentence(id: string) {
     return (
-      await this.mysql.query('SELECT * FROM sentences WHERE id = ? LIMIT 1', [
-        id,
-      ])
+      await this.mysql.query(
+        'SELECT locale_id, text FROM sentences WHERE id = ? LIMIT 1',
+        [id]
+      )
     )[0][0];
   }
 

--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -512,20 +512,18 @@ export default class DB {
 
   async saveClip({
     client_id,
-    locale,
+    localeId,
     original_sentence_id,
     path,
     sentence,
   }: {
     client_id: string;
-    locale: string;
+    localeId: number;
     original_sentence_id: string;
     path: string;
     sentence: string;
   }): Promise<void> {
     try {
-      const localeId = await getLocaleId(locale);
-
       await this.mysql.query(
         `
           INSERT INTO clips (client_id, original_sentence_id, path, sentence, locale_id)
@@ -718,6 +716,14 @@ export default class DB {
   async findClip(id: string) {
     return (
       await this.mysql.query('SELECT * FROM clips WHERE id = ? LIMIT 1', [id])
+    )[0][0];
+  }
+
+  async findSentence(id: string) {
+    return (
+      await this.mysql.query('SELECT * FROM sentences WHERE id = ? LIMIT 1', [
+        id,
+      ])
     )[0][0];
   }
 

--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -441,11 +441,7 @@ class SpeakPage extends React.Component<Props, State> {
               hasEarnedSessionToast = false,
               showFirstStreakToast = false,
               challengeEnded = true,
-            } = await api.uploadClip(
-              recording.blob,
-              sentence.id,
-              sentence.text
-            );
+            } = await api.uploadClip(recording.blob, sentence.id);
             URL.revokeObjectURL(recording.url);
             sessionStorage.setItem(
               'challengeEnded',

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -111,8 +111,7 @@ export default class API {
 
   uploadClip(
     blob: Blob,
-    sentenceId: string,
-    sentence: string
+    sentenceId: string
   ): Promise<{
     showFirstContributionToast?: boolean;
     hasEarnedSessionToast?: boolean;
@@ -124,7 +123,6 @@ export default class API {
       method: 'POST',
       headers: {
         'Content-Type': blob.type,
-        sentence: encodeURIComponent(sentence),
         sentence_id: sentenceId,
         challenge: getChallenge(this.user),
       },


### PR DESCRIPTION
We've been seeing reports of clips of one language showing up on the
/listen page of another language. Our client does its best to be
responsive and quick when a user changes their language… as it should.
But when someone changes their language mid-way through recording a
batch of clips, it shouldn't affect the language those clips are saved
under.

This is a small and simple commit to move locale-handling to the server.
It adds a db call with `db.findSentence`, but removes three calls by
avoiding `db.getLocaleId`… so I think this might be a performance win in
the end.