### PR TITLE
Use compat build of Fluent

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@fluent/bundle": "^0.15.0",
-    "@fluent/react": "^0.12.0",
+    "@fluent/bundle/compat": "^0.15.0",
+    "@fluent/react/compat": "^0.12.0",
     "@fullstory/browser": "^1.3.1",
     "@types/amplitude-js": "^5.8.0",
     "@types/classnames": "^2.2.9",

--- a/web/src/components/app.tsx
+++ b/web/src/components/app.tsx
@@ -44,7 +44,7 @@ import {
   LocalePropsFromState,
 } from './locale-helpers';
 import { Flags } from '../stores/flags';
-import { ReactLocalization, LocalizationProvider } from '@fluent/react';
+import { ReactLocalization, LocalizationProvider } from '@fluent/react/compat';
 const rtlLocales = require('../../../locales/rtl.json');
 const ListenPage = React.lazy(() =>
   import('./pages/contribution/listen/listen')

--- a/web/src/components/contact-modal/contact-modal.tsx
+++ b/web/src/components/contact-modal/contact-modal.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import Modal from '../modal/modal';
 import { Button, LabeledInput, LabeledTextArea, TextButton } from '../ui/ui';

--- a/web/src/components/language-select/language-select.tsx
+++ b/web/src/components/language-select/language-select.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import Downshift from 'downshift';
 import * as React from 'react';
 

--- a/web/src/components/layout/footer.tsx
+++ b/web/src/components/layout/footer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import { trackNav } from '../../services/tracker';
 import URLS from '../../urls';
 import ShareButtons from '../share-buttons/share-buttons';

--- a/web/src/components/layout/layout.tsx
+++ b/web/src/components/layout/layout.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { RouteComponentProps, Redirect, withRouter } from 'react-router';

--- a/web/src/components/layout/nav.tsx
+++ b/web/src/components/layout/nav.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { trackNav, getTrackClass } from '../../services/tracker';
 import URLS from '../../urls';

--- a/web/src/components/layout/subscribe-newsletter.tsx
+++ b/web/src/components/layout/subscribe-newsletter.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { useState } from 'react';
 import { useAPI } from '../../hooks/store-hooks';

--- a/web/src/components/layout/user-menu.tsx
+++ b/web/src/components/layout/user-menu.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { Suspense, lazy } from 'react';
 import { useState } from 'react';

--- a/web/src/components/locale-helpers.tsx
+++ b/web/src/components/locale-helpers.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Link, LinkProps, NavLink, NavLinkProps } from 'react-router-dom';
 import { Locale } from '../stores/locale';
 import StateTree, { useTypedSelector } from '../stores/tree';
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 
 export const contributableLocales = require('../../../locales/contributable.json') as string[];
 export const discourseLocales = require('../../../locales/discourse.json');

--- a/web/src/components/pages/about/get-involved.tsx
+++ b/web/src/components/pages/about/get-involved.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import {
   GitHubLink,
   DiscourseLink,

--- a/web/src/components/pages/about/how-it-works.tsx
+++ b/web/src/components/pages/about/how-it-works.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as cx from 'classnames';
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 
 import './how-it-works.css';
 

--- a/web/src/components/pages/about/nav.tsx
+++ b/web/src/components/pages/about/nav.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as cx from 'classnames';
 import { SECTIONS } from './constants';
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import { FlagIcon, LayersIcon, UsersIcon, HeartIcon } from '../../ui/icons';
 
 const throttle = require('lodash.throttle');

--- a/web/src/components/pages/about/partners.tsx
+++ b/web/src/components/pages/about/partners.tsx
@@ -2,7 +2,7 @@ import Slider from './slider';
 import * as React from 'react';
 import { Button } from '../../ui/ui';
 import { ArrowLeft } from '../../ui/icons';
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import { ContactLink } from '../../shared/links';
 
 import './partners.css';

--- a/web/src/components/pages/about/slider.tsx
+++ b/web/src/components/pages/about/slider.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as cx from 'classnames';
 import { ChevronRight } from '../../ui/icons';
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 
 import './slider.css';
 

--- a/web/src/components/pages/about/why-common-voice.tsx
+++ b/web/src/components/pages/about/why-common-voice.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 
 import './why-common-voice.css';
 

--- a/web/src/components/pages/contribution/contribution.tsx
+++ b/web/src/components/pages/contribution/contribution.tsx
@@ -2,7 +2,7 @@ import {
   Localized,
   withLocalization,
   WithLocalizationProps,
-} from '@fluent/react';
+} from '@fluent/react/compat';
 import * as React from 'react';
 import { connect } from 'react-redux';
 const { Tooltip } = require('react-tippy');

--- a/web/src/components/pages/contribution/listen/listen.tsx
+++ b/web/src/components/pages/contribution/listen/listen.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Clip as ClipType } from 'common';

--- a/web/src/components/pages/contribution/report/report.tsx
+++ b/web/src/components/pages/contribution/report/report.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { useState } from 'react';
 import { useAPI } from '../../../../hooks/store-hooks';

--- a/web/src/components/pages/contribution/speak/recording-pill.tsx
+++ b/web/src/components/pages/contribution/speak/recording-pill.tsx
@@ -2,7 +2,7 @@ import {
   Localized,
   withLocalization,
   WithLocalizationProps,
-} from '@fluent/react';
+} from '@fluent/react/compat';
 import * as React from 'react';
 import { useRef, useState } from 'react';
 import { trackRecording } from '../../../../services/tracker';

--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -2,7 +2,7 @@ import {
   Localized,
   WithLocalizationProps,
   withLocalization,
-} from '@fluent/react';
+} from '@fluent/react/compat';
 import * as React from 'react';
 import BalanceText from 'react-balance-text';
 import { connect } from 'react-redux';

--- a/web/src/components/pages/contribution/success.tsx
+++ b/web/src/components/pages/contribution/success.tsx
@@ -2,7 +2,7 @@ import {
   Localized,
   withLocalization,
   WithLocalizationProps,
-} from '@fluent/react';
+} from '@fluent/react/compat';
 import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { DAILY_GOALS } from '../../../constants';

--- a/web/src/components/pages/dashboard/dashboard.tsx
+++ b/web/src/components/pages/dashboard/dashboard.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { Redirect, Route, Switch } from 'react-router';

--- a/web/src/components/pages/dashboard/goals/custom-goal-steps.tsx
+++ b/web/src/components/pages/dashboard/goals/custom-goal-steps.tsx
@@ -1,4 +1,4 @@
-import { Localized, withLocalization } from '@fluent/react';
+import { Localized, withLocalization } from '@fluent/react/compat';
 import * as React from 'react';
 import { useState } from 'react';
 import { CustomGoal, CustomGoalParams } from 'common';

--- a/web/src/components/pages/dashboard/goals/custom-goal.tsx
+++ b/web/src/components/pages/dashboard/goals/custom-goal.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { useState } from 'react';
 import { CustomGoalParams } from 'common';

--- a/web/src/components/pages/dashboard/goals/goal-row.tsx
+++ b/web/src/components/pages/dashboard/goals/goal-row.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import { GlobalGoal } from 'common';
 
 import './goal-row.css';

--- a/web/src/components/pages/dashboard/stats/leaderboard-card.tsx
+++ b/web/src/components/pages/dashboard/stats/leaderboard-card.tsx
@@ -2,7 +2,7 @@ import {
   Localized,
   withLocalization,
   WithLocalizationProps,
-} from '@fluent/react';
+} from '@fluent/react/compat';
 import * as React from 'react';
 import { useRef, useState } from 'react';
 import { connect } from 'react-redux';

--- a/web/src/components/pages/dashboard/stats/progress-card.tsx
+++ b/web/src/components/pages/dashboard/stats/progress-card.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { DAILY_GOALS } from '../../../../constants';

--- a/web/src/components/pages/dashboard/stats/stats-card.tsx
+++ b/web/src/components/pages/dashboard/stats/stats-card.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { useState } from 'react';
 import LanguageSelect, {

--- a/web/src/components/pages/datasets/circle-stats.tsx
+++ b/web/src/components/pages/datasets/circle-stats.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { GlobeIcon, MicIcon, PlayOutlineIcon } from '../../ui/icons';
 import Dots from './dots';

--- a/web/src/components/pages/datasets/dataset-info.tsx
+++ b/web/src/components/pages/datasets/dataset-info.tsx
@@ -2,7 +2,7 @@ import {
   Localized,
   withLocalization,
   WithLocalizationProps,
-} from '@fluent/react';
+} from '@fluent/react/compat';
 import * as React from 'react';
 import { useState } from 'react';
 import { connect } from 'react-redux';

--- a/web/src/components/pages/datasets/datasets.tsx
+++ b/web/src/components/pages/datasets/datasets.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import URLS from '../../../urls';

--- a/web/src/components/pages/datasets/resources.tsx
+++ b/web/src/components/pages/datasets/resources.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { useState } from 'react';
 import { InView } from 'react-intersection-observer';

--- a/web/src/components/pages/datasets/subscribe.tsx
+++ b/web/src/components/pages/datasets/subscribe.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import URLS from '../../../urls';

--- a/web/src/components/pages/faq/faq.tsx
+++ b/web/src/components/pages/faq/faq.tsx
@@ -10,7 +10,7 @@ import {
   Localized,
   withLocalization,
   WithLocalizationProps,
-} from '@fluent/react';
+} from '@fluent/react/compat';
 
 const throttle = require('lodash.throttle');
 

--- a/web/src/components/pages/faq/selectors.tsx
+++ b/web/src/components/pages/faq/selectors.tsx
@@ -3,7 +3,7 @@ import URLS from '../../../urls';
 import { StyledLink } from '../../ui/ui';
 import { LocaleLink } from '../../locale-helpers';
 import { stringContains } from '../../../utility';
-import { WithLocalizationProps } from '@fluent/react';
+import { WithLocalizationProps } from '@fluent/react/compat';
 import { BENEFITS, WHATS_PUBLIC } from '../../../constants';
 
 const memoize = require('lodash.memoize');

--- a/web/src/components/pages/home/hero.tsx
+++ b/web/src/components/pages/home/hero.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { DAILY_GOALS } from '../../../constants';

--- a/web/src/components/pages/home/home.tsx
+++ b/web/src/components/pages/home/home.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { shallowEqual } from 'react-redux';

--- a/web/src/components/pages/home/stats.tsx
+++ b/web/src/components/pages/home/stats.tsx
@@ -3,7 +3,7 @@ import {
   Localized,
   withLocalization,
   WithLocalizationProps,
-} from '@fluent/react';
+} from '@fluent/react/compat';
 import * as React from 'react';
 import { useState } from 'react';
 import { connect } from 'react-redux';

--- a/web/src/components/pages/landing/landing.tsx
+++ b/web/src/components/pages/landing/landing.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { trackLanding } from '../../../services/tracker';
 import { useTypedSelector } from '../../../stores/tree';

--- a/web/src/components/pages/languages/get-involved-modal.tsx
+++ b/web/src/components/pages/languages/get-involved-modal.tsx
@@ -9,7 +9,7 @@ import StateTree from '../../../stores/tree';
 import { User } from '../../../stores/user';
 import PrivacyInfo from '../../privacy-info';
 import { Button, Hr, LabeledInput } from '../../ui/ui';
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 
 interface PropsFromState {
   api: API;

--- a/web/src/components/pages/languages/languages.tsx
+++ b/web/src/components/pages/languages/languages.tsx
@@ -2,7 +2,7 @@ import {
   Localized,
   withLocalization,
   WithLocalizationProps,
-} from '@fluent/react';
+} from '@fluent/react/compat';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { BaseLanguage, InProgressLanguage, LaunchedLanguage } from 'common';

--- a/web/src/components/pages/languages/localization-box.tsx
+++ b/web/src/components/pages/languages/localization-box.tsx
@@ -11,7 +11,7 @@ import { toLocaleRouteBuilder, useLocale } from '../../locale-helpers';
 import ProgressBar from '../../progress-bar/progress-bar';
 import { Hr } from '../../ui/ui';
 import GetInvolvedModal from './get-involved-modal';
-import { Localized, LocalizationProvider } from '@fluent/react';
+import { Localized, LocalizationProvider } from '@fluent/react/compat';
 
 const SENTENCE_COUNT_TARGET = 5000;
 

--- a/web/src/components/pages/not-found.tsx
+++ b/web/src/components/pages/not-found.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 
 export default () => (
   <div id="not-found-container">

--- a/web/src/components/pages/profile/avatar-setup/avatar-setup.tsx
+++ b/web/src/components/pages/profile/avatar-setup/avatar-setup.tsx
@@ -2,7 +2,7 @@ import {
   Localized,
   withLocalization,
   WithLocalizationProps,
-} from '@fluent/react';
+} from '@fluent/react/compat';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import API from '../../../../services/api';

--- a/web/src/components/pages/profile/delete/delete.tsx
+++ b/web/src/components/pages/profile/delete/delete.tsx
@@ -2,7 +2,7 @@ import {
   Localized,
   withLocalization,
   WithLocalizationProps,
-} from '@fluent/react';
+} from '@fluent/react/compat';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { User } from '../../../../stores/user';

--- a/web/src/components/pages/profile/info/info.tsx
+++ b/web/src/components/pages/profile/info/info.tsx
@@ -2,7 +2,7 @@ import {
   Localized,
   withLocalization,
   WithLocalizationProps,
-} from '@fluent/react';
+} from '@fluent/react/compat';
 import * as React from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import { Redirect, RouteComponentProps, withRouter } from 'react-router';

--- a/web/src/components/pages/profile/layout.tsx
+++ b/web/src/components/pages/profile/layout.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 const pick = require('lodash.pick');
 import * as React from 'react';
 import { connect } from 'react-redux';

--- a/web/src/components/pages/profile/settings/settings.tsx
+++ b/web/src/components/pages/profile/settings/settings.tsx
@@ -2,7 +2,7 @@ import {
   Localized,
   withLocalization,
   WithLocalizationProps,
-} from '@fluent/react';
+} from '@fluent/react/compat';
 import * as React from 'react';
 import { useEffect } from 'react';
 import { connect } from 'react-redux';

--- a/web/src/components/privacy-info.tsx
+++ b/web/src/components/privacy-info.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 
 export default ({ localizedPrefix }: { localizedPrefix?: string }) => {

--- a/web/src/components/register-section/register-section.tsx
+++ b/web/src/components/register-section/register-section.tsx
@@ -1,5 +1,5 @@
 import * as cx from 'classnames';
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { useState } from 'react';
 import { trackHome } from '../../services/tracker';

--- a/web/src/components/request-language-modal/language-autocomplete.tsx
+++ b/web/src/components/request-language-modal/language-autocomplete.tsx
@@ -1,5 +1,5 @@
 import Downshift from 'downshift';
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { useEffect } from 'react';
 import { useAction } from '../../hooks/store-hooks';

--- a/web/src/components/request-language-modal/language-request-success.tsx
+++ b/web/src/components/request-language-modal/language-request-success.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { SuccessIcon } from '../ui/icons';
 import { TextButton } from '../ui/ui';

--- a/web/src/components/request-language-modal/request-language-modal.tsx
+++ b/web/src/components/request-language-modal/request-language-modal.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import Modal from '../modal/modal';

--- a/web/src/components/share-buttons/share-buttons.tsx
+++ b/web/src/components/share-buttons/share-buttons.tsx
@@ -2,7 +2,7 @@ import {
   Localized,
   withLocalization,
   WithLocalizationProps,
-} from '@fluent/react';
+} from '@fluent/react/compat';
 import * as React from 'react';
 import { useRef } from 'react';
 import { trackSharing } from '../../services/tracker';

--- a/web/src/components/share-modal/share-modal.tsx
+++ b/web/src/components/share-modal/share-modal.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import Modal from '../modal/modal';
 import ShareButtons from '../share-buttons/share-buttons';

--- a/web/src/components/terms-modal.tsx
+++ b/web/src/components/terms-modal.tsx
@@ -3,7 +3,7 @@ import {
   Localized,
   withLocalization,
   WithLocalizationProps,
-} from '@fluent/react';
+} from '@fluent/react/compat';
 import URLS from '../urls';
 import { LocaleLink } from './locale-helpers';
 import Modal from './modal/modal';

--- a/web/src/components/ui/ui.tsx
+++ b/web/src/components/ui/ui.tsx
@@ -1,4 +1,4 @@
-import { Localized } from '@fluent/react';
+import { Localized } from '@fluent/react/compat';
 import * as React from 'react';
 import { HTMLProps, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';

--- a/web/src/services/localization.ts
+++ b/web/src/services/localization.ts
@@ -5,8 +5,8 @@ export const NATIVE_NAMES = require('../../../locales/native-names.json') as {
   [key: string]: string;
 };
 const translatedLocales = require('../../../locales/translated.json');
-import { FluentBundle, FluentResource } from '@fluent/bundle';
-import { ReactLocalization } from '@fluent/react';
+import { FluentBundle, FluentResource } from '@fluent/bundle/compat';
+import { ReactLocalization } from '@fluent/react/compat';
 import { Flags } from '../stores/flags';
 import { isProduction } from '../utility';
 import API from './api';


### PR DESCRIPTION
Use compat build of fluent to support Edge older than 79.

See projectfluent/fluent.js#431 and mozilla-iot/gateway#2238