### PR TITLE
message strings from an earlier commit

### DIFF
--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -840,3 +840,34 @@ help-contribute = You can help build a diverse, open-source dataset by creating 
 login-company = Log In / Sign Up with { $company } email
 profile-not-required = Having a profile is not required to contribute though it is helpful, see why below.
 read-more-about = Read more on our About page
+
+## DemoLayout
+demo-get-started = Let's Get Started
+demo-welcome = Welcome to Common Voice
+demo-welcome-subheader = Interested in learning more and contributing to the project?
+
+## Demo Datasets
+demo-language-select-card-header = Common Voice is the world’s largest publicly available, multi-language voice dataset.
+demo-language-select-card-body = Thanks to contributions from over 259k people in over 50 languages, this data is being used to train speech-enabled applications to better respond to the human voice.
+card-button-next = Next
+card-button-back = Back
+demo-language-select-label = Browse Languages
+demo-eofy-header = 2019 End-of-Year Release
+demo-eofy-sub_header = Voice Dataset, Ready for Download
+demo-account = Account
+
+## Demo Account
+demo-account-card-header = Having an account is not required to contribute, though it is helpful. 
+demo-account-card-body = To the right we outline the benefits and clarify what information we make public. Use the links below to get started with a Common Voice account on your own device.
+demo-account-enter-email = 
+.label = Enter email to send a sign up link
+demo-account-sign-up = Send sign up link
+
+## Demo Contribute
+demo-contribute-card-header = Ready to add your voice or lend your ear?
+demo-contribute-card-body = Now that you know a little bit more about Common Voice, why not try it out? Click on the microphone icon to start reading sentences aloud. <br/><br/>If you prefer to review other people's voice contributions, click on the play icon. If the voice recording you hear matches the words written onscreen.
+demo-listen-subtitle = Ready to contribute?
+
+## Demo Dashboard
+demo-dashboard-card-header = Personal dashboards keep you up-to-date with individual and community progress.
+demo-dashboard-card-body = For every voice clip donated, and every audio clip validated, your account dashboards are updated to reflect your latest progress in each language you contribute to. Yes, you can contribute to more than one!<br/><br/> Use dashboards to track your stats, see how you're doing alongside others in the community, and set daily or weekly contribution goals.


### PR DESCRIPTION
@phirework The previous merge from master erased all message strings for the demo mode. This PR fixes that.