### PR TITLE
Change repo name and default branch name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ deploy:
   provider: script
   on:
     all_branches: true
-    condition: ($TRAVIS_TAG != "" || $TRAVIS_BRANCH =~ ^(master|production|stage)$) && ! $TRAVIS_COMMIT_MESSAGE =~ ^Pontoon:*
+    condition: ($TRAVIS_TAG != "" || $TRAVIS_BRANCH =~ ^(main|production|stage)$) && ! $TRAVIS_COMMIT_MESSAGE =~ ^Pontoon:*
   script: docker push "$IMAGE_NAME:$REVISION_TAG" && docker push "$IMAGE_NAME:$SYMBOLIC_TAG"
 env:
   global:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Help us add more sentences for other volunteers to read. We've written [a detail
 
 ### Bug Fixes and Feature Enhancements
 
-All of our current issues can be found here on GitHub. Anything with a [help wanted](https://github.com/mozilla/voice-web/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) tag is definitely up for grabs. If you're interested in an issues without this tag, best to ask first to make sure our vision of it aligns.
+All of our current issues can be found here on GitHub. Anything with a [help wanted](https://github.com/mozilla/common-voice/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) tag is definitely up for grabs. If you're interested in an issues without this tag, best to ask first to make sure our vision of it aligns.
 
 #### Project requirements
 
@@ -36,19 +36,19 @@ We provide a [docker-compose](https://docs.docker.com/compose/) setup to orchest
 
 ##### Setup
 
-[Fork](https://help.github.com/articles/fork-a-repo/) and [clone](https://help.github.com/articles/cloning-a-repository/) the repository onto your computer. Then run the following commands to spin off `voice-web`:
+[Fork](https://help.github.com/articles/fork-a-repo/) and [clone](https://help.github.com/articles/cloning-a-repository/) the repository onto your computer. Then run the following commands to spin off `common-voice`:
 
 ```
-> cd voice-web
+> cd common-voice
 > docker-compose up
 ```
 
 This is going to:
 
-- Launch a mysql instance configured for `voice-web`
+- Launch a mysql instance configured for `common-voice`
 - Launch an s3proxy instance to store files locally and avoid going through setting up AWS S3.
 - Mount the project using a Docker volume to allow reflecting changes to the codebase directly to the container.
-- Launch `voice-web` server
+- Launch `common-voice` server
 
 You can visit the website at [http://localhost:9000](http://localhost:9000).
 
@@ -91,7 +91,7 @@ You may have to run these commands as root/superuser.
 
 [Fork](https://help.github.com/articles/fork-a-repo/) and [clone](https://help.github.com/articles/cloning-a-repository/) the repository onto your computer.
 
-Either create a MySQL superuser that that uses the default `DB_ROOT_USER` and `DB_ROOT_PASS` values from `/server/src/config-helper.ts` or [create your own config](https://github.com/mozilla/voice-web/blob/master/CONTRIBUTING.md#configuration).
+Either create a MySQL superuser that that uses the default `DB_ROOT_USER` and `DB_ROOT_PASS` values from `/server/src/config-helper.ts` or [create your own config](https://github.com/mozilla/common-voice/blob/main/CONTRIBUTING.md#configuration).
 
 Then `cd` into the project directory and enter the following commands:
 
@@ -144,9 +144,9 @@ You do not need to set up NewRelic, except if you fix anything related to that.
 During the server start (after running ‘yarn start’), you might notice an error log similar to this:
 
 ```
-at Class.exports.up (/Users/admin/Desktop/myprojects/mozilla/voice-web-master/server/src/lib/model/db/migrations/20180910121256-user-sso-fields.ts:2:13)
+at Class.exports.up (/Users/admin/Desktop/myprojects/mozilla/common-voice-master/server/src/lib/model/db/migrations/20180910121256-user-sso-fields.ts:2:13)
 ....
-[BE]       at /Users/admin/Desktop/myprojects/mozilla/voice-web-master/node_modules/db-migrate/lib/migrator.js:237:31 {
+[BE]       at /Users/admin/Desktop/myprojects/mozilla/common-voice-master/node_modules/db-migrate/lib/migrator.js:237:31 {
 [BE]     code: 'ER_BLOB_CANT_HAVE_DEFAULT',
 [BE]     errno: 1101,
 [BE]     sqlMessage: "BLOB, TEXT, GEOMETRY or JSON column 'username' can't have a default value",
@@ -225,7 +225,7 @@ Migrations are always run when the server is started.
 
 #### Making Strings localizable
 
-We're using [Fluent](http://projectfluent.org/) to localize strings. You can find examples all over the frontend code. Strings that appear in the [english message files](https://github.com/mozilla/voice-web/tree/master/web/locales/en), can then be translated on [Pontoon](https://pontoon.mozilla.org/projects/common-voice/). Some things to note regarding string changes are documented on [MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Localization/Localization_content_best_practices#Changing_existing_strings).
+We're using [Fluent](http://projectfluent.org/) to localize strings. You can find examples all over the frontend code. Strings that appear in the [english message files](https://github.com/mozilla/common-voice/tree/main/web/locales/en), can then be translated on [Pontoon](https://pontoon.mozilla.org/projects/common-voice/). Some things to note regarding string changes are documented on [MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Localization/Localization_content_best_practices#Changing_existing_strings).
 
 #### Import languages
 
@@ -262,7 +262,7 @@ The project is organized into the following directories:
 
 ## Submitting an Issue
 
-Did you notice a bug? Do you have a feature request? Please file an issue [here on GitHub](https://github.com/mozilla/voice-web/issues).
+Did you notice a bug? Do you have a feature request? Please file an issue [here on GitHub](https://github.com/mozilla/common-voice/issues).
 
 ## Something Else?
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Common Voice [![Travis Status](https://travis-ci.org/mozilla/voice-web.svg?branch=master)](https://travis-ci.org/mozilla/voice-web)
+## Common Voice [![Travis Status](https://travis-ci.org/mozilla/voice-web.svg?branch=main)](https://travis-ci.org/mozilla/voice-web)
 
 This is the web app for Mozilla Common Voice, a platform for collecting speech donations in order to create public domain datasets for training voice recognition-related tools.
 
@@ -16,7 +16,7 @@ This repository is released under [MPL (Mozilla Public License) 2.0](LICENSE).
 
 The majority of our sentence text in `/server/data` comes directly from user submissions in our [Sentence Collector](https://github.com/Common-Voice/sentence-collector/) or they are scraped from Wikipedia using our [extractor tool](https://github.com/Common-Voice/common-voice-wiki-scraper), and are released under a [CC0 public domain Creative Commons license](https://creativecommons.org/share-your-work/public-domain/cc0/).
 
-Any files that follow the pattern `europarl-VERSION-LANG.txt` (such as [europarl-v7-de.txt](https://github.com/mozilla/voice-web/blob/master/server/data/de/europarl-v7-de.txt)) were extracted with our thanks from the [Europarl Corpus](http://www.statmt.org/europarl/), which features transcripts from proceedings in the European parliament.
+Any files that follow the pattern `europarl-VERSION-LANG.txt` (such as [europarl-v7-de.txt](https://github.com/mozilla/voice-web/blob/main/server/data/de/europarl-v7-de.txt)) were extracted with our thanks from the [Europarl Corpus](http://www.statmt.org/europarl/), which features transcripts from proceedings in the European parliament.
 
 ### Contributing
 

--- a/contribute.json
+++ b/contribute.json
@@ -2,19 +2,19 @@
   "name": "Common Voice",
   "description": "Common Voice is Mozilla's initiative to help teach machines how real people speak.",
   "repository": {
-    "url": "https://github.com/mozilla/voice-web",
+    "url": "https://github.com/mozilla/common-voice",
     "license": "MPL2",
-    "tests": "https://travis-ci.org/mozilla/voice-web/"
+    "tests": "https://travis-ci.org/mozilla/common-voice/"
   },
   "participate": {
     "home": "https://commonvoice.mozilla.org",
-    "docs": "https://github.com/mozilla/voice-web/blob/master/CONTRIBUTING.md",
+    "docs": "https://github.com/mozilla/common-voice/blob/main/CONTRIBUTING.md",
     "forum": "https://discourse.mozilla.org/c/voice",
     "matrix": "https://chat.mozilla.org/#/room/#common-voice:mozilla.org"
   },
   "bugs": {
-    "list": "https://github.com/mozilla/voice-web/issues",
-    "report": "https://github.com/mozilla/voice-web/issues/new"
+    "list": "https://github.com/mozilla/common-voice/issues",
+    "report": "https://github.com/mozilla/common-voice/issues/new"
   },
   "urls": {
     "prod": "https://commonvoice.mozilla.org",

--- a/web/src/components/invite-modal/invite-modal.tsx
+++ b/web/src/components/invite-modal/invite-modal.tsx
@@ -1,6 +1,6 @@
 /**
  * NOTE: Want to add a mailto form to this component? Start here:
- *       https://github.com/mozilla/voice-web/pull/2440
+ *       https://github.com/mozilla/common-voice/pull/2440
  */
 import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';

--- a/web/src/urls.ts
+++ b/web/src/urls.ts
@@ -37,5 +37,5 @@ export default Object.freeze({
 
   HTTP_ROOT: 'https://commonvoice.mozilla.org',
   STAGING_ROOT: 'https://commonvoice.allizom.org',
-  GITHUB_ROOT: 'https://github.com/mozilla/voice-web',
+  GITHUB_ROOT: 'https://github.com/mozilla/common-voice',
 });


### PR DESCRIPTION
This is mostly documentation updates. Travis is now looking at a new branch, but it's still pushing to `itsre/voice-web` because that's a setting in Docker Hub that I don't think we're planning on changing right now, right? Unless you want to move everything into the new Docker Hub org now as well... 