### PR TITLE
Scrub leaderboard data if there are fewer than 5 users on list

### DIFF
--- a/server/src/lib/model/leaderboard.ts
+++ b/server/src/lib/model/leaderboard.ts
@@ -345,6 +345,8 @@ export default async function getLeaderboard({
     return prepareRows(leaderboard.slice(cursor[0], cursor[1]));
   }
 
+  if (leaderboard.length < 5) leaderboard = [];
+
   const userIndex = leaderboard.findIndex(row => row.client_id == client_id);
   const userRegion =
     userIndex == -1 ? [] : leaderboard.slice(userIndex - 1, userIndex + 2);


### PR DESCRIPTION
@mbransn According to the strictest definition of the rule of 5, we should be hiding leaderboard entries for all languages that have fewer than 5 unique speakers, which as of right now is just Votic. But since leaderboards are influenced by user settings, I've set it up so that leaderboard entries are hidden for all languages that have fewer than 5 visible speakers, which feels more in line with the spirit of the rule. Let me know if you have any concerns about this!