### PR TITLE
Sort languages by active hours other than currently selected language

### DIFF
--- a/web/src/components/pages/languages/languages.tsx
+++ b/web/src/components/pages/languages/languages.tsx
@@ -99,14 +99,6 @@ class LanguagesPage extends React.PureComponent<Props, State> {
           return 1;
         }
 
-        // English comes last
-        if (l1.locale === 'en') {
-          return 1;
-        }
-        if (l2.locale === 'en') {
-          return -1;
-        }
-
         // Browser locales are prioritized as well
         if (navigator.languages.includes(l1.locale)) {
           return -1;


### PR DESCRIPTION
Once upon a time in the halcyon days of 2018, we decided that languages on the `/languages` page should be sorted by the currently selected locales and then by active hours, except for English, which would always be last (unless you were currently localized as English). No one currently knows why this is, and it is a confusing user experience (see #2834) so we're changing this to prioritize the currently selected language and otherwise sort by active hours as normal. 