### PR TITLE
Feature/auto switch local for stats card

### DIFF
--- a/web/src/components/pages/dashboard/stats/leaderboard-card.tsx
+++ b/web/src/components/pages/dashboard/stats/leaderboard-card.tsx
@@ -331,7 +331,11 @@ const FilledCheckIcon = () => (
 
 const Percentage = () => <div className="percent">%</div>;
 
-export default function LeaderboardCard() {
+export default function LeaderboardCard({
+  currentLocale,
+}: {
+  currentLocale?: string;
+}) {
   const account = useAccount();
   const saveAccount = useAction(User.actions.saveAccount);
 
@@ -343,6 +347,7 @@ export default function LeaderboardCard() {
   return (
     <StatsCard
       key="leaderboard"
+      {...{ currentLocale }}
       className={'leaderboard-card ' + (showOverlay ? 'has-overlay' : '')}
       title="top-contributors"
       iconButtons={
@@ -431,7 +436,7 @@ export default function LeaderboardCard() {
                 saveAccount({ visible: event.target.checked });
               }}
             />
-            <Localized id="visibility-explainer" vars={{minutes: 20}}>
+            <Localized id="visibility-explainer" vars={{ minutes: 20 }}>
               <p className="explainer" />
             </Localized>
             <div className="info">
@@ -439,7 +444,7 @@ export default function LeaderboardCard() {
               <Localized
                 id="visibility-overlay-note"
                 elems={{
-                  profileLink: <LocaleLink to={URLS.PROFILE_INFO} />
+                  profileLink: <LocaleLink to={URLS.PROFILE_INFO} />,
                 }}>
                 <p className="note" />
               </Localized>

--- a/web/src/components/pages/dashboard/stats/stats-card.tsx
+++ b/web/src/components/pages/dashboard/stats/stats-card.tsx
@@ -1,6 +1,6 @@
 import { Localized } from '@fluent/react';
 import * as React from 'react';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import LanguageSelect, {
   ALL_LOCALES,
 } from '../../../language-select/language-select';
@@ -14,6 +14,7 @@ export default function StatsCard({
   overlay,
   tabs,
   challenge,
+  currentLocale,
 }: {
   className?: string;
   title: string;
@@ -21,9 +22,13 @@ export default function StatsCard({
   overlay?: React.ReactNode;
   tabs?: { [label: string]: (props: { locale?: string }) => any };
   challenge?: boolean;
+  currentLocale?: string;
 }) {
-  const [locale, setLocale] = useState(ALL_LOCALES);
+  const [locale, setLocale] = useState(
+    currentLocale ? currentLocale : ALL_LOCALES
+  );
   const [selectedTab, setSelectedTab] = useState(Object.keys(tabs)[0]);
+  useEffect(() => setLocale(currentLocale), [currentLocale]);
 
   return (
     <div className={'stats-card ' + (className || '')}>

--- a/web/src/components/pages/dashboard/stats/stats-card.tsx
+++ b/web/src/components/pages/dashboard/stats/stats-card.tsx
@@ -24,11 +24,11 @@ export default function StatsCard({
   challenge?: boolean;
   currentLocale?: string;
 }) {
-  const [locale, setLocale] = useState(
-    currentLocale ? currentLocale : ALL_LOCALES
-  );
+  const [locale, setLocale] = useState(ALL_LOCALES);
   const [selectedTab, setSelectedTab] = useState(Object.keys(tabs)[0]);
-  useEffect(() => setLocale(currentLocale), [currentLocale]);
+  useEffect(() => setLocale(currentLocale ? currentLocale : ALL_LOCALES), [
+    currentLocale,
+  ]);
 
   return (
     <div className={'stats-card ' + (className || '')}>

--- a/web/src/components/pages/dashboard/stats/stats.tsx
+++ b/web/src/components/pages/dashboard/stats/stats.tsx
@@ -35,6 +35,7 @@ const StatsPage = ({ allGoals, dashboardLocale }: Props) =>
         <StatsCard
           key="contribution"
           title="contribution-activity"
+          currentLocale={dashboardLocale}
           tabs={['you', 'everyone'].reduce(
             (o: any, from: any) => ({
               ...o,
@@ -48,7 +49,7 @@ const StatsPage = ({ allGoals, dashboardLocale }: Props) =>
             {}
           )}
         />
-        <LeaderboardCard />
+        <LeaderboardCard currentLocale={dashboardLocale} />
       </div>
     </div>
   ) : null;


### PR DESCRIPTION
@phirework. this is a PR for issue #2786; I basically passed in dashboardLocale as a prop for the stats-card component, and set-up a side-effect to change the card's locale whenever dashboardLocale changes. To avoid making unnecessary changes in other locations, I made the new stats-card prop (currentLocale) optional.