### PR TITLE
added fill rule for disabled hover state

### DIFF
--- a/web/src/components/pages/contribution/listen/listen.css
+++ b/web/src/components/pages/contribution/listen/listen.css
@@ -114,6 +114,12 @@
             background: var(--white);
             box-shadow: var(--vote-button-box-shadow)
                 color-mod(var(--grey) alpha(80%));
+
+            &:hover {
+                path {
+                    fill: var(--near-black);
+                }
+            }
         }
 
         & svg {


### PR DESCRIPTION
bug fix for issue #2780 where vote button icons become invisible in the disabled state during hovering.