### PR TITLE
Prepare for voice -> commonvoice domain change

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -253,7 +253,7 @@ For more options, just type:
 
 The project is organized into the following directories:
 
-- _android_: The Android app, a simple webview wrapper of voice.mozilla.org. This app is currently not published.
+- _android_: The Android app, a simple webview wrapper of commonvoice.mozilla.org. This app is currently not published.
 - _docs_: Design and data specifications for Common Voice.
 - _ios **(deprecated)**_: We used to maintain a native iOS app as a workaround for microphone issues in mobile Safari. As of early 2020, we officially support voice recording in iOS Safari. The Common Voice iOS app has been decommissioned.
 - _server_: The server-side app logic, written in [TypeScript](http://www.typescriptlang.org/).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ## Common Voice [![Travis Status](https://travis-ci.org/mozilla/voice-web.svg?branch=master)](https://travis-ci.org/mozilla/voice-web)
 
-This is the web app for Mozilla Common Voice, a platform for collecting speech donations in order to create public domain datasets for training voice recognition-related tools. 
+This is the web app for Mozilla Common Voice, a platform for collecting speech donations in order to create public domain datasets for training voice recognition-related tools.
 
 ### Official Website
 
-[voice.mozilla.org](https://voice.mozilla.org)
+[voice.mozilla.org](https://commonvoice.mozilla.org)
 
 ### Code of Conduct
 

--- a/contribute.json
+++ b/contribute.json
@@ -7,7 +7,7 @@
     "tests": "https://travis-ci.org/mozilla/voice-web/"
   },
   "participate": {
-    "home": "https://voice.mozilla.org",
+    "home": "https://commonvoice.mozilla.org",
     "docs": "https://github.com/mozilla/voice-web/blob/master/CONTRIBUTING.md",
     "forum": "https://discourse.mozilla.org/c/voice",
     "matrix": "https://chat.mozilla.org/#/room/#common-voice:mozilla.org"
@@ -17,8 +17,8 @@
     "report": "https://github.com/mozilla/voice-web/issues/new"
   },
   "urls": {
-    "prod": "https://voice.mozilla.org",
-    "stage": "https://voice.allizom.org"
+    "prod": "https://commonvoice.mozilla.org",
+    "stage": "https://commonvoice.allizom.org"
   },
   "keywords": [
     "asr",

--- a/docs/corpus_readme.txt
+++ b/docs/corpus_readme.txt
@@ -1,7 +1,7 @@
 1. General information
 ======================
 
-Common Voice is a corpus of speech data read by users on the Common Voice website (https://voice.mozilla.org/), and based upon text from a number of public domain sources like user submitted blog posts, old books, movies, and other public speech corpora. Its primary purpose is to enable the training and testing of automatic speech recognition (ASR) systems, but we encourage its use for other purposes as well.
+Common Voice is a corpus of speech data read by users on the Common Voice website (https://commonvoice.mozilla.org/), and based upon text from a number of public domain sources like user submitted blog posts, old books, movies, and other public speech corpora. Its primary purpose is to enable the training and testing of automatic speech recognition (ASR) systems, but we encourage its use for other purposes as well.
 
 
 2. Structure
@@ -44,7 +44,7 @@ Each row of a csv file represents a single audio clip, and contains the followin
   female
   other
 * accent - accent of the speaker, if the speaker reported it
-  us: 'United States English'                                                                                                                                          
+  us: 'United States English'
   australia: 'Australian English'
   england: 'England English'
   canada: 'Canadian English'

--- a/docs/open-data-registry.yaml
+++ b/docs/open-data-registry.yaml
@@ -1,5 +1,5 @@
 Name: The Common Voice Project
-Description: Common Voice is a corpus of speech data read by users on the Common Voice website (https://voice.mozilla.org/), and based upon text from a number of public domain sources like user submitted blog posts, old books, movies, and other public speech corpora. Its primary purpose is to enable the training and testing of automatic speech recognition (ASR) systems, but we encourage its use for other purposes as well.
+Description: Common Voice is a corpus of speech data read by users on the Common Voice website (https://commonvoice.mozilla.org/), and based upon text from a number of public domain sources like user submitted blog posts, old books, movies, and other public speech corpora. Its primary purpose is to enable the training and testing of automatic speech recognition (ASR) systems, but we encourage its use for other purposes as well.
 Documentation: https://github.com/mozilla/voice-web/blob/master/docs/corpus_readme.txt
 Contact: https://chat.mozilla.org/#/room/#common-voice:mozilla.org
 UpdateFrequency: We publish new versions of the dataset for every 500 hours collected for a single language. We may publish more often for smaller languages.

--- a/server/src/auth-router.ts
+++ b/server/src/auth-router.ts
@@ -76,8 +76,8 @@ if (DOMAIN) {
       clientSecret: CLIENT_SECRET,
       callbackURL:
         (({
-          stage: 'https://voice.allizom.org',
-          prod: 'https://voice.mozilla.org',
+          stage: 'https://commonvoice.allizom.org',
+          prod: 'https://commonvoice.mozilla.org',
           dev: 'https://dev.voice.mozit.cloud',
           sandbox: 'https://sandbox.voice.mozit.cloud',
         } as any)[ENVIRONMENT] || '') + CALLBACK_URL,

--- a/web/index_template.html
+++ b/web/index_template.html
@@ -21,22 +21,22 @@
       property="og:description"
       content="Common Voice is a project to help make voice recognition open to everyone. Now you can donate your voice to help us build an open-source voice database that anyone can use to make innovative apps for devices and the web."
     />
-    <meta property="og:url" content="https://voice.mozilla.org/" />
+    <meta property="og:url" content="https://commonvoice.mozilla.org/" />
     <meta
       property="og:image"
-      content="https://voice.mozilla.org/img/cv-social-1024x512.jpg"
+      content="https://commonvoice.mozilla.org/img/cv-social-1024x512.jpg"
     />
     <meta property="og:image:width" content="1024" />
     <meta property="og:image:height" content="512" />
     <meta
       property="og:image"
-      content="https://voice.mozilla.org/img/cv-social-1024x512@2x.jpg"
+      content="https://commonvoice.mozilla.org/img/cv-social-1024x512@2x.jpg"
     />
     <meta property="og:image:width" content="2048" />
     <meta property="og:image:height" content="1024" />
     <meta
       property="og:image"
-      content="https://voice.mozilla.org/img/cv-social-1024x512@3x.jpg"
+      content="https://commonvoice.mozilla.org/img/cv-social-1024x512@3x.jpg"
     />
     <meta property="og:image:width" content="3072" />
     <meta property="og:image:height" content="1536" />
@@ -56,7 +56,7 @@
     -->
     <!-- prettier-ignore -->
     <script>
-      if (window.location.origin !== 'https://voice.mozilla.org') {
+      if (window.location.origin !== 'https://commonvoice.mozilla.org') {
         console.log('disabling analytics on non production');
         window.ga = function() {};
       } else if (

--- a/web/src/components/layout/layout.tsx
+++ b/web/src/components/layout/layout.tsx
@@ -308,7 +308,7 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
           <div className="staging-banner">
             You're on the staging server. Voice data is not collected here.{' '}
             <a
-              href={URLS.HTTP_ROOT}
+              href={URLS.HTTP_ROOT[0]}
               target="_blank"
               rel="noopener noreferrer">
               Don't waste your breath.

--- a/web/src/components/layout/layout.tsx
+++ b/web/src/components/layout/layout.tsx
@@ -308,13 +308,13 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
           <div className="staging-banner">
             You're on the staging server. Voice data is not collected here.{' '}
             <a
-              href="https://voice.mozilla.org"
+              href={URLS.HTTP_ROOT}
               target="_blank"
               rel="noopener noreferrer">
               Don't waste your breath.
             </a>{' '}
             <a
-              href="https://github.com/mozilla/voice-web/issues/new"
+              href={`${URLS.GITHUB_ROOT}/issues/new`}
               rel="noopener noreferrer"
               target="_blank">
               Feel free to report issues.

--- a/web/src/components/pages/faq/selectors.tsx
+++ b/web/src/components/pages/faq/selectors.tsx
@@ -106,7 +106,7 @@ const SECTION_CONTENTS: any = {
           italic: <i />,
           githubLink: (
             <StyledLink
-              href="https://github.com/mozilla/voice-web/tree/master/server/data"
+              href={`${URLS.GITHUB_ROOT}/tree/master/server/data`}
               blank
             />
           ),

--- a/web/src/components/share-buttons/share-buttons.tsx
+++ b/web/src/components/share-buttons/share-buttons.tsx
@@ -9,11 +9,12 @@ import { trackSharing } from '../../services/tracker';
 import { Notifications } from '../../stores/notifications';
 import { FontIcon } from '../ui/icons';
 import { useLocale } from '../locale-helpers';
+import URLS from '../../urls';
 
 import './share-buttons.css';
 import { useAction } from '../../hooks/store-hooks';
 
-const SHARE_URL = 'https://voice.mozilla.org/';
+const SHARE_URL = URLS.HTTP_ROOT;
 
 interface Props extends WithLocalizationProps {
   shareTextId?: string;

--- a/web/src/components/share-buttons/share-buttons.tsx
+++ b/web/src/components/share-buttons/share-buttons.tsx
@@ -14,7 +14,7 @@ import URLS from '../../urls';
 import './share-buttons.css';
 import { useAction } from '../../hooks/store-hooks';
 
-const SHARE_URL = URLS.HTTP_ROOT;
+const SHARE_URL = URLS.HTTP_ROOT[0];
 
 interface Props extends WithLocalizationProps {
   shareTextId?: string;

--- a/web/src/components/shared/links.tsx
+++ b/web/src/components/shared/links.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useState } from 'react';
 import { TextButton } from '../ui/ui';
+import URLS from '../../urls';
 import { trackGlobal } from '../../services/tracker';
 import ContactModal from '../contact-modal/contact-modal';
 import { useLocale, useLocalizedDiscourseURL } from '../locale-helpers';
@@ -17,7 +18,7 @@ export const GitHubLink = ({ dispatch, ...props }: SharedLinkProps) => {
   return (
     <a
       target="_blank"
-      href="https://github.com/mozilla/voice-web"
+      href={`${URLS.GITHUB_ROOT}`}
       rel="noopener noreferrer"
       onClick={() => trackGlobal('github', locale)}
       {...props}

--- a/web/src/urls.ts
+++ b/web/src/urls.ts
@@ -34,4 +34,8 @@ export default Object.freeze({
     'https://discourse.mozilla.org/t/help-create-common-voices-first-target-segment/59587',
   TARGET_SEGMENT_INFO_ES:
     'https://discourse.mozilla.org/t/ayuda-a-crear-el-primer-objetivo-segmentado-de-common-voice/60472/',
+
+  HTTP_ROOT: 'https://commonvoice.mozilla.org',
+  STAGING_ROOT: 'https://commonvoice.allizom.org',
+  GITHUB_ROOT: 'https://github.com/mozilla/voice-web',
 });

--- a/web/src/urls.ts
+++ b/web/src/urls.ts
@@ -35,7 +35,7 @@ export default Object.freeze({
   TARGET_SEGMENT_INFO_ES:
     'https://discourse.mozilla.org/t/ayuda-a-crear-el-primer-objetivo-segmentado-de-common-voice/60472/',
 
-  HTTP_ROOT: 'https://commonvoice.mozilla.org',
-  STAGING_ROOT: 'https://commonvoice.allizom.org',
+  HTTP_ROOT: ['https://commonvoice.mozilla.org', 'https://voice.mozilla.org'],
+  STAGING_ROOT: ['https://commonvoice.allizom.org', 'https://voice.mozilla.org'],
   GITHUB_ROOT: 'https://github.com/mozilla/voice-web',
 });

--- a/web/src/utility.ts
+++ b/web/src/utility.ts
@@ -1,4 +1,5 @@
 import { UserClient } from 'common';
+import URLS from './urls';
 
 const SEARCH_REG_EXP = new RegExp('</?[^>]+(>|$)', 'g');
 
@@ -65,11 +66,11 @@ export function isMobileResolution(): boolean {
 }
 
 export function isProduction(): boolean {
-  return window.location.origin === 'https://voice.mozilla.org';
+  return window.location.origin === URLS.HTTP_ROOT;
 }
 
 export function isStaging(): boolean {
-  return window.location.origin === 'https://voice.allizom.org';
+  return window.location.origin === URLS.STAGING_ROOT;
 }
 
 /**

--- a/web/src/utility.ts
+++ b/web/src/utility.ts
@@ -66,11 +66,11 @@ export function isMobileResolution(): boolean {
 }
 
 export function isProduction(): boolean {
-  return window.location.origin === URLS.HTTP_ROOT;
+  return URLS.HTTP_ROOT.includes(window.location.origin);
 }
 
 export function isStaging(): boolean {
-  return window.location.origin === URLS.STAGING_ROOT;
+  return URLS.STAGING_ROOT.includes(window.location.origin);
 }
 
 /**


### PR DESCRIPTION
There's a few places where it's hardcoded and a few documentation pages. I moved the URLs into the `urls.ts` file to make it easier in the future (though hopefully this will never need to happen again). 